### PR TITLE
ci: 让 claude/* 和 codex/* 分支也触发 Docker 构建

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - master
       - dev/*
+      - claude/*
+      - codex/*
     tags:
       - "v*"
   pull_request:
@@ -64,7 +66,7 @@ jobs:
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
             type=raw,value=master,enable=${{ github.ref == 'refs/heads/master' }}
             type=raw,value=${{ github.ref_name }},enable=${{ startsWith(github.ref, 'refs/tags/') }}
-            type=raw,value=${{ steps.prep.outputs.safe_ref_name }},enable=${{ startsWith(github.ref, 'refs/heads/dev/') }}
+            type=raw,value=${{ steps.prep.outputs.safe_ref_name }},enable=${{ startsWith(github.ref, 'refs/heads/dev/') || startsWith(github.ref, 'refs/heads/claude/') || startsWith(github.ref, 'refs/heads/codex/') }}
 
       - name: Set build platforms
         id: platforms
@@ -109,7 +111,7 @@ jobs:
             ${{ startsWith(github.ref, 'refs/tags/') && format('{0}/{1}:server-side-render', env.REGISTRY, env.IMAGE_NAME) || '' }}
             ${{ startsWith(github.ref, 'refs/tags/') && format('{0}/{1}:server-side-render-{2}', env.REGISTRY, env.IMAGE_NAME, github.ref_name) || '' }}
             ${{ github.ref == 'refs/heads/master' && format('{0}/{1}:server-side-render', env.REGISTRY, env.IMAGE_NAME) || '' }}
-            ${{ startsWith(github.ref, 'refs/heads/dev/') && format('{0}/{1}:server-side-render-{2}', env.REGISTRY, env.IMAGE_NAME, steps.prep.outputs.safe_ref_name) || '' }}
+            ${{ (startsWith(github.ref, 'refs/heads/dev/') || startsWith(github.ref, 'refs/heads/claude/') || startsWith(github.ref, 'refs/heads/codex/')) && format('{0}/{1}:server-side-render-{2}', env.REGISTRY, env.IMAGE_NAME, steps.prep.outputs.safe_ref_name) || '' }}
           build-args: ${{ steps.prep.outputs.build_args }}
           cache-from: type=gha,scope=ssr
           cache-to: type=gha,scope=ssr,mode=max


### PR DESCRIPTION
## 改动
让 AI 编码代理分支(`claude/*`、`codex/*`)在推送时也触发 Docker 构建工作流。

- `on.push.branches` 增加 `claude/*`、`codex/*`
- SPA / SSR 镜像的 `safe_ref_name` tag 启用条件扩展到这两类分支(否则无 tag 会导致 `build-push-action` 推送失败)

镜像 tag 形如 `talebook/talebook:claude-xxx`、`server-side-render-claude-xxx`(斜杠转连字符)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)