### PR TITLE
feat: 使用优书网(youshu.me)数据支持了网络小说的刮削, close #470

### DIFF
--- a/tests/run.py
+++ b/tests/run.py
@@ -13,6 +13,7 @@ from tests.test_ssl_crt import *
 from tests.test_scan import *
 from tests.test_admin import *
 from tests.test_utils import *
+from tests.test_youshu import *
 import unittest
 
 if __name__ == "__main__":

--- a/tests/test_youshu.py
+++ b/tests/test_youshu.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env pytest
+# -*- coding: UTF-8 -*-
+
+import os
+import sys
+import unittest
+from unittest import mock
+
+testdir = os.path.realpath(os.path.dirname(os.path.realpath(__file__)) + "/../../../")
+sys.path.append(testdir)
+sys.path.append("/home/batkiz/code/talebook")
+
+import webserver.main
+from webserver.plugins.meta.youshu import YoushuApi
+
+webserver.main.init_calibre()
+
+
+YOUSHU_DATA = {
+    "info": {
+        "title": "黜龙",
+        "author": "榴弹怕水",
+        "url": "https://www.youshu.me/book/268231",
+    },
+    "tags": ["架空历史", "历史" ],
+    "summary": "此方天地有龙。龙形百态，不一而足，或游于江海，或翔于高山，或藏于九幽，或腾于云间。一旦奋起，便可吞风降雪，引江划河，落雷喷火，分山避海。此处人间也有龙。人中之龙，胸怀大志，腹有良谋，有包藏宇宙之机，吞吐天地之志。一时机发，便可翻云覆雨，决势分野，定鼎问道，证位成龙。作为一个迷路的穿越者，张行一开始也想成龙，但后来，他发现这个行当卷的太厉害了，就决定改行，去黜落群龙。所谓行尽天下路，使天地处处通，黜遍天下龙，使世间人人可为龙。这是一个老套的穿越故事。",
+    "id": "268231",
+    "image": "https://qidian.qpic.cn/qdbimg/349573/1031516087/600",
+}
+
+
+def get_mock_page():
+    p = mock.Mock()
+    p.get_id.return_value = YOUSHU_DATA['id']
+    p.get_tags.return_value = YOUSHU_DATA['tags']
+    p.get_info.return_value = YOUSHU_DATA['info']
+    p.get_image.return_value = YOUSHU_DATA['image']
+    p.get_summary.return_value = YOUSHU_DATA['summary']
+    p.http.url = YOUSHU_DATA['info']['url']
+    return p
+
+YOUSHU_PAGE = get_mock_page()
+
+class TestYoushu(unittest.TestCase):
+    def test_youshu_api(self):
+        api = YoushuApi(copy_image=False)
+        with mock.patch.object(api, "_youshu") as mk:
+            mk.return_value = None
+            d = api.get_book("黜龙")
+            self.assertEqual(d, None)
+
+            mk.return_value = YOUSHU_PAGE
+            d = api.get_book("黜龙")
+            self.assertTrue(d != None)
+            self.assertEqual(d.title, "黜龙")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/webserver/handlers/book.py
+++ b/webserver/handlers/book.py
@@ -19,7 +19,7 @@ from webserver.services.extract import ExtractService
 from webserver.services.mail import MailService
 from webserver.handlers.base import BaseHandler, ListHandler, auth, js
 from webserver.models import Item
-from webserver.plugins.meta import baike, douban
+from webserver.plugins.meta import baike, douban, youshu
 from webserver.plugins.parser.txt import get_content_encoding
 
 CONF = loader.get_settings()
@@ -112,6 +112,15 @@ class BookRefer(BaseHandler):
             return {"err": "httprequest.baidubaike.failed", "msg": _(u"百度百科查询失败")}
         if book:
             books.append(book)
+
+        api = youshu.YoushuApi(copy_image=True)
+        try:
+            book = api.get_book(title)
+        except:
+            return {"err": "httprequest.youshu.failed", "msg": _(u"优书网查询失败")}
+        if book:
+            books.append(book)
+
         return books
 
     def plugin_get_book_meta(self, provider_key, provider_value, mi):
@@ -135,6 +144,14 @@ class BookRefer(BaseHandler):
                 return api.get_book(mi)
             except:
                 raise RuntimeError({"err": "httprequest.douban.failed", "msg": _(u"豆瓣接口查询失败")})
