### PR TITLE
fix: 为 drop 状态添加友好提示说明 (#697)

### DIFF
--- a/app/i18n/locales/en-US.json
+++ b/app/i18n/locales/en-US.json
@@ -385,7 +385,9 @@
         "ready": "Ready",
         "exist": "Existing",
         "imported": "Imported",
-        "downloading": "Downloading"
+        "downloading": "Downloading",
+        "drop": "Duplicate",
+        "dropTooltip": "A file with the same hash already exists and was skipped. Delete the duplicate record and re-scan to import again."
       },
       "tab": {
         "todo": "Pending",

--- a/app/i18n/locales/zh-CN.json
+++ b/app/i18n/locales/zh-CN.json
@@ -406,7 +406,9 @@
         "ready": "可导入",
         "exist": "已存在",
         "imported": "导入成功",
-        "downloading": "下载中"
+        "downloading": "下载中",
+        "drop": "重复文件",
+        "dropTooltip": "检测到哈希值相同的重复文件，已自动跳过。如需重新导入，请删除重复记录后重新扫描。"
       },
       "tab": {
         "todo": "待处理",

--- a/app/pages/admin/books.vue
+++ b/app/pages/admin/books.vue
@@ -106,6 +106,21 @@
                 >
                     {{ t('admin.books.status.downloading') }}
                 </v-chip>
+                <v-tooltip
+                    v-else-if="item.status == 'drop'"
+                    :text="t('admin.imports.status.dropTooltip')"
+                    location="top"
+                >
+                    <template #activator="{ props }">
+                        <v-chip
+                            size="small"
+                            color="warning"
+                            v-bind="props"
+                        >
+                            {{ t('admin.imports.status.drop') }}
+                        </v-chip>
+                    </template>
+                </v-tooltip>
                 <v-chip
                     v-else
                     size="small"

--- a/app/pages/admin/imports.vue
+++ b/app/pages/admin/imports.vue
@@ -156,6 +156,21 @@
                 >
                     {{ t('admin.imports.status.downloading') }}
                 </v-chip>
+                <v-tooltip
+                    v-else-if="item.status == 'drop'"
+                    :text="t('admin.imports.status.dropTooltip')"
+                    location="top"
+                >
+                    <template #activator="{ props }">
+                        <v-chip
+                            size="small"
+                            color="warning"
+                            v-bind="props"
+                        >
+                            {{ t('admin.imports.status.drop') }}
+                        </v-chip>
+                    </template>
+                </v-tooltip>
                 <v-chip
                     v-else
                     size="small"


### PR DESCRIPTION
## 问题描述

修复 issue #697：扫描导入页面中，状态为 `drop` 的文件显示原始字符串 "drop"，用户不理解含义（为何被跳过、如何处理）。

## 根本原因

`imports.vue` 和 `books.vue` 的状态 chip 模板中，`drop` 状态没有单独处理，走 `v-else` 分支直接显示原始字符串，且 i18n 也没有对应文案。

## 修复方案

- 为 `drop` 状态添加橙色警告 chip（区别于其他状态）
- 悬浮显示 tooltip，说明：检测到哈希值相同的重复文件，已自动跳过；如需重新导入，删除记录后重新扫描
- zh-CN 和 en-US i18n 添加 `drop` 和 `dropTooltip` 文案
- imports.vue 和 books.vue 均已处理

## 变更文件

- `app/pages/admin/imports.vue`
- `app/pages/admin/books.vue`
- `app/i18n/locales/zh-CN.json`
- `app/i18n/locales/en-US.json`

Closes #697