### PR TITLE
fix: prevent settings key code injection

### DIFF
--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -2,8 +2,13 @@
 # -*- coding: UTF-8 -*-
 
 import json
+import os
+import tempfile
 from unittest import mock
-from tests.test_main import TestWithUserLogin, TestWithAdminUser, setUpModule as init, get_db
+
+from tests.test_main import TestWithAdminUser, TestWithUserLogin, get_db
+from tests.test_main import setUpModule as init
+from webserver import loader
 
 
 def setUpModule():
@@ -57,3 +62,31 @@ class TestAdminSettingsSecurity(TestWithAdminUser):
             d = self.json("/api/admin/settings", method="POST", body=req)
             self.assertEqual(d["err"], "ok")
             self.assertNotIn("not_in_whitelist", d["rsp"])
+
+    def test_settings_rejects_malformed_social_auth_key(self):
+        """SOCIAL_AUTH 动态字段必须是普通配置名，不能携带 Python 语法"""
+        key = "SOCIAL_AUTH_BAD_KEY' : {}, }\nexec('raise RuntimeError')\nsettings = {'SOCIAL_AUTH_FINAL_KEY"
+        with mock.patch("webserver.loader.SettingsLoader.set_store_path", return_value="/tmp/"):
+            req = json.dumps({"site_title": "ok", key: "injected"})
+            d = self.json("/api/admin/settings", method="POST", body=req)
+            self.assertEqual(d["err"], "ok")
+            self.assertNotIn(key, d["rsp"])
+
+    def test_settings_dumpfile_quotes_keys_safely(self):
+        """配置写盘时 key 必须用 repr 转义，避免生成可执行注入代码"""
+        key = "SOCIAL_AUTH_BAD_KEY' : {}, }\nexec('raise RuntimeError')\nsettings = {'SOCIAL_AUTH_FINAL_KEY"
+        settings = loader.SettingsLoader()
+        settings.clear()
+        settings[key] = "value"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch.object(settings, "set_store_path", return_value=tmpdir):
+                settings.dumpfile()
+
+            path = os.path.join(tmpdir, "auto.py")
+            namespace = {}
+            with open(path) as f:
+                code = f.read()
+            exec(compile(code, path, "exec"), namespace)
+
+        self.assertEqual(namespace["settings"][key], "value")

--- a/webserver/handlers/admin.py
+++ b/webserver/handlers/admin.py
@@ -30,6 +30,7 @@ CONF = loader.get_settings()
 # 元数据源配置
 META_ALL_SOURCES = ["douban", "baidu", "google", "amazon", "xinhua", "ai"]
 DEFAULT_META_SOURCES = ["douban", "baidu", "xinhua"]
+SOCIAL_AUTH_SETTING_RE = re.compile(r"^SOCIAL_AUTH_[A-Z0-9_]+_(KEY|SECRET)$")
 
 
 class AdminUsers(BaseHandler):
@@ -383,9 +384,8 @@ class AdminSettings(BaseHandler):
         args.clear()
 
         for key, val in data.items():
-            if key.startswith("SOCIAL_AUTH"):
-                if key.endswith("_KEY") or key.endswith("_SECRET"):
-                    args[key] = val
+            if SOCIAL_AUTH_SETTING_RE.match(key):
+                args[key] = val
             elif key in KEYS:
                 args[key] = val
 

--- a/webserver/loader.py
+++ b/webserver/loader.py
@@ -51,7 +51,7 @@ class SettingsLoader(dict):
             pass
 
     def dumpfile(self, filename="auto.py"):
-        s = "\n".join("%-30s: %s," % ("'" + k + "'", repr(v)) for k, v in sorted(self.items()))
+        s = "\n".join("%-30s: %s," % (repr(k), repr(v)) for k, v in sorted(self.items()))
         code = (
             """#!/usr/bin/env python3
 #-*- coding: UTF-8 -*-


### PR DESCRIPTION
## Summary
- safely serialize settings keys with repr() when writing Python config files
- restrict dynamic SOCIAL_AUTH settings to safe KEY/SECRET names
- add regression coverage for malformed SOCIAL_AUTH keys and dumpfile escaping

## Verification
- ruff check webserver/loader.py webserver/handlers/admin.py tests/test_admin.py --no-cache
- ruff format --check webserver/loader.py webserver/handlers/admin.py tests/test_admin.py --no-cache
- PYTHONPYCACHEPREFIX=/private/tmp/talebook-pycache python3 -m py_compile webserver/loader.py webserver/handlers/admin.py tests/test_admin.py

Note: python3 -m pytest tests/test_admin.py -q is blocked in the local environment by missing calibre.db.