### PR TITLE
build: 合并 calibre-docker 为 Dockerfile.base（第一步：建立基础镜像）

### DIFF
--- a/.github/workflows/build-base.yml
+++ b/.github/workflows/build-base.yml
@@ -1,5 +1,8 @@
 name: Build and Push Base Image
 
+permissions:
+  contents: read
+
 # 基础镜像（Dockerfile.base）独立构建，只在以下情况触发，避免日常改 app 时重复编译：
 #   - 改动了 Dockerfile.base（push 到 master）
 #   - 打 base-v* 形式的 tag 发布版本（如 base-v8.5.0）

--- a/.github/workflows/build-base.yml
+++ b/.github/workflows/build-base.yml
@@ -1,0 +1,69 @@
+name: Build and Push Base Image
+
+# 基础镜像（Dockerfile.base）独立构建，只在以下情况触发，避免日常改 app 时重复编译：
+#   - 改动了 Dockerfile.base（push 到 master）
+#   - 打 base-v* 形式的 tag 发布版本（如 base-v8.5.0）
+#   - 手动触发
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "Dockerfile.base"
+      - ".github/workflows/build-base.yml"
+    tags:
+      - "base-v*"
+  workflow_dispatch:
+
+env:
+  REGISTRY: docker.io
+  IMAGE_NAME: talebook/talebook-base
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # base-v8.5.0 -> 8 / 8.5 / 8.5.0；master push -> latest / master
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' }}
+            type=raw,value=master,enable=${{ github.ref == 'refs/heads/master' }}
+            type=match,pattern=base-v(\d+),group=1
+            type=match,pattern=base-v(\d+\.\d+),group=1
+            type=match,pattern=base-v(\d+\.\d+\.\d+),group=1
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: .
+          file: ./Dockerfile.base
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          cache-to: type=inline,mode=max

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,87 @@
+# ----------------------------------------
+# talebook 基础镜像（含 calibre / nginx / supervisor / PyQt5 等）
+# 独立构建并推送到 registry，主 Dockerfile 通过 FROM 引用，避免每次构建重复编译。
+# 源自原 talebook/calibre-docker 仓库，现统一在本仓库管理。
+# 构建/发布见 Makefile 的 build-base / push-base 与 .github/workflows/build-base.yml
+# ----------------------------------------
+FROM debian:13-slim
+
+ARG TARGETARCH
+ARG TARGETVARIANT
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
+
+# 安装基础系统（包含 PyQt5 系统包）
+RUN apt-get update && \
+    apt-get install -y \
+        tzdata \
+        python3 \
+        python3-pip \
+        python3-venv \
+        nginx \
+        supervisor \
+        sqlite3 \
+        curl \
+        wget \
+        unzip \
+        git \
+        ca-certificates \
+        python3-pyqt5 \
+        python3-pyqt5.qtwebengine \
+        python3-pyqt5.qtsql \
+        python3-pyqt5.qtmultimedia \
+        python3-dateutil \
+        python3-cssselect \
+        python3-lxml \
+        python3-pil \
+        python3-psutil \
+        python3-chardet \
+        python3-html5lib \
+        fonts-liberation && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# 校验 nginx 版本，确保已修复 CVE-2026-42945（ngx_http_rewrite_module 堆溢出 RCE/DoS）
+RUN ver="$(dpkg-query -W -f='${Version}' nginx)" && \
+    echo "Installed nginx: $ver" && \
+    dpkg --compare-versions "$ver" ge 1.26.3-3+deb13u5 || \
+    { echo "ERROR: nginx $ver 仍受 CVE-2026-42945 影响，需 >= 1.26.3-3+deb13u5" && exit 1; }
+
+# 根据架构安装 Calibre
+RUN echo "Installing Calibre via apt for $TARGETARCH $TARGETVARIANT" && \
+    apt-get update && \
+    apt-get install -y calibre && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*;
+
+# 验证 Calibre 安装
+RUN echo "Verifying Calibre installation..." && \
+    if command -v calibre > /dev/null 2>&1; then \
+        echo "Calibre installed successfully" && \
+        calibre --version; \
+    else \
+        echo "Calibre installation failed" && \
+        exit 1; \
+    fi
+
+# 验证 PyQt5 安装
+RUN echo "Verifying PyQt5 installation..." && \
+    python3 -c "import PyQt5; print('PyQt5 imported successfully')" && \
+    python3 -c "import PyQt5.QtWebEngine; print('PyQt5.QtWebEngine imported successfully')"
+
+# 安装 Python 包（使用 --break-system-packages）
+RUN pip3 install --no-cache-dir --break-system-packages \
+    flask \
+    sqlalchemy \
+    requests \
+    beautifulsoup4
+
+# 创建应用用户
+RUN useradd -m -u 1000 -s /bin/bash talebook && \
+    mkdir -p /app /data && \
+    chown talebook:talebook /app /data
+
+USER talebook
+WORKDIR /app
+
+CMD ["/bin/bash"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build push test
+.PHONY: all build push test build-base push-base
 
 VER := $(shell git branch --show-current | tr '/' '-')
 IMAGE := talebook/talebook:$(VER)
@@ -6,6 +6,7 @@ REPO1 := talebook/talebook:latest
 REPO2 := talebook/calibre-webserver:latest
 TAG1 := talebook/talebook:server-side-render
 TAG2 := talebook/talebook:server-side-render-$(VER)
+BASE := talebook/talebook-base
 
 all: lint-py-fix build up
 
@@ -15,6 +16,15 @@ init:
 	#uv sync
 
 build: test build-spa build-ssr
+
+# 基础镜像：本地构建/发布。主 Dockerfile 默认 FROM talebook/talebook-base:8.5，
+# 首次切换镜像名后需先执行 make build-base push-base 引导出 :8.5 标签。
+build-base:
+	docker build -f Dockerfile.base -t $(BASE):latest -t $(BASE):8.5 .
+
+push-base:
+	docker push $(BASE):latest
+	docker push $(BASE):8.5
 
 build-spa:
 	docker build --no-cache=false --build-arg BUILD_COUNTRY=CN --build-arg GIT_VERSION=$(VER) \

--- a/document/20260602/calibre-docker-merge.md
+++ b/document/20260602/calibre-docker-merge.md
@@ -1,0 +1,62 @@
+# 合并 calibre-docker 基础镜像并改名
+
+日期：2026-06-02
+
+## 背景
+
+原 `talebook/calibre-docker` 是一个独立仓库，构建出供主项目 `FROM` 的基础镜像
+（debian:13-slim + calibre + nginx + supervisor + PyQt5）。基础镜像独立构建、推到
+registry、主镜像按 tag 引用，避免每次构建重复编译 calibre（QEMU 下 arm 尤其慢）。
+
+为统一管理，将其源码合并进本仓库，并把镜像名从 `talebook/calibre-docker`
+改为 **`talebook/talebook-base`**（语义更准：它是 talebook 专用基础镜像，而非纯 calibre）。
+
+## 分两步落地
+
+为避免在基础镜像尚未发布到 registry 时切坏构建，分两个 PR：
+
+**第一步（本次）：建好基础镜像并发布，不切换任何消费方**
+
+| 文件 | 改动 |
+| --- | --- |
+| `Dockerfile.base` | 新增，源自原 calibre-docker/Dockerfile，内容原样照搬 |
+| `.github/workflows/build-base.yml` | 新增，独立构建/推送基础镜像，仅在改 `Dockerfile.base` / 打 `base-v*` tag / 手动触发时运行 |
+| `Makefile` | 新增 `build-base` / `push-base` 目标 |
+| `document/Development.zh_CN.md` | 手动搭建参考链接改为本仓库 `Dockerfile.base`（仅文档，无构建影响） |
+
+完成后执行发布（见下文「首次引导」），确认 `talebook/talebook-base:8.5` 在 registry 可拉取。
+
+**第二步（后续 PR）：切换消费方到新镜像名**
+
+| 文件 | 改动 |
+| --- | --- |
+| `Dockerfile` | `FROM talebook/calibre-docker:8.5` → `ARG BASE_IMAGE=talebook/talebook-base:8.5` + `FROM ${BASE_IMAGE}`（全局 ARG 放文件顶部） |
+| `.github/workflows/ci.yml` | 测试容器镜像 `talebook/calibre-docker:latest` → `talebook/talebook-base:latest` |
+
+## 设计要点
+
+- **保持"编译一次、registry 复用"分工**：基础镜像没有内联成主 Dockerfile 的 stage，
+  否则每次 build app 都会重编 calibre。
+- **触发收敛**：`build-base.yml` 用 `paths: [Dockerfile.base]` 过滤，日常改 app 不会触发基础镜像重建。
+- **版本标签**：打 `base-v8.5.0` 这类 tag → 产出 `8` / `8.5` / `8.5.0`；
+  master push（改了 Dockerfile.base）→ 产出 `latest` / `master`。
+  用 `base-v*` 前缀是为了和主项目已有的 `v*`（app 发版）tag 区分开。
+- 主 Dockerfile 默认 pin `talebook/talebook-base:8.5`，可用 `--build-arg BASE_IMAGE=...` 覆盖。
+
+## 切换后首次引导
+
+新镜像名首次需要先把 `:8.5` 标签推上去，主镜像/CI 才能拉到：
+
+```bash
+make build-base push-base      # 本地构建并推送 latest + 8.5
+# 或在 GitHub 上打 tag：git tag base-v8.5.0 && git push origin base-v8.5.0
+```
+
+## 待办（未在本次处理）
+
+- 原 `talebook/calibre-docker` 仓库归档，README 指向本仓库 `Dockerfile.base`。
+- Docker Hub 旧镜像 `talebook/calibre-docker` 加"已迁移"说明。
+- `Dockerfile.base` 末尾 `pip install flask sqlalchemy requests beautifulsoup4` 疑似历史遗留
+  （talebook 用 Tornado，实际依赖走主 Dockerfile 的 requirements.txt），可后续确认是否删除。
+- 基础镜像建 `talebook` uid=1000 用户，主 Dockerfile 的"不存在才建 uid=911"分支因此被跳过——
+  现状行为，本次未改动。

--- a/document/Development.zh_CN.md
+++ b/document/Development.zh_CN.md
@@ -77,7 +77,7 @@ npx playwright test               # E2E 测试（需先启动 mock server）
 
 如果希望完全脱离 Docker 运行，以下是完整的手动搭建步骤。**推荐在 Linux 环境下进行**，Mac / Windows 未经完整测试。
 
-随着版本更新，部分命令可能不及时更新；遇到问题可参考 [calibre-docker/Dockerfile](https://github.com/talebook/calibre-docker/blob/master/Dockerfile) 和 [本仓库 Dockerfile](../Dockerfile)。
+随着版本更新，部分命令可能不及时更新；遇到问题可参考 [基础镜像 Dockerfile.base](../Dockerfile.base) 和 [本仓库 Dockerfile](../Dockerfile)。
 
 ### 准备目录
 
@@ -97,7 +97,7 @@ cd talebook
 
 ### 安装 Calibre 基础环境
 
-参考 [calibre-docker/Dockerfile](https://github.com/talebook/calibre-docker/blob/master/Dockerfile)：
+参考 [基础镜像 Dockerfile.base](../Dockerfile.base)：
 
 ```bash
 apt-get install -y tzdata


### PR DESCRIPTION
## 背景

将原 `talebook/calibre-docker` 仓库的基础镜像源码合并进本仓库统一管理，镜像改名为 **`talebook/talebook-base`**（语义更准：talebook 专用基础镜像，含 calibre/nginx/supervisor/PyQt5）。

## 分两步落地

为避免基础镜像尚未发布时切坏构建，分两个 PR：

**第一步（本 PR）：建立基础镜像与独立发布链路，不切换任何消费方**
- `Dockerfile.base` — 源自 calibre-docker/Dockerfile，内容原样照搬
- `.github/workflows/build-base.yml` — 独立构建/推送，仅在改 `Dockerfile.base` / 打 `base-v*` tag / 手动触发时运行（多架构 amd64/arm64/arm-v7）
- `Makefile` — 新增 `build-base` / `push-base`
- `document/Development.zh_CN.md` — 手动搭建参考链接改为本仓库 `Dockerfile.base`（仅文档）

主 `Dockerfile`、`ci.yml` **本 PR 不动**，继续引用 `talebook/calibre-docker`，因此合入不影响现有构建。

**第二步（后续 PR）：** 待 `talebook/talebook-base:8.5` 发布到 registry 后，再把主 `Dockerfile`（`FROM` 改为 `ARG BASE_IMAGE=talebook/talebook-base:8.5`）和 `ci.yml`（测试容器镜像）切到新镜像名。

## 版本

debian:13 apt 的 calibre 版本为 `8.5.0`，与主 Dockerfile 现有 `:8.5` pin 一致。合入后通过 `base-v8.5.0` tag 或 `make build-base push-base` 发布。

详见 `document/20260602/calibre-docker-merge.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)