### PR TITLE
fix(app): 条件重定向改用 302，避免浏览器永久缓存 301

### DIFF
--- a/app/plugins/talebook.js
+++ b/app/plugins/talebook.js
@@ -75,16 +75,16 @@ export default defineNuxtPlugin((nuxtApp) => {
 
       if (data.err === 'not_installed') {
         console.log('[Talebook] Redirecting to /install');
-        await nuxtApp.runWithContext(() => navigateTo('/install', { redirectCode: 301 }));
+        await nuxtApp.runWithContext(() => navigateTo('/install', { redirectCode: 302 }));
       } else if (data.err === 'not_invited') {
         const route = useRoute();
         var next = route.fullPath;
         next = next ? '?next=' + next : '';
         if (route.path !== '/welcome') {
-          await nuxtApp.runWithContext(() => navigateTo('/welcome' + next, { redirectCode: 301 }));
+          await nuxtApp.runWithContext(() => navigateTo('/welcome' + next, { redirectCode: 302 }));
         }
       } else if (data.err === 'user.need_login') {
-        await nuxtApp.runWithContext(() => navigateTo('/login', { redirectCode: 301 }));
+        await nuxtApp.runWithContext(() => navigateTo('/login', { redirectCode: 302 }));
       } else if (data.err === 'exception') {
         store.setAlert({ type: 'error', msg: data.msg, to: null });
       }

--- a/app/test/e2e/install.spec.ts
+++ b/app/test/e2e/install.spec.ts
@@ -33,6 +33,31 @@ test.describe('Install Flow', () => {
         await expect(page.getByText('安装 TaleBook')).toBeVisible();
     });
 
+    test('Install redirect uses 302, not a cacheable 301', async ({ page }) => {
+        // Regression: a 301 (Moved Permanently) gets cached by the browser, so once a
+        // fresh user hits "/" while not_installed, "/" -> "/install" is pinned permanently
+        // and never re-checked — leaving them stuck on the install page even after setup.
+        const installRedirectStatuses: number[] = [];
+        page.on('response', response => {
+            const status = response.status();
+            if (status >= 300 && status < 400) {
+                const location = response.headers()['location'] || '';
+                if (location.includes('/install')) {
+                    installRedirectStatuses.push(status);
+                }
+            }
+        });
+
+        await page.goto('/');
+        await expect(page).toHaveURL(/\/install/, { timeout: 10000 });
+
+        expect(installRedirectStatuses.length).toBeGreaterThan(0);
+        expect(installRedirectStatuses).not.toContain(301);
+        for (const status of installRedirectStatuses) {
+            expect(status).toBe(302);
+        }
+    });
+
     test('Can complete installation', async ({ page }) => {
         page.on('console', msg => console.log('Browser Console:', msg.text()));
         page.on('response', response => {


### PR DESCRIPTION
## 问题

`app/plugins/talebook.js` 的 `backend()` 中，三处**取决于运行时状态**的跳转使用了 `redirectCode: 301`：

| 行 | 条件 | 跳转 |
|----|------|------|
| 78 | `not_installed` | `/install` |
| 84 | `not_invited` | `/welcome` |
| 87 | `user.need_login` | `/login` |

`301 Moved Permanently` 会被浏览器**长期缓存**。典型故障路径：

1. 用户在站点尚未安装（空数据目录）时首次访问 `/`，SSR 返回 `301: / → /install`；
2. 浏览器把"`/` 已永久搬到 `/install`"记入缓存；
3. 之后后端完成安装、`/api/welcome` 已返回正常状态，但浏览器**根本不再请求服务器**，直接用缓存的 301 把用户甩到 `/install` —— 表现为"已经装好了却一直跳安装页，改后端配置也没用"。

`not_invited` / `need_login` 同理：登录或输入访问码后，访问受限页仍可能被缓存的永久重定向打断。

## 根因

`git log -S 'redirect(301'` 定位到 commit `4d1cc4e`（2022-02-28，*"fix bug of nodejs, 302 -> 301"*）将原本的隐式 302（Nuxt 2 `redirect()` 默认状态码）手动改成了显式 301。后续 Nuxt 2→4 升级（`9150a17`）把 `redirect(301, x)` 忠实翻译为 `navigateTo(x, { redirectCode: 301 })`，bug 原样保留至今。

## 改动

- 三处 `redirectCode: 301` → `redirectCode: 302`（临时重定向，不被缓存），等价于回退 `4d1cc4e` 的语义。
- 新增 e2e 回归用例 `install.spec.ts`：断言未安装时 `/ → /install` 的重定向状态码为 **302 而非 301**。

## 验证

- `npx eslint plugins/talebook.js` 通过。
- 在本地全栈环境（Docker 后端 + Nuxt dev）用 Chrome DevTools 复现并确认：修复前浏览器缓存 301 导致持续跳转安装页；修复后状态相关跳转改为 302，不再被缓存。
- 新增的 e2e 用例覆盖该回归，由 CI 执行。

> 注：未在本地跑完整 e2e —— `master` 上 `install.spec.ts` 硬编码向 `:8080` 发 `/_test/reset`，而 `master` 的 `mock-server.js` 监听 `:8000`，二者端口不一致；本地 `:8080` 又被开发用的后端容器占用。该端口漂移是既有问题，不在本 PR 范围内（保持改动聚焦），CI 环境不受影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)