### PR TITLE
fix(test): 修复 test_upload.py 的测试失败及 library 文件污染问题

### DIFF
--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -114,12 +114,13 @@ class TestUploadFormatSecurity(TestWithUserLogin):
         self.assertEqual(d["err"], "params.format")
 
     @mock.patch("webserver.handlers.book.BookUpload.get_upload_file")
+    @mock.patch("webserver.handlers.base.BaseHandler.user_history")
+    @mock.patch("webserver.handlers.base.BaseHandler.add_msg")
     @mock.patch("webserver.models.Item.save")
     @mock.patch("calibre.db.legacy.LibraryDatabase.import_book")
-    def test_upload_valid_epub_passes_magic(self, mock_import, mock_save, m):
+    def test_upload_valid_epub_passes_magic(self, mock_import, mock_save, mock_msg, mock_hist, m):
         """合法 EPUB 文件（ZIP 魔数）通过魔数校验"""
         mock_import.return_value = 9999
-        mock_save.return_value = True
         path = testdir + "/cases/new.epub"
         with open(path, "rb") as f:
             data = f.read()
@@ -128,12 +129,13 @@ class TestUploadFormatSecurity(TestWithUserLogin):
         self.assertNotEqual(d["err"], "params.format")
 
     @mock.patch("webserver.handlers.book.BookUpload.get_upload_file")
+    @mock.patch("webserver.handlers.base.BaseHandler.user_history")
+    @mock.patch("webserver.handlers.base.BaseHandler.add_msg")
     @mock.patch("webserver.models.Item.save")
     @mock.patch("calibre.db.legacy.LibraryDatabase.import_book")
-    def test_upload_valid_pdf_passes_magic(self, mock_import, mock_save, m):
+    def test_upload_valid_pdf_passes_magic(self, mock_import, mock_save, mock_msg, mock_hist, m):
         """合法 PDF 文件（%PDF 魔数）通过魔数校验"""
         mock_import.return_value = 9999
-        mock_save.return_value = True
         path = testdir + "/cases/title_has_0x00.pdf"
         with open(path, "rb") as f:
             data = f.read()
@@ -144,6 +146,18 @@ class TestUploadFormatSecurity(TestWithUserLogin):
 
 class TestCoverUploadSecurity(TestWithUserLogin):
     """封面图上传魔数校验的安全测试"""
+
+    def setUp(self):
+        super().setUp()
+        self._patcher_get = mock.patch("calibre.db.legacy.LibraryDatabase.get_metadata")
+        self._patcher_set = mock.patch("calibre.db.legacy.LibraryDatabase.set_metadata")
+        self._patcher_get.start().return_value = mock.MagicMock()
+        self._patcher_set.start()
+
+    def tearDown(self):
+        self._patcher_set.stop()
+        self._patcher_get.stop()
+        super().tearDown()
 
     def _upload_cover(self, filename, content_type, data, bid=1):
         boundary = "----TalebookTestBoundary"

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -2,6 +2,7 @@
 # -*- coding: UTF-8 -*-
 
 import json
+import unittest
 import warnings
 from unittest import mock
 from tests.test_main import TestWithUserLogin, setUpModule as init, testdir, get_db
@@ -113,8 +114,12 @@ class TestUploadFormatSecurity(TestWithUserLogin):
         self.assertEqual(d["err"], "params.format")
 
     @mock.patch("webserver.handlers.book.BookUpload.get_upload_file")
-    def test_upload_valid_epub_passes_magic(self, m):
+    @mock.patch("webserver.models.Item.save")
+    @mock.patch("calibre.db.legacy.LibraryDatabase.import_book")
+    def test_upload_valid_epub_passes_magic(self, mock_import, mock_save, m):
         """合法 EPUB 文件（ZIP 魔数）通过魔数校验"""
+        mock_import.return_value = 9999
+        mock_save.return_value = True
         path = testdir + "/cases/new.epub"
         with open(path, "rb") as f:
             data = f.read()
@@ -123,8 +128,12 @@ class TestUploadFormatSecurity(TestWithUserLogin):
         self.assertNotEqual(d["err"], "params.format")
 
     @mock.patch("webserver.handlers.book.BookUpload.get_upload_file")
-    def test_upload_valid_pdf_passes_magic(self, m):
+    @mock.patch("webserver.models.Item.save")
+    @mock.patch("calibre.db.legacy.LibraryDatabase.import_book")
+    def test_upload_valid_pdf_passes_magic(self, mock_import, mock_save, m):
         """合法 PDF 文件（%PDF 魔数）通过魔数校验"""
+        mock_import.return_value = 9999
+        mock_save.return_value = True
         path = testdir + "/cases/title_has_0x00.pdf"
         with open(path, "rb") as f:
             data = f.read()
@@ -186,7 +195,7 @@ class TestCoverUploadSecurity(TestWithUserLogin):
         self.assertNotEqual(d["err"], "params.cover.type")
 
 
-class TestProxyImageWhitelist(TestWithUserLogin):
+class TestProxyImageWhitelist(unittest.TestCase):
     """ProxyImageHandler.is_whitelist 修复验证（直接测试 files.py 中的实现）"""
 
     def setUp(self):


### PR DESCRIPTION
## Summary

- `test_upload_valid_epub/pdf_passes_magic`：补齐 `import_book`、`Item.save`、`user_history`、`add_msg` 的 mock，与 `test_upload_new_file` 保持一致，避免真实写入 Calibre DB 导致 `tests/library/` 文件被删除
- `TestCoverUploadSecurity`：在 `setUp`/`tearDown` 中统一 mock `get_metadata` 和 `set_metadata`，防止 `upload_cover` 的真实 Calibre 写操作重整 library 目录
- `TestProxyImageWhitelist`：改为继承 `unittest.TestCase`，其 `setUp` 未调 `super().setUp()`，导致 `tearDown` 找不到 `http_server` 而报 `AttributeError`

## Test plan

- [x] `make test` 全部通过（174 passed, 1 skipped）
- [x] 单独执行 `tests/test_upload.py` 后 `git status tests/library/` 无变化

🤖 Generated with [Claude Code](https://claude.com/claude-code)