### PR TITLE
fix: 个别文件丢失时跳过而非中断整体导入 (#692)

### DIFF
--- a/webserver/services/scan.py
+++ b/webserver/services/scan.py
@@ -126,10 +126,16 @@ class ScanService(AsyncService):
 
             # 读取文件，计算哈希值
             sha256 = hashlib.sha256()
-            with open(fpath, "rb") as f:
-                # Read and update hash string value in blocks of 4K
-                for byte_block in iter(lambda: f.read(4096), b""):
-                    sha256.update(byte_block)
+            try:
+                with open(fpath, "rb") as f:
+                    # Read and update hash string value in blocks of 4K
+                    for byte_block in iter(lambda: f.read(4096), b""):
+                        sha256.update(byte_block)
+            except FileNotFoundError:
+                logging.warning("扫描时文件已不存在，跳过: %s", fpath)
+                row.status = ScanFile.DROP
+                self.save_or_rollback(row)
+                continue
 
             real_hash = "sha256:" + sha256.hexdigest()
 
@@ -150,12 +156,18 @@ class ScanService(AsyncService):
             # 尝试解析metadata
             fmt = fpath.split(".")[-1].lower()
             mi = None
-            with open(fpath, "rb") as stream:
-                try:
-                    mi = get_metadata(stream, stream_type=fmt, use_libprs_metadata=True)
-                except Exception as err:
-                    logging.error("Failed to parse metadata for %s: %s", fpath, err)
-                    logging.exception("Error details:")
+            try:
+                with open(fpath, "rb") as stream:
+                    try:
+                        mi = get_metadata(stream, stream_type=fmt, use_libprs_metadata=True)
+                    except Exception as err:
+                        logging.error("Failed to parse metadata for %s: %s", fpath, err)
+                        logging.exception("Error details:")
+            except FileNotFoundError:
+                logging.warning("解析元数据时文件已不存在，跳过: %s", fpath)
+                row.status = ScanFile.DROP
+                self.save_or_rollback(row)
+                continue
 
             if mi:
                 mi.title = utils.super_strip(mi.title)
@@ -218,26 +230,32 @@ class ScanService(AsyncService):
             fname = os.path.basename(row.path)
             fmt = fpath.split(".")[-1].lower()
             mi = None
-            with open(fpath, "rb") as stream:
-                try:
-                    mi = get_metadata(stream, stream_type=fmt, use_libprs_metadata=True)
-                except Exception as err:
-                    logging.error("Failed to parse metadata for %s during import: %s", fpath, err)
-                    logging.exception("Error details:")
-                    # 创建一个简单的metadata对象，避免导入失败
-                    from calibre.ebooks.metadata.book.base import Metadata
-                    mi = Metadata()
-                    mi.title = fname.replace("." + fmt, "")
-                    mi.authors = [_(u"佚名")]
-                else:
-                    # 处理metadata
-                    mi.title = utils.super_strip(mi.title)
-                    mi.authors = [utils.super_strip(s) for s in mi.authors]
-
-                    # 非结构化的格式，calibre无法识别准确的信息，直接从文件名提取
-                    if fmt in ["txt", "pdf"]:
+            try:
+                with open(fpath, "rb") as stream:
+                    try:
+                        mi = get_metadata(stream, stream_type=fmt, use_libprs_metadata=True)
+                    except Exception as err:
+                        logging.error("Failed to parse metadata for %s during import: %s", fpath, err)
+                        logging.exception("Error details:")
+                        # 创建一个简单的metadata对象，避免导入失败
+                        from calibre.ebooks.metadata.book.base import Metadata
+                        mi = Metadata()
                         mi.title = fname.replace("." + fmt, "")
                         mi.authors = [_(u"佚名")]
+                    else:
+                        # 处理metadata
+                        mi.title = utils.super_strip(mi.title)
+                        mi.authors = [utils.super_strip(s) for s in mi.authors]
+
+                        # 非结构化的格式，calibre无法识别准确的信息，直接从文件名提取
+                        if fmt in ["txt", "pdf"]:
+                            mi.title = fname.replace("." + fmt, "")
+                            mi.authors = [_(u"佚名")]
+            except FileNotFoundError:
+                logging.warning("导入时文件已不存在，跳过: %s", fpath)
+                row.status = ScanFile.DROP
+                self.save_or_rollback(row)
+                continue
 
             # 再次检查是否有重复书籍
             ids = self.db.books_with_same_title(mi)


### PR DESCRIPTION
## 问题描述

修复 issue #692：大量导入书籍时，个别文件丢失（被删除）导致整批导入失败。

## 根本原因

`webserver/services/scan.py` 的扫描和导入流程中，`with open(fpath, "rb")` 未处理 `FileNotFoundError`。当某个文件在扫描/导入过程中被删除，会抛出未捕获异常，导致整个导入循环中断。

## 修复方案

在三处 `with open()` 调用处捕获 `FileNotFoundError`，将对应记录标记为 `DROP` 并 `continue`，跳过丢失的文件，让其余书籍正常完成导入：

1. `do_scan()` — 计算文件 hash 时
2. `do_scan()` — 解析书籍元数据时  
3. `do_import()` — 导入时读取文件内容时

## 变更文件

- `webserver/services/scan.py`

Closes #692