### PR TITLE
fix: support uploads with non-ASCII filenames

### DIFF
--- a/app/components/Upload.vue
+++ b/app/components/Upload.vue
@@ -69,18 +69,38 @@ const loading = ref(false);
 const dialog = ref(false);
 const ebooks = ref(null);
 
+function getAsciiSafeFilename(file) {
+    const originalName = file?.name || 'upload.bin';
+    const extIndex = originalName.lastIndexOf('.');
+    const hasExt = extIndex > 0;
+    const ext = hasExt ? originalName.slice(extIndex) : '';
+    const base = hasExt ? originalName.slice(0, extIndex) : originalName;
+
+    const normalized = base
+        .normalize('NFKD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .replace(/[^A-Za-z0-9._-]+/g, '_')
+        .replace(/^_+|_+$/g, '');
+
+    const safeBase = normalized || `upload_${Date.now()}`;
+    return `${safeBase}${ext}`;
+}
+
 function do_upload() {
     loading.value = true;
-    var data = new FormData();
-    // Vuetify 3 file input returns array
+    const data = new FormData();
+
+    let file = null;
     if (ebooks.value) {
-        if (Array.isArray(ebooks.value)) {
-            data.append('ebook', ebooks.value[0]);
-        } else {
-            data.append('ebook', ebooks.value);
-        }
+        file = Array.isArray(ebooks.value) ? ebooks.value[0] : ebooks.value;
     }
-    
+
+    if (file) {
+        const uploadName = getAsciiSafeFilename(file);
+        data.append('ebook', file, uploadName);
+        data.append('original_filename', file.name || uploadName);
+    }
+
     $backend('/book/upload', {
         method: 'POST',
         body: data,

--- a/webserver/handlers/book.py
+++ b/webserver/handlers/book.py
@@ -743,7 +743,9 @@ class BookUpload(BaseHandler):
     def get_upload_file(self):
         # for unittest mock
         p = self.request.files["ebook"][0]
-        filename = decode_filename(p["filename"])
+        original_filename = self.get_argument("original_filename", None)
+        filename = original_filename or p["filename"]
+        filename = decode_filename(filename)
         return (filename, p["body"])
 
     @js


### PR DESCRIPTION
## Summary
- avoid sending raw non-ASCII multipart filename values from the upload dialog
- send the original filename separately and prefer it on the server
- keep existing filename decoding fallback for compatible requests

## Root cause
Tornado 6.5 rejects multipart `Content-Disposition` headers when `filename=...` contains raw non-ASCII characters, so the request fails before `decode_filename()` runs.

## Changes
- frontend upload now generates an ASCII-safe multipart filename
- frontend also sends `original_filename` in the form body
- backend upload handler prefers `original_filename` when present

## Verification
- validated in the home environment
- confirmed this fix resolves uploads for files whose names contain Chinese characters

Fixes #709
