### PR TITLE
txt小说按章节拆分处理，提高在线阅读速度

### DIFF
--- a/app/src/pages/admin/settings.vue
+++ b/app/src/pages/admin/settings.vue
@@ -7,79 +7,82 @@
                 </v-btn>
                 {{card.title}}
             </v-card-title>
-    
-            <v-card-text v-show="card.show">
+          <v-expand-transition>
+            <!-- v-card-text的padding导致动画收起时卡顿，置为 0，内部用一个div来控制-->
+            <v-card-text v-show="card.show" style="padding: 0">
+              <div style="padding: 0 16px 16px">
                 <p v-if="card.subtitle" class="">{{card.subtitle}}</p>
-
                 <template v-if="card.tips">
-                    <p v-for="t in card.tips" :key="t.text">{{t.text}} <a v-if="t.link" target="_blank" :href="t.link">链接</a></p>
+                  <p v-for="t in card.tips" :key="t.text">{{t.text}} <a v-if="t.link" target="_blank" :href="t.link">链接</a></p>
                 </template>
 
                 <template v-for="f in card.fields">
-                    <v-checkbox small hide-details v-if="f.type === 'checkbox' " :prepend-icon="f.icon" v-model="settings[f.key]" :key="f.key" :label="f.label" ></v-checkbox>
-                    <v-textarea outlined v-else-if="f.type === 'textarea' " :prepend-icon="f.icon" v-model="settings[f.key]" :key="f.key" :label="f.label" ></v-textarea>
-                    <v-text-field v-else :prepend-icon="f.icon" v-model="settings[f.key]" :key="f.key" :label="f.label" type="text"></v-text-field>
+                  <v-checkbox small hide-details v-if="f.type === 'checkbox' " :prepend-icon="f.icon" v-model="settings[f.key]" :key="f.key" :label="f.label" ></v-checkbox>
+                  <v-textarea outlined v-else-if="f.type === 'textarea' " :prepend-icon="f.icon" v-model="settings[f.key]" :key="f.key" :label="f.label" ></v-textarea>
+                  <v-text-field v-else :prepend-icon="f.icon" v-model="settings[f.key]" :key="f.key" :label="f.label" type="text"></v-text-field>
                 </template>
                 <template v-for="b in card.buttons">
-                    <v-btn :key="b.label" @click="run(b.action)" color="primary"><v-icon>{{b.icon}}</v-icon>{{b.label}}</v-btn>
+                  <v-btn :key="b.label" @click="run(b.action)" color="primary"><v-icon>{{b.icon}}</v-icon>{{b.label}}</v-btn>
                 </template>
 
                 <template v-for="g in card.groups" >
-                    <v-checkbox small hide-details v-model="settings[g.key]" :key="g.label" :label="g.label"></v-checkbox>
-                    <template v-if="settings[g.key]">
-                        <template v-for="f in g.fields">
-                            <v-textarea outlined v-if="f.type === 'textarea' " :prepend-icon="f.icon" v-model="settings[f.key]" :key="f.key" :label="f.label" ></v-textarea>
-                            <v-text-field v-else :prepend-icon="f.icon" v-model="settings[f.key]" :key="f.key" :label="f.label" type="text"></v-text-field>
-                        </template>
+                  <v-checkbox small hide-details v-model="settings[g.key]" :key="g.label" :label="g.label"></v-checkbox>
+                  <template v-if="settings[g.key]">
+                    <template v-for="f in g.fields">
+                      <v-textarea outlined v-if="f.type === 'textarea' " :prepend-icon="f.icon" v-model="settings[f.key]" :key="f.key" :label="f.label" ></v-textarea>
+                      <v-text-field v-else :prepend-icon="f.icon" v-model="settings[f.key]" :key="f.key" :label="f.label" type="text"></v-text-field>
                     </template>
+                  </template>
                 </template>
 
                 <template v-if="card.show_friends">