+            
+        if provider_key == youshu.KEY:
+            title = re.sub(u"[(（].*", "", mi.title)
+            api = youshu.YoushuApi(copy_image=True)
+            try:
+                return api.get_book(title)
+            except:
+                raise RuntimeError({"err": "httprequest.youshu.failed", "msg": _(u"优书网查询失败")})
         raise RuntimeError({"err": "params.provider_key.not_support", "msg": _(u"不支持该provider_key")})
 
     @js

--- a/webserver/plugins/meta/youshu/__init__.py
+++ b/webserver/plugins/meta/youshu/__init__.py
@@ -1,0 +1,7 @@
+#!/usr/bin/python3
+# -*- coding: UTF-8 -*-
+from .api import YoushuApi, KEY, YOUSHU_ISBN  # noqa: F401
+
+"""
+Youshu.me metadata plugin for Talebook
+"""

--- a/webserver/plugins/meta/youshu/api.py
+++ b/webserver/plugins/meta/youshu/api.py
@@ -1,0 +1,201 @@
+#!/usr/bin/python3
+# -*- coding: UTF-8 -*-
+
+"""
+Youshu.me metadata plugin for Talebook
+"""
+
+import logging
+import re
+import requests
+from gettext import gettext as _
+from bs4 import BeautifulSoup
+
+YOUSHU_ISBN = "0000000000002"
+KEY = "Youshu"
+
+CHROME_HEADERS = {
+    "Accept-Language": "zh-CN,zh;q=0.8,zh-TW;q=0.6",
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko)"
+                  + "Chrome/66.0.3359.139 Safari/537.36",
+}
+
+
+class YoushuPage:
+    """
+    parse youshu.me book page
+    """
+    def __init__(self, url):
+        self.url = url
+        self.http = self._request(url)
+        self.soup = BeautifulSoup(self.http.text, 'html.parser')
+        
+    def _request(self, url):
+        try:
+            return requests.get(url, timeout=10, headers=CHROME_HEADERS)
+        except Exception as err:
+            logging.error(_(f"优书网请求异常: {err}"))
+            raise
+    
+    def get_info(self):
+        """
+        extract book title and author from page
+        """
+        info = {"title": "", "author": ""}
+        
+        # 提取书名和作者
+        title = self.soup.find('span', style="font-size:20px;font-weight:bold;color:#f27622;").text
+        author = self.soup.select_one('a:not([class])[href*="authorarticle.php"]').text
+        info["title"] = title
+        info["author"] = author
+        return info
+    
+    def get_summary(self):
+        """
+        extract book summary
+        """
+        summary_div = self.soup.find('div', style="padding:3px;border:0;height:100%;width:100%;overflow-y:scroll;")
+        if summary_div:
+            return summary_div.text.strip()
+        return ""
+    
+    def get_image(self):
+        """
+        extract book cover image
+        """
+        img = self.soup.select_one('a.book-detail-img')
+        if img and img.has_attr('href'):
+            href = img['href']
+            url = re.sub(r'/300$', '/600', href)
+            return url
+        return None
+    
+    def get_id(self):
+        """
+        extract book id
+        """
+        match = re.search(r'/book/(\d+)', self.url)
+        if match:
+            return match.group(1)
+        return "0000"
+
+    def get_tags(self):
+        """
+        extract book tags
+        """
+        tags = []
+        for tag in self.soup.select('a[href*="tagarticle"]'):
+            tags.append(tag.get_text(strip=True))
+
+        return tags
+    
+    def get_plat(self):
+        """
+        extract book source site
+        """
+        td = self.soup.find('td', string=lambda text: text and '首发网站' in text)
+        if td:
+            source_site = td.text.split('：')[-1].strip()
+            return source_site
+
+        return ""
+
+    def get_rating(self):
+        """
+        extract book rating
+        """
+        rt = self.soup.find('span', class_='ratenum')
+        if rt:
+            return int(float(rt.text))
+
+        return 0
+
+class YoushuSearch:
+    """
+    search books on youshu.me
+    """
+    def __init__(self):
+        self.search_url = "https://www.youshu.me/modules/article/search.php"
+    
+    def search(self, keyword):
+        payload = {
+            "searchtype": "all",
+            "searchkey": keyword,
+            "t_btnsearch": ""
+        }
+        
+        try:
+            response = requests.post(self.search_url, data=payload, headers=CHROME_HEADERS, timeout=10)
+            soup = BeautifulSoup(response.text, 'html.parser')
+            
+            # check if multiple results
+            if "搜索关键词" in response.text:
+                # multiple results, redirect to first result
+                first_result = soup.select_one('span.c_subject a')
+                if first_result and first_result.has_attr('href'):
+                    book_url = "https://www.youshu.me" + first_result['href']
+                    return YoushuPage(book_url)
+                return None
+            else:
+                # directly get the page of the unique match
+                return YoushuPage(response.url)
+        except Exception as err:
+            logging.error(_(f"优书网搜索异常: {err}"))
+            return None
+
+
+class YoushuApi:
+    def __init__(self, copy_image=True, manual_select=False):
+        self.copy_image = copy_image
+        self.searcher = YoushuSearch()
+
+    def get_book(self, title):
+        page = self.searcher.search(title)
+        if not page:
+            return None
+
+        return self._metadata(page)
+
+    def _metadata(self, page):
+        from calibre.ebooks.metadata.book.base import Metadata
+        from calibre.utils.date import utcnow
+
+        info = page.get_info()
+
+        mi = Metadata(info["title"])
+        mi.authors = [info.get("author", "佚名")]
+        mi.author_sort = mi.authors[0]
+        mi.isbn = YOUSHU_ISBN
+        mi.tags = page.get_tags()
+        mi.publisher = page.get_plat()
+        mi.pubdate = utcnow()
+        mi.timestamp = mi.pubdate
+        mi.cover_url = page.get_image()
+        mi.comments = page.get_summary()
+        mi.website = page.url
+        mi.source = "优书网"
+        mi.provider_key = KEY
+        mi.provider_value = page.get_id()
+        mi.cover_data = self.get_cover(mi.cover_url)
+        mi.rating = page.get_rating()
+
+        return mi
+
+    def get_cover(self, cover_url):
+        if not self.copy_image or not cover_url:
+            return None
+        try:
+            img = requests.get(cover_url, timeout=10, headers=CHROME_HEADERS).content
+            img_fmt = cover_url.split(".")[-1]
+            return (img_fmt, img)
+        except Exception as err:
+            logging.error(_(f"获取封面图片异常: {err}"))
+            return None
+        
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    api = YoushuApi()
+    print(api.get_book(u"黜龙"))
+    print(api.get_book(u"一世之尊"))

