### PR TITLE
fix: 导入图书时排除隐藏文件夹和隐藏文件

### DIFF
--- a/webserver/services/scan.py
+++ b/webserver/services/scan.py
@@ -58,12 +58,12 @@ class ScanService(AsyncService):
         for dirpath, dirnames, filenames in os.walk(path_dir):
             # 排除隐藏文件夹（以.开头或@__thumb等）
             dirnames[:] = [d for d in dirnames if not (d.startswith('.') or d.startswith('@__'))]
-            
+
             for fname in filenames:
                 # 排除隐藏文件
                 if fname.startswith('.'):
                     continue
-                    
+
                 fpath = os.path.join(dirpath, fname)
                 if not os.path.isfile(fpath):
                     continue


### PR DESCRIPTION
修复 #526

- 排除以.开头的隐藏文件夹
- 排除以@__开头的文件夹（如@__thumb）
- 排除以.开头的隐藏文件