-                    <v-row v-for="(friend, idx) in settings.FRIENDS" :key="'friend-'+friend.href">
-                        <v-col class='py-0' cols=3>
-                            <v-text-field flat small hide-details single-line v-model="friend.text" label="名称" type="text"></v-text-field>
-                        </v-col>
-                        <v-col class='pa-0' cols=9>
-                            <v-text-field flat small hide-details single-line v-model="friend.href" label="链接" type="text"
-                                append-outer-icon="delete" @click:append-outer="settings.FRIENDS.splice(idx, 1)" ></v-text-field>
-                        </v-col>
-                    </v-row>
-                    <v-row>
-                        <v-col align="center">
-                            <v-btn color="primary" @click="settings.FRIENDS.push({text:'', href: ''})"><v-icon>add</v-icon>添加</v-btn>
-                        </v-col>
-                    </v-row>
+                  <v-row v-for="(friend, idx) in settings.FRIENDS" :key="'friend-'+friend.href">
+                    <v-col class='py-0' cols=3>
+                      <v-text-field flat small hide-details single-line v-model="friend.text" label="名称" type="text"></v-text-field>
+                    </v-col>
+                    <v-col class='pa-0' cols=9>
+                      <v-text-field flat small hide-details single-line v-model="friend.href" label="链接" type="text"
+                                    append-outer-icon="delete" @click:append-outer="settings.FRIENDS.splice(idx, 1)" ></v-text-field>
+                    </v-col>
+                  </v-row>
+                  <v-row>
+                    <v-col align="center">
+                      <v-btn color="primary" @click="settings.FRIENDS.push({text:'', href: ''})"><v-icon>add</v-icon>添加</v-btn>
+                    </v-col>
+                  </v-row>
                 </template>
 
                 <template v-if="card.show_socials">
-                    <p>所启用的社交网络将会在登录页面自动显示按钮。</p>
-                    <v-combobox v-model="settings.SOCIALS" :items="sns_items" label="选择要启用的社交网络账号" hide-selected multiple small-chips>
-                        <template v-slot:selection="{ attrs, item, parent, selected }">
-                            <v-chip v-bind="attrs" color="green lighten-3" :input-value="selected" label small >
-                                <span class="pr-2"> {{ item.text }} </span>
-                                <v-icon small @click="parent.selectItem(item)" >close</v-icon>
-                            </v-chip>
-                        </template>
-                    </v-combobox>
-                    <v-row v-for="s in settings.SOCIALS" :key="'social-'+s.value" >
-                        <v-col class='py-0' cols=12 sm=2>
-                            <v-subheader class="px-0 pt-4" :class="$vuetify.breakpoint.smAndUp?'float-right':''">
-                                {{s.text}}  (<a @click="show_sns_config(s)">说明</a>)
-                            </v-subheader>
-                        </v-col>
-                        <v-col class='py-0' cols=12 sm=3>
-                            <v-text-field small hide-details single-line v-model="settings['SOCIAL_AUTH_'+s.value.toUpperCase()+'_KEY']" label="Key" type="text"></v-text-field>
-                        </v-col>
-                        <v-col class='py-0' cols=12 sm=7>
-                            <v-text-field small hide-details single-line v-model="settings['SOCIAL_AUTH_'+s.value.toUpperCase()+'_SECRET']" label="Secret" type="text"></v-text-field>
-                        </v-col>
-                    </v-row>
+                  <p>所启用的社交网络将会在登录页面自动显示按钮。</p>
+                  <v-combobox v-model="settings.SOCIALS" :items="sns_items" label="选择要启用的社交网络账号" hide-selected multiple small-chips>
+                    <template v-slot:selection="{ attrs, item, parent, selected }">
+                      <v-chip v-bind="attrs" color="green lighten-3" :input-value="selected" label small >
+                        <span class="pr-2"> {{ item.text }} </span>
+                        <v-icon small @click="parent.selectItem(item)" >close</v-icon>
+                      </v-chip>
+                    </template>
+                  </v-combobox>
+                  <v-row v-for="s in settings.SOCIALS" :key="'social-'+s.value" >
+                    <v-col class='py-0' cols=12 sm=2>
+                      <v-subheader class="px-0 pt-4" :class="$vuetify.breakpoint.smAndUp?'float-right':''">
+                        {{s.text}}  (<a @click="show_sns_config(s)">说明</a>)
+                      </v-subheader>
+                    </v-col>
+                    <v-col class='py-0' cols=12 sm=3>
+                      <v-text-field small hide-details single-line v-model="settings['SOCIAL_AUTH_'+s.value.toUpperCase()+'_KEY']" label="Key" type="text"></v-text-field>
+                    </v-col>
+                    <v-col class='py-0' cols=12 sm=7>
+                      <v-text-field small hide-details single-line v-model="settings['SOCIAL_AUTH_'+s.value.toUpperCase()+'_SECRET']" label="Secret" type="text"></v-text-field>
+                    </v-col>
+                  </v-row>
                 </template>
 
                 <template v-if="card.show_ssl">