--- a/webserver/plugins/meta/youshu/api.py
+++ b/webserver/plugins/meta/youshu/api.py
@@ -151,11 +151,18 @@ class YoushuApi:
         self.searcher = YoushuSearch()
 
     def get_book(self, title):
-        page = self.searcher.search(title)
+        page = self._youshu(title)
         if not page:
             return None
 
         return self._metadata(page)
+
+    def _youshu(self, title):
+        try:
+            return self.searcher.search(title)
+        except Exception as err:
+            logging.error(_(f"优书网接口异常: {err}"))
+            return None
 
     def _metadata(self, page):
         from calibre.ebooks.metadata.book.base import Metadata


### PR DESCRIPTION
使用优书网 ( www.youshu.me ) 的数据支持了网络小说的刮削。

由于数据提供方或其他原因，目前存在下面问题：
- 优书网没有书籍的开始连载时间，因此 `pubdate` 取的是当前时间
- `autofill` 功能自己测试时没成功，而且暂不确定优书网有没有反爬限制，因此只支持了手动点击从互联网更新
- ISBN号仿照百度百科的代码，分配了个 `0000000000002`
 
---
示例：
![image](https://github.com/user-attachments/assets/91d89c26-9358-4c19-b70e-30bc165b6548)
![image](https://github.com/user-attachments/assets/fb5a03f4-1572-4fa4-8dc8-2c8dd9808319)
![image](https://github.com/user-attachments/assets/9c6943e2-ab13-4a2f-a8e2-06f15d299c98)
![image](https://github.com/user-attachments/assets/714a803d-28d4-4529-9077-29a3ecf0afcf)
![image](https://github.com/user-attachments/assets/507b78c2-0b8f-446d-9efe-4fe12a50f832)
