### PR TITLE
ci: 优化 GitHub Actions 构建速度

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,15 @@ jobs:
           fi
           echo "build_args=GIT_VERSION=$VERSION" >> $GITHUB_OUTPUT
 
+      - name: Set build platforms
+        id: platforms
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "platforms=linux/amd64" >> $GITHUB_OUTPUT
+          else
+            echo "platforms=linux/amd64,linux/arm64,linux/arm/v7" >> $GITHUB_OUTPUT
+          fi
+
       # ----------------------------------------
       # SPA 镜像：talebook/talebook:latest / <ver> / calibre-webserver:latest
       - name: Build and push SPA
@@ -71,11 +80,15 @@ jobs:
         with:
           context: .
           target: production-spa
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: ${{ steps.platforms.outputs.platforms }}
           labels: ${{ steps.meta.outputs.labels }}
           push: ${{ github.event_name != 'pull_request' }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/talebook/talebook:latest
-          cache-to: type=inline,mode=max
+          cache-from: |
+            type=gha
+            type=registry,ref=${{ env.REGISTRY }}/talebook/talebook:latest
+          cache-to: |
+            type=gha,mode=max
+            type=inline,mode=max
           provenance: false
           tags: |
             ${{ steps.meta.outputs.tags }}
@@ -90,11 +103,15 @@ jobs:
         with:
           context: .
           target: production-ssr
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: ${{ steps.platforms.outputs.platforms }}
           labels: ${{ steps.meta.outputs.labels }}
           push: ${{ github.event_name != 'pull_request' }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/talebook/talebook:server-side-render
-          cache-to: type=inline,mode=max
+          cache-from: |
+            type=gha
+            type=registry,ref=${{ env.REGISTRY }}/talebook/talebook:server-side-render
+          cache-to: |
+            type=gha,mode=max
+            type=inline,mode=max
           provenance: false
           tags: |
             ${{ startsWith(github.ref, 'refs/tags/') && format('{0}/{1}:server-side-render', env.REGISTRY, env.IMAGE_NAME) || '' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -176,3 +176,4 @@ RUN rm -rf /var/www/talebook/app/.output/public/logo && \
 # 生产环境（spa版，作为默认 docker build 结果）
 FROM production AS production-spa
 # no more actions
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.6
 # ----------------------------------------
 # 第一阶段，拉取 node 基础镜像并安装依赖，执行构建
 FROM node:20-alpine AS builder
@@ -11,7 +12,7 @@ RUN if [ "x${BUILD_COUNTRY}" = "xCN" ]; then \
     fi
 
 COPY app/package.json app/package-lock.json* ./
-RUN npm ci
+RUN --mount=type=cache,target=/root/.npm npm ci
 
 # spa build mode will clear ssr build data, run it first
 COPY app/ /build/
@@ -64,8 +65,7 @@ fi && \
 
 # install python packages
 COPY requirements.txt /tmp/
-RUN pip install -r /tmp/requirements.txt && \
-    rm -rf /root/.cache
+RUN --mount=type=cache,target=/root/.cache/pip pip install -r /tmp/requirements.txt
 
 
 # ----------------------------------------
@@ -175,3 +175,4 @@ RUN rm -rf /var/www/talebook/app/.output/public/logo && \
 # ----------------------------------------
 # 生产环境（spa版，作为默认 docker build 结果）
 FROM production AS production-spa
+# no more actions


### PR DESCRIPTION
## Summary

- PR 触发时只编译 `linux/amd64`，跳过 arm 架构，减少 CI 等待时间
- 启用 GitHub Actions Cache（`type=gha`）加速 Docker 层缓存
- Dockerfile 使用 `--mount=type=cache` 缓存 npm 和 pip 依赖，加快镜像构建

## Test Plan

- [ ] 提交 PR 验证 CI 只构建 amd64，耗时明显缩短
- [ ] 合并到 master 后验证三平台（amd64/arm64/arm/v7）正常构建并推送镜像