### PR TITLE
fix(docker): 修复 SSR 模式下 logo 无法覆盖的问题，并统一构建流程

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Extract metadata
+      - name: Extract metadata (for SPA tags)
         id: meta
         uses: docker/metadata-action@v5
         with:
@@ -64,10 +64,13 @@ jobs:
           fi
           echo "build_args=GIT_VERSION=$VERSION" >> $GITHUB_OUTPUT
 
-      - name: Build and push
+      # ----------------------------------------
+      # SPA 镜像：talebook/talebook:latest / <ver> / calibre-webserver:latest
+      - name: Build and push SPA
         uses: docker/build-push-action@v5
         with:
           context: .
+          target: production-spa
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           labels: ${{ steps.meta.outputs.labels }}
           push: ${{ github.event_name != 'pull_request' }}
@@ -78,4 +81,21 @@ jobs:
             ${{ steps.meta.outputs.tags }}
             ${{ github.repository == 'talebook/talebook' && startsWith(github.ref, 'refs/tags/') && format('{0}/talebook/calibre-webserver:latest', env.REGISTRY) || '' }}
             ${{ github.repository == 'talebook/talebook' && github.ref == 'refs/heads/master' && format('{0}/talebook/calibre-webserver:master', env.REGISTRY) || '' }}
+          build-args: ${{ steps.prep.outputs.build_args }}
+
+      # ----------------------------------------
+      # SSR 镜像：talebook/talebook:server-side-render / server-side-render-<ver>
+      - name: Build and push SSR
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          target: production-ssr
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          labels: ${{ steps.meta.outputs.labels }}
+          push: ${{ github.event_name != 'pull_request' }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/talebook/talebook:server-side-render
+          cache-to: type=inline,mode=max
+          provenance: false
+          tags: |
+            ${{ startsWith(github.ref, 'refs/tags/') && format('{0}/{1}:server-side-render', env.REGISTRY, env.IMAGE_NAME) || '' }}
           build-args: ${{ steps.prep.outputs.build_args }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -166,3 +166,12 @@ RUN mkdir -p /var/lib/apt/lists/partial && \
 COPY conf/nginx/server-side-render.conf /etc/nginx/conf.d/talebook.conf
 COPY conf/supervisor/server-side-render.conf /etc/supervisor/conf.d/talebook.conf
 COPY --from=builder /app-ssr/ /var/www/talebook/app/
+
+# fix: symlink logo dir so user can override /data/books/logo/link.png
+RUN rm -rf /var/www/talebook/app/.output/public/logo && \
+    ln -s /data/books/logo /var/www/talebook/app/.output/public/logo
+
+
+# ----------------------------------------
+# 生产环境（spa版，作为默认 docker build 结果）
+FROM production AS production-spa


### PR DESCRIPTION
## 问题分析

Issue #679 反馈：用户替换 `/data/books/logo/link.png` 后，浏览器中的图片没有更新。

根本原因：`production-ssr` stage 的 nginx root 是 `.output/public/`，但该目录下的 `logo/` 是构建时打包进镜像的**实体目录**，没有像 SPA 模式那样建立指向 `/data/books/logo` 的 symlink。因此无论用户怎么替换宿主机上的文件，SSR nginx 始终读取镜像内置版本。

此外，`production-ssr` 是 Dockerfile 的最后一个 stage，导致 `docker build .` 不带 `--target` 时默认构建 SSR 镜像，而 CI workflow 也一直没有指定 target，所有推送到 Docker Hub 的镜像（包括 `latest`）实际上都是 SSR 版本。

## 修改内容

**Dockerfile**
- `production-ssr` 阶段：删除 `.output/public/logo` 实体目录，建立 symlink 指向 `/data/books/logo`，与 SPA 模式保持一致
- 新增 `production-spa` stage（继承 `production`）作为最末尾 stage，使 `docker build .` 默认产物为 SPA 镜像

**build.yml**
- 拆分为两个独立构建步骤，分别指定 `target`
- SPA：推送 `latest` / `<ver>` / `calibre-webserver:latest`（与 Makefile 对齐）
- SSR：仅在 push tag 时推送 `server-side-render`（与 `latest` 同步更新）
- 各自使用独立的 `cache-from`，互不干扰

## 测试计划

- [ ] 验证 `docker build . --target production-spa` 构建成功
- [ ] 验证 `docker build . --target production-ssr` 构建成功
- [ ] 验证 `docker build .`（无 target）默认产物为 SPA 镜像
- [ ] 验证 SSR 容器启动后替换 `/data/books/logo/link.png`，浏览器刷新后图片更新

Fixes #679

🤖 Generated with [Claude Code](https://claude.com/claude-code)