### PR TITLE
fix: add missing SSR image tags for master and dev branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,4 +98,7 @@ jobs:
           provenance: false
           tags: |
             ${{ startsWith(github.ref, 'refs/tags/') && format('{0}/{1}:server-side-render', env.REGISTRY, env.IMAGE_NAME) || '' }}
+            ${{ startsWith(github.ref, 'refs/tags/') && format('{0}/{1}:server-side-render-{2}', env.REGISTRY, env.IMAGE_NAME, github.ref_name) || '' }}
+            ${{ github.ref == 'refs/heads/master' && format('{0}/{1}:server-side-render', env.REGISTRY, env.IMAGE_NAME) || '' }}
+            ${{ startsWith(github.ref, 'refs/heads/dev-') && format('{0}/{1}:server-side-render-{2}', env.REGISTRY, env.IMAGE_NAME, github.ref_name) || '' }}
           build-args: ${{ steps.prep.outputs.build_args }}


### PR DESCRIPTION
The SSR build step only had a tag for version tag pushes, causing
'tag is needed when pushing to registry' error on master/dev branches.

Added tags for:
- master branch: server-side-render
- dev-* branches: server-side-render-<branch-name>
- version tags: server-side-render and server-side-render-<version>