### PR TITLE
revert: 恢复测试依赖版本并清理requirements文件

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "jinja2==3.1.6",
     "pymysql>=1.1.2",
     "msgpack>=1.1.2",
-    "pytest==9.0.3",
+    "pytest==7.4.4",
     "pytest-cov>=4.1.0",
     "python-dateutil>=2.9.0",
     "social-auth-app-tornado==1.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,13 +3,13 @@ social-auth-core==4.5.1
 social-auth-app-tornado==1.0.0
 social-auth-storage-sqlalchemy==1.1.0
 tornado==6.5
-bs4>=0.0.2
-chardet>=5.2.0
-ruff>=0.1.0
-bcrypt
+bs4
+chardet
+ruff
 
 # build-in support for MYSQL
-pymysql>=1.1.2
-pytest==9.0.3
-pytest-cov>=4.1.0
+pymysql
+pytest==7.4.4
+pytest-cov
 flake8
+bcrypt


### PR DESCRIPTION
统一将pytest从9.0.3降级至7.4.4以解决兼容性问题
清理requirements.txt中的冗余版本约束