### PR TITLE
fix: PDF 在线阅读时设置正确的 Content-Type (#595)

### DIFF
--- a/webserver/handlers/book.py
+++ b/webserver/handlers/book.py
@@ -526,8 +526,18 @@ class BookDownload(BaseHandler, web.StaticFileHandler):
         if self.is_opds:
             att = 'attachment; filename="%(id)d.%(fmt)s"' % book
 
-        self.set_header("Content-Disposition", att.encode("UTF-8"))
-        self.set_header("Content-Type", "application/octet-stream")
+        # PDF 文件使用 application/pdf，允许浏览器内联预览（供 pdfjs 等在线阅读器使用）
+        # 其他格式使用 application/octet-stream 强制下载
+        if fmt == "pdf":
+            self.set_header("Content-Type", "application/pdf")
+            # 在线阅读时不附加 Content-Disposition attachment，避免触发下载
+            if not self.is_opds:
+                self.set_header("Content-Disposition", f"inline; filename=\"{fname}\"".encode("UTF-8"))
+            else:
+                self.set_header("Content-Disposition", att.encode("UTF-8"))
+        else:
+            self.set_header("Content-Disposition", att.encode("UTF-8"))
+            self.set_header("Content-Type", "application/octet-stream")
         return path
 
     @classmethod


### PR DESCRIPTION
## 问题描述

修复 issue #595：在 fnos docker 环境中，点击在线阅读 PDF 书籍时，页面跳转到 pdfjs viewer 但 Firefox 直接触发了文件下载。

## 根本原因

`BookDownload` handler 对所有格式（包括 PDF）统一返回：

```
Content-Type: application/octet-stream
Content-Disposition: attachment; filename=...
```

`application/octet-stream` + `attachment` 会让浏览器（尤其是 Firefox）直接触发下载，而不是将内容传递给 pdfjs viewer 进行内联渲染。

## 修复方案

针对 PDF 格式单独处理：

- **Content-Type** 改为 `application/pdf`，浏览器和 pdfjs 能正确识别内容类型
- **Content-Disposition** 改为 `inline`，明确告知浏览器内联展示而非下载
- OPDS 场景（作为附件下载）保持原 `attachment` 行为不变
- 其他格式（epub、mobi 等）继续使用 `application/octet-stream` 强制下载

## 变更文件

- `webserver/handlers/book.py`

Closes #595