### PR TITLE
Initialize parent class in ReadingState constructor

### DIFF
--- a/webserver/models.py
+++ b/webserver/models.py
@@ -470,6 +470,7 @@ class ReadingState(Base, SQLAlchemyMixin):
     reader = relationship(Reader, backref="reading_states")
 
     def __init__(self, book_id, reader_id):
+        super(ReadingState, self).__init__()
         self.book_id = book_id
         self.reader_id = reader_id
         self.favorite = 0


### PR DESCRIPTION
## Summary
Added explicit parent class initialization to the `ReadingState.__init__` method to ensure proper initialization of SQLAlchemy base classes.

## Key Changes
- Added `super(ReadingState, self).__init__()` call at the beginning of the `ReadingState.__init__` method

## Implementation Details
This change ensures that the `Base` and `SQLAlchemyMixin` parent classes are properly initialized before setting instance attributes. This is a best practice for SQLAlchemy models and helps prevent potential issues with declarative base initialization and mixin functionality.

https://claude.ai/code/session_01As6LbWyodm8dLZvYqzRosw