### PR TITLE
fix: disable read button when book.id is not loaded (issue #688)

### DIFF
--- a/app/pages/book/[bid]/index.vue
+++ b/app/pages/book/[bid]/index.vue
@@ -246,6 +246,7 @@
                             color="primary"
                             variant="elevated"
                             class="mx-2"
+                            :disabled="book.id === 0"
                             :href="is_txt ? '/book/' + book.id + '/readtxt' : '/read/' + book.id"
                             target="_blank"
                         >
@@ -439,6 +440,7 @@
                         >
                             <v-list density="compact">
                                 <v-list-item
+                                    v-if="book.id > 0"
                                     :href="'/read/' + book.id"
                                     target="_blank"
                                     class="w-100"


### PR DESCRIPTION
## Problem
When book data is not loaded or loading fails, `book.id` defaults to `0`.
The read button still renders with `href="/read/0"`, causing the error:
> 抱歉，这本书不存在 (Sorry, this book does not exist)

## Root Cause
In `app/pages/book/[bid]/index.vue`:
```javascript
const book = ref({
    id: 0,  // initial value
    ...
});
```

The read button was unconditionally rendering:
```vue
<v-btn :href="'/read/' + book.id">
```

## Solution
1. Added `:disabled="book.id === 0"` to the main read button
2. Added `v-if="book.id > 0"` to the sidebar read link

This prevents users from clicking the read button before data is loaded.

## Testing
- Verified that the read button is disabled when `book.id === 0`
- Verified that normal navigation works when data is loaded

Fixes #688