### PR TITLE
FIX: 处理前端返回'null'而不是None

### DIFF
--- a/webserver/handlers/base.py
+++ b/webserver/handlers/base.py
@@ -107,6 +107,12 @@ class BaseHandler(web.RequestHandler):
             username,
         )
 
+    def get_argument(self, name, default=None, strip=True):
+        value = super().get_argument(name, default, strip)
+        if value == 'null':
+            return default
+        return value
+
     def get_secure_cookie(self, key):
         if not self.cookies_cache.get(key, ""):
             self.cookies_cache[key] = super(BaseHandler, self).get_secure_cookie(key)


### PR DESCRIPTION
当输入为空时，前端返回字符串'null'而不是None， 将'null'统一按None进行处理