-                    <ssl-manager />
+                  <ssl-manager />
                 </template>
+              </div>
             </v-card-text>
+          </v-expand-transition>
         </v-card>
 
         <br/>

--- a/app/src/pages/book/_bid/readtxt.vue
+++ b/app/src/pages/book/_bid/readtxt.vue
@@ -1,0 +1,172 @@
+<template>
+  <div id="txt-main">
+    <v-navigation-drawer v-model="sidebar" app fixed width="240"
+                         class="d-flex flex-column" style="height: 100%"
+                         :clipped="$vuetify.breakpoint.lgAndUp">
+      <v-subheader style="height: 48px">{{ name }}</v-subheader>
+      <v-virtual-scroll
+        style="height: calc(100% - 48px)"
+        :items="content" bench="20"
+        item-height="40">
+        <template v-slot:default="{item,index}">
+          <v-list-item dense :key="item.title" @click="getNovelContent(index)"
+                       :color="selected===index?'primary':''">
+            <v-list-item-content>
+              <v-list-item-title>
+                {{ item.title }}
+              </v-list-item-title>
+            </v-list-item-content>
+          </v-list-item>
+        </template>
+      </v-virtual-scroll>
+    </v-navigation-drawer>
+
+    <v-app-bar class="px-0" color="blue" dense dark app fixed clipped-left extension-height="64">
+
+      <v-toolbar-title class="ml-n5 mr-12 align-center">
+        <v-app-bar-nav-icon @click.stop="sidebar = !sidebar">
+          <v-icon>menu</v-icon>
+        </v-app-bar-nav-icon>
+        <span class="cursor-pointer" @click="$router.push('/')">
+          {{ name }}
+        </span>
+      </v-toolbar-title>
+
+    </v-app-bar>
+    <div>
+      <v-container>
+        <v-card outlined v-if="!inited" width="300" style="margin: 0 auto">
+          <v-card-title ref="tipTitle">{{ tip.title }}</v-card-title>
+          <v-card-text ref="tip">
+            {{ tip.content }}
+          </v-card-text>
+        </v-card>
+        <div v-else>
+          <div class="d-flex justify-center align-content-center" style="margin-bottom: 20px" v-if="loading">
+            <v-progress-circular color="primary" indeterminate size="28" style="margin-right: 10px"/>
+            加载中...
+          </div>
+          <div style="word-wrap: break-word" v-html="novelContent" v-show="!loading"/>
+          <div class="d-flex justify-space-between" v-show="novelContent && !loading">
+            <v-btn color="info" elevation="0" :disabled="selected===0"
+                   @click="getNovelContent(selected-1)">
+              上一章
+            </v-btn>
+            <v-btn outlined elevation="0" @click="sidebar=true" v-show="!sidebar">
+              目录
+            </v-btn>
+            <v-btn color="primary" elevation="0" :disabled="selected===content.length-1"
+                   @click="getNovelContent(selected+1)">
+              下一章
+            </v-btn>
+          </div>
+        </div>
+        <app-footer v-if="$store.state.nav"></app-footer>
+      </v-container>
+    </div>
+  </div>
+</template>
+
+<script>
+import AppFooter from "~/components/AppFooter.vue"
+
+export default {
+  name: "TxtReader",
+  components: {AppFooter},
+  data: () => ({
+    sidebar: null,
+    bookid: null,
+    items: ["1", "2", "3"],
+    content: [],
+    inited: false,
+    wait: 0,
+    name: null,
+    novelContent: '',
+    selected: -1,
+    loading: true,
+    tip: {
+      title: '正在解析',
+      content: '正在解析目录，请稍后...'
+    }
+  }),
+  created() {
+    this.bookid = this.$route.params.bid;
+    this.$store.commit("navbar", false);
+    this.init()
+  },
+  methods: {
+    init() {
+      this.loading = true
+      this.$backend(`/book/txt/init?id=${this.bookid}&test=0`)
+        .then(rsp => {
+          if (rsp.err !== "ok") {
+            this.tip.title = "错误"
+            this.tip.content = rsp.msg
+            return
+          }
+          if (rsp.msg === "已解析") {
+            this.inited = true
+            this.content = rsp.data.content
+            this.name = rsp.data.name
+            this.getNovelContent(0)
+          } else {
+            this.wait = parseInt(rsp.data.wait)
+            let queLen = parseInt(rsp.data.que)
+            this.name = rsp.data.name
+            if (queLen > 0) {
+              this.tip.title = "队列中"
+              this.tip.content = "前方等待" + queLen + "个转换待完成，已步入后台队列"
+              return;
+            }
+            let intvl = setInterval(() => {
+              this.wait--;
+              this.tip.content = "首次阅读，正在解析目录，请稍后... " + this.wait
+              if (this.wait <= 0) {
+                clearInterval(intvl)
+                this.tip.content = "超时未完成，可继续等待稍后刷新尝试"
+                this.tip.title = "解析超时"
+                return
+              }
+              if (this.wait % 5 !== 0) return;
+              this.$backend(`/book/txt/init?id=${this.bookid}&test=1`,)
+                .then(res => {
+                  if (res.err === "ok" && res.msg === "已解析") {
+                    this.inited = true;
+                    this.content = res.data.content
+                    this.name = res.data.name
+                    this.getNovelContent(0)
+                    clearInterval(intvl)
+                  }
+                })
+            }, 1000)
+          }
+        }).finally(() => {
+        this.loading = false
+      });
+    },
+    getNovelContent(i) {
+      if (this.selected === i) return;
+      this.selected = i
+      const {title, start, end} = {...this.content[i]}
+      this.loading = true
+      console.log(title, start, end)
+      this.$backend(`/read/txt?id=${this.bookid}&start=${start}&end=${end}`)
+        .then(res => {
+          if (res.err !== "ok") {
+            this.novelContent = "获取正文失败！" + res.msg
+            return
+          }
+          this.novelContent = title + "<br>" + res.content
+        }).finally(() => {
+        this.loading = false
+        document.getElementsByTagName('html')[0].style.scrollBehavior = 'smooth'
+        document.getElementsByTagName('html')[0].scrollTop = 0
+      })
+    }
+  }
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/app/src/pages/book/_bookid.vue
+++ b/app/src/pages/book/_bookid.vue
@@ -262,7 +262,7 @@
                 </v-card-text>
             </v-card>
         </v-col>
-        <v-col cols="12" sm="6" md="4">
+        <v-col cols="12" :sm="is_txt?6:5" :md="is_txt?3:4">
             <v-card outlined>
                 <v-list>
                     <v-list-item :href="'/read/' + book.id" target="_blank">
@@ -279,7 +279,24 @@
                 </v-list>
             </v-card>
         </v-col>
-        <v-col cols="12" sm="6" md="4">
+        <v-col cols="12" sm="5" md="3" v-show="is_txt">
+          <v-card outlined>
+            <v-list>
+              <v-list-item :href="'/book/' + book.id+'/readtxt'" target="_blank">
+                <v-list-item-avatar large color="primary">
+                  <v-icon dark>import_contacts</v-icon>
+                </v-list-item-avatar>
+                <v-list-item-content>
+                  <v-list-item-title>Txt在线阅读({{ txt_parse_inited ? '已解析' : '未解析' }})</v-list-item-title>
+                </v-list-item-content>
+                <v-list-item-action>
+                  <v-icon>mdi-arrow-right</v-icon>
+                </v-list-item-action>
+              </v-list-item>
+            </v-list>
+          </v-card>
+        </v-col>
+        <v-col cols="12" :sm="is_txt?6:5" :md="is_txt?3:4">
             <v-card outlined>
                 <v-list>
                     <v-list-item @click="dialog_download = !dialog_download">
@@ -296,7 +313,7 @@
                 </v-list>
             </v-card>
         </v-col>
-        <v-col cols="12" sm="6" md="4">
+        <v-col cols="12" :sm="is_txt?6:5" :md="is_txt?3:4">
             <v-card outlined>
                 <v-list>
                     <v-list-item @click="dialog_kindle = !dialog_kindle">
@@ -324,6 +341,11 @@ export default {
         BookCards,
     },
     computed: {
+        is_txt(){
+          if(!this.book)return false
+          let formats=this.book.files.map(x=>x.format.toLowerCase())
+          return formats.includes("txt")
+        },
         pub_year: function () {
             if (this.book === null || this.book.pubdate == null) {
                 return "N/A";
@@ -350,6 +372,7 @@ export default {
         debug: false,
         mail_to: "",
         kindle_sender: "",
+        txt_parse_inited: false,
         dialog_download: false,
         dialog_kindle: false,
         dialog_refer: false,
@@ -376,6 +399,7 @@ export default {
     created() {
         this.init(this.$route);
         this.mail_to = this.$store.state.user.kindle_email;
+        this.get_txt_parse_status()
         if (process.client) {
             this.mail_to = this.$cookies.get("last_mailto");
         }
@@ -410,6 +434,14 @@ export default {
                     this.$alert("error", rsp.msg, "#");
                 }
             });
+        },
+        get_txt_parse_status(){
+          this.$backend(`/book/txt/init?id=${this.book.id}&test=1`,)
+            .then(res => {
+              if (res.err === "ok" && res.msg === "已解析") {
+                this.txt_parse_inited = true;
+              }
+            })
         },
         get_refer() {
             this.dialog_refer = true;

--- a/app/src/pages/book/_bookid.vue
+++ b/app/src/pages/book/_bookid.vue
@@ -93,7 +93,8 @@
                                     <v-spacer></v-spacer>
                                     <v-menu offset-y right>
                                         <template v-slot:activator="{ on }">
-                                            <v-btn color="primary" small rounded v-on="on">
+                                            <v-btn color="primary" small rounded v-on="on"
+                                                   :loading="refer_books_setting_btn_loading">
                                                 <v-icon small>done</v-icon>
                                                 设置
                                             </v-btn>
@@ -354,6 +355,7 @@ export default {
         dialog_refer: false,
         dialog_msg: false,
         refer_books_loading: false,
+        refer_books_setting_btn_loading:false,
         refer_books: [],
         email_rules: function (email) {
             var re = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
@@ -425,6 +427,10 @@ export default {
                 });
         },
         set_refer(provider_key, provider_value, opt) {
+            // 防止多次重复点击
+            if(this.refer_books_setting_btn_loading) return;
+            // 显示加载条提示
+            this.refer_books_setting_btn_loading = true;
             var data = new URLSearchParams(opt);
             data.append("provider_key", provider_key);
             data.append("provider_value", provider_value);
@@ -441,6 +447,9 @@ export default {
                     this.$alert("error", rsp.msg);
                 }
                 this.init(this.$route);
+            }).finally(()=>{
+               //关闭加载条提示
+               this.refer_books_setting_btn_loading = false;
             });
         },
         delete_book() {


### PR DESCRIPTION
1. 增加部分动画效果
2. 在线阅读都加载的整本？纯文本小说如果比较大耗时太长，现在可选单独解析目录和正文内容，避免一次全文加载，阅读速度快