### PR TITLE
fix: 去除 CHROME_HEADERS 中的 image/webp，修复封面更新失败

### DIFF
--- a/webserver/plugins/meta/baike/api.py
+++ b/webserver/plugins/meta/baike/api.py
@@ -19,7 +19,7 @@ KEY = "BaiduBaike"
 
 CHROME_HEADERS = {
     "Accept-Language": "zh-CN,zh;q=0.8,zh-TW;q=0.6",
-    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
     "User-Agent": "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko)"
                   + "Chrome/66.0.3359.139 Safari/537.36",
 }

--- a/webserver/plugins/meta/douban.py
+++ b/webserver/plugins/meta/douban.py
@@ -16,7 +16,7 @@ import requests
 
 CHROME_HEADERS = {
     "Accept-Language": "zh-CN,zh;q=0.8,zh-TW;q=0.6",
-    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
     "User-Agent": "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko)"
     + "Chrome/66.0.3359.139 Safari/537.36",
     "Referer": "https://book.douban.com/",

--- a/webserver/plugins/meta/youshu/api.py
+++ b/webserver/plugins/meta/youshu/api.py
@@ -16,7 +16,7 @@ KEY = "Youshu"
 
 CHROME_HEADERS = {
     "Accept-Language": "zh-CN,zh;q=0.8,zh-TW;q=0.6",
-    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
     "User-Agent": "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko)"
                   + "Chrome/66.0.3359.139 Safari/537.36",
 }


### PR DESCRIPTION
## 问题

关联 #678

图片 CDN 看到请求头 `Accept: ...,image/webp,...` 时会返回 WebP 格式图片，但 calibre 使用的 Qt 不支持 WebP，导致 `save_cover_data_to` 报错：

```
ValueError: Failed to export image as JPEG with error: Image is empty
```

## 修复

去掉 `douban.py`、`baike/api.py`、`youshu/api.py` 三个插件的 `CHROME_HEADERS` 中的 `image/webp`，使 CDN 回落到 JPEG/PNG 等 calibre 可正常处理的格式。

```diff
- "Accept": "text/html,...,image/webp,*/*;q=0.8",
+ "Accept": "text/html,...,*/*;q=0.8",
```

## 测试

从豆瓣获取书籍元数据并保存封面，确认不再报错。

🤖 Generated with [Claude Code](https://claude.com/claude-code)