### PR TITLE
build: 切换基础镜像到 talebook/talebook-base（第二步）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   test-server:
     runs-on: ubuntu-latest
     container:
-      image: talebook/calibre-docker:latest
+      image: talebook/talebook-base:latest
       options: --user root
 
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 # syntax=docker/dockerfile:1.6
+# 基础镜像源码见本仓库 Dockerfile.base，独立构建并推送，避免重复编译 calibre
+ARG BASE_IMAGE=talebook/talebook-base:8.5
 # ----------------------------------------
 # 第一阶段，拉取 node 基础镜像并安装依赖，执行构建
 FROM node:20-alpine AS builder
@@ -28,7 +30,7 @@ RUN cp -r dist package* /app-static/
 
 # ----------------------------------------
 # 第二阶段，构建环境
-FROM talebook/calibre-docker:8.5 AS server
+FROM ${BASE_IMAGE} AS server
 ARG BUILD_COUNTRY=""
 ARG TARGETARCH
 ARG TARGETVARIANT

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
 # syntax=docker/dockerfile:1.6
-# 基础镜像源码见本仓库 Dockerfile.base，独立构建并推送，避免重复编译 calibre
-ARG BASE_IMAGE=talebook/talebook-base:8.5
 # ----------------------------------------
 # 第一阶段，拉取 node 基础镜像并安装依赖，执行构建
 FROM node:20-alpine AS builder
@@ -30,7 +28,8 @@ RUN cp -r dist package* /app-static/
 
 # ----------------------------------------
 # 第二阶段，构建环境
-FROM ${BASE_IMAGE} AS server
+# 基础镜像源码见本仓库 Dockerfile.base，独立构建并推送，避免重复编译 calibre
+FROM talebook/talebook-base:8.5 AS server
 ARG BUILD_COUNTRY=""
 ARG TARGETARCH
 ARG TARGETVARIANT


### PR DESCRIPTION
## 背景

承接 #779。`talebook/talebook-base` 已合并进本仓库并发布到 registry（`base-v8.5.0` → `8` / `8.5`，master 合入 → `latest`，三架构 amd64/arm64/arm-v7 齐全），本 PR 把消费方从旧镜像名 `talebook/calibre-docker` 切换过来。

## 改动

- **`Dockerfile`**：server 阶段 `FROM talebook/talebook-base:8.5`（直接写死，不引入变量）
- **`.github/workflows/ci.yml`**：测试容器镜像 `talebook/calibre-docker:latest` → `talebook/talebook-base:latest`

## 验证

- `docker buildx imagetools inspect` 确认 `talebook/talebook-base` 的 `latest` / `8.5` / `8` 均已发布、三架构齐全。
- `docker build --check` 主 Dockerfile 通过，无警告。

## 后续（不在本 PR）

- 原 `talebook/calibre-docker` 仓库归档，Docker Hub 旧镜像加“已迁移”说明。

🤖 Generated with [Claude Code](https://claude.com/claude-code)