### PR TITLE
fix: fix #216, Default date is wrong after import a new book

### DIFF
--- a/webserver/utils.py
+++ b/webserver/utils.py
@@ -26,7 +26,7 @@ class SimpleBookFormatter:
         if not v:
             v = default_value
         if isinstance(v, datetime.datetime):
-            return v.strftime("%Y-%m-%d")
+            return f'{v.year:04}-{v.month:02}-{v.day:02}'
         return v
 
     def format(self):


### PR DESCRIPTION
解决下面的这个问题
https://github.com/talebook/talebook/issues/216

看了一下, 数据库里日期就是0101-01-01. 
![image](https://user-images.githubusercontent.com/9068314/185754748-f90ff61f-c8b0-430a-9a39-96d7a9265efb.png)

然后看了后端的api返回的日期格式为101-01-01
<img width="717" alt="image" src="https://user-images.githubusercontent.com/9068314/185754652-5d000f88-aca9-41be-9b7c-44abf134fce3.png">

再次保存时, strptime()这个函数在校验到非4位年份时报错. (如果手输 0101-01-01的话, 可以正确保存到数据库)
https://docs.python.org/zh-cn/3/library/datetime.html#strftime-and-strptime-format-codes

解决方案:
个人认为保持数据库一致比较好, 尽管0101看上去有点奇怪, 但理论上也是个有效年份, 只需要在返回给前端时, 把年份格式化成4位的即可.
所以改的代码是在返回时, 把年份格式化为4位小数.

改完后:
<img width="815" alt="image" src="https://user-images.githubusercontent.com/9068314/185755675-fcc8ee00-a43b-46fa-b64b-2313ada2bb39.png">



最小重现测试代码:
```python
import datetime 

def str2date(s):
    for fmt in ("%Y-%m-%d", "%Y/%m/%d", "%Y-%m", "%Y"):
        try:
            return datetime.datetime.strptime(s, fmt).replace(tzinfo=datetime.timezone.utc)
        except Exception as inst:
            print(type(inst))    # the exception instance
            print(inst.args)     # arguments stored in .args
            print(inst) 
            continue
    return None

dt = datetime.date(101, 1, 1)
strDate = dt.strftime("%Y-%m-%d")
print(strDate)

print(f'{dt.year:04}-{dt.month:02}-{dt.day:02}')

print(str2date(strDate))
```
