### PR TITLE
build: 切换基础镜像到 talebook/talebook-base

### DIFF
--- a/.github/workflows/build-base.yml
+++ b/.github/workflows/build-base.yml
@@ -68,5 +68,3 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-          cache-to: type=inline,mode=max


### PR DESCRIPTION
## 概述

将生产 Dockerfile 切换到独立构建的 `talebook/talebook-base` 基础镜像，并整理 base 镜像的构建流程。

## 改动

- 合并 calibre-docker 为本仓库 `Dockerfile.base`
- 切换基础镜像到 `talebook/talebook-base`
- 基础镜像直接写死，去掉 `BASE_IMAGE` 变量
- `build-base.yml` 移除 registry cache 配置

🤖 Generated with [Claude Code](https://claude.com/claude-code)