### PR TITLE
fix: 非EPUB书籍首次在线阅读报错加载超时 & 表格页脚分页文案错误

### DIFF
--- a/app/i18n/locales/en-US.json
+++ b/app/i18n/locales/en-US.json
@@ -769,7 +769,7 @@
     "loading": "Loading...",
     "dataFooter": {
       "itemsPerPageText": "Items per page",
-      "pageText": "Page {0} of {1}",
+      "pageText": "{0}-{1} of {2}",
       "itemsPerPageAll": "All",
       "firstPage": "First page",
       "prevPage": "Previous page",

--- a/app/i18n/locales/zh-CN.json
+++ b/app/i18n/locales/zh-CN.json
@@ -789,7 +789,7 @@
     "loading": "加载中...",
     "dataFooter": {
       "itemsPerPageText": "每页条目",
-      "pageText": "第 {0} 页，共 {1} 页",
+      "pageText": "第 {0}-{1} 条，共 {2} 条",
       "itemsPerPageAll": "全部",
       "firstPage": "首页",
       "prevPage": "上一页",

--- a/app/test/components/DataFooterPageText.spec.ts
+++ b/app/test/components/DataFooterPageText.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createVuetify } from 'vuetify';
+import * as components from 'vuetify/components';
+import * as directives from 'vuetify/directives';
+import { readFileSync } from 'node:fs';
+
+global.ResizeObserver = require('resize-observer-polyfill');
+
+// 用 fs 读取原始 JSON：直接 import 会被 @nuxtjs/i18n 插件预编译成 AST，拿不到字符串
+const loadLocale = (name: string) =>
+    JSON.parse(readFileSync(`${process.cwd()}/i18n/locales/${name}.json`, 'utf-8'));
+
+// issue #791：dataFooter.pageText 的占位符是 {0}=起始条目、{1}=结束条目、{2}=总条数，
+// 误写成"第 {0} 页，共 {1} 页"会把条目序号当成页码展示
+const items = Array.from({ length: 12 }, (_, i) => ({ name: `book-${i + 1}` }));
+
+function mountTable(localeName: string) {
+    const vuetify = createVuetify({
+        components,
+        directives,
+        locale: { locale: localeName, messages: { [localeName]: loadLocale(localeName).$vuetify } },
+    });
+    return mount(components.VDataTableServer, {
+        global: { plugins: [vuetify] },
+        props: {
+            headers: [{ title: 'Name', key: 'name' }],
+            items,
+            itemsLength: 12,
+            itemsPerPage: 100,
+        },
+    });
+}
+
+describe('dataFooter pageText', () => {
+    it('zh-CN 页脚显示条目范围与总条数', () => {
+        const wrapper = mountTable('zh-CN');
+        expect(wrapper.text()).toContain('第 1-12 条，共 12 条');
+        expect(wrapper.text()).not.toContain('共 12 页');
+    });
+
+    it('en-US footer shows item range and total count', () => {
+        const wrapper = mountTable('en-US');
+        expect(wrapper.text()).toContain('1-12 of 12');
+    });
+});

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -546,6 +546,19 @@ class TestBook(TestWithUserLogin):
                 rsp = self.fetch("/read/%s" % bid, follow_redirects=False)
                 self.assertEqual(rsp.code, 302 if bid == BID_PDF or bid == BID_TXT else 200)
 
+    def test_read_waits_for_conversion(self):
+        with mock.patch("webserver.services.convert.ConvertService.convert_and_save", return_value="Yo"):
+            # 非EPUB书籍：转换尚未完成，页面应包含轮询等待逻辑，不能直接初始化阅读器
+            for bid in [BID_MOBI, BID_AZW3]:
+                rsp = self.fetch("/read/%s" % bid)
+                self.assertEqual(rsp.code, 200)
+                self.assertIn("waitReady", rsp.body.decode("utf-8"))
+
+            # EPUB书籍：已就绪，直接初始化阅读器，无需轮询
+            rsp = self.fetch("/read/%s" % BID_EPUB)
+            self.assertEqual(rsp.code, 200)
+            self.assertNotIn("waitReady", rsp.body.decode("utf-8"))
+
     def test_edit(self):
         body = {
             "id": 5,

--- a/webserver/resources/book/creader.html
+++ b/webserver/resources/book/creader.html
@@ -17,16 +17,82 @@
   <script src="js/epub-v0.3.88.js"></script>
   <script  type="module">
     import { Reader } from "./candle-reader.es.js?v=v1.0.2"
-    new Reader('#app', {
-      debug: false,
-      server: "{{CANDLE_READER_SERVER}}",
-      themes_css: "{{RES}}/static/candle-reader/css/themes.css?v=v1.0.2",
-      book_url: "{{RES}}{{epub_dir}}/",
-      display: "",
-    })
+
+    function startReader() {
+      document.getElementById('converting').style.display = 'none'
+      new Reader('#app', {
+        debug: false,
+        server: "{{CANDLE_READER_SERVER}}",
+        themes_css: "{{RES}}/static/candle-reader/css/themes.css?v=v1.0.2",
+        book_url: "{{RES}}{{epub_dir}}/",
+        display: "",
+      })
+    }
+
+    {% if is_ready %}
+    startReader()
+    {% else %}
+    // 本书无EPUB格式，服务器正在后台转换；轮询等待EPUB就绪后再初始化阅读器，
+    // 避免阅读器在转换完成前请求书籍文件而报"加载超时"
+    document.getElementById('converting').style.display = 'flex'
+    let retries = 180
+    function waitReady() {
+      fetch("{{RES}}{{epub_dir}}/META-INF/container.xml?t=" + Date.now())
+        .then(function(rsp) {
+          if (rsp.ok) {
+            startReader()
+            return
+          }
+          retry()
+        })
+        .catch(retry)
+    }
+    function retry() {
+      retries -= 1
+      if (retries <= 0) {
+        document.getElementById('converting-msg').textContent = "转换超时，请刷新页面重试，或联系管理员查看转换日志"
+        return
+      }
+      setTimeout(waitReady, 2000)
+    }
+    waitReady()
+    {% endif %}
   </script>
+  <style>
+    #converting {
+      display: none;
+      position: fixed;
+      inset: 0;
+      z-index: 9999;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      background: #fafafa;
+      color: #333;
+      font-family: Roboto, sans-serif;
+      text-align: center;
+      padding: 0 24px;
+    }
+    #converting .spinner {
+      width: 40px;
+      height: 40px;
+      margin-bottom: 24px;
+      border: 4px solid #ddd;
+      border-top-color: #1976d2;
+      border-radius: 50%;
+      animation: converting-spin 1s linear infinite;
+    }
+    @keyframes converting-spin {
+      to { transform: rotate(360deg); }
+    }
+  </style>
 </head>
 <body>
   <div id="app"></div>
+  <div id="converting">
+    <div class="spinner"></div>
+    <h3>{{ book.title }}</h3>
+    <p id="converting-msg">首次在线阅读，服务器正在将本书转换为 EPUB 格式，<br>预计需要 1~2 分钟，请耐心等待，转换完成后将自动打开。</p>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
Fixes #791

## 问题一：mobi/azw3 首次在线阅读弹出"加载超时"

首次打开非 EPUB 书籍时，后端通过 `ConvertService` 异步转换 EPUB，但 `creader.html` 忽略了 `is_ready` 标记，立即初始化 Candle Reader 并请求 `/get/extract/<id>/` 资源。转换完成前该接口返回 404，阅读器超时后弹出"加载超时"错误；等转换完成后刷新又能正常阅读——与 issue 描述完全一致。

**修复**：`is_ready` 为 false 时先展示"正在转换为 EPUB"提示页（带转圈动画），每 2 秒轮询 `META-INF/container.xml` 直到 EPUB 就绪后再初始化阅读器（与旧版 readium.html 的等待逻辑一致），超时（约 6 分钟）则提示刷新重试。

## 问题二：导入页页脚显示"第 1 页，共 12 页"（数字实为条目序号）

Vuetify `dataFooter.pageText` 的占位符语义是 `{0}`=当前页起始条目、`{1}`=结束条目、`{2}`=总条数，而语言包里误写成了 `"第 {0} 页，共 {1} 页"`，于是条目序号被当成了页码展示。

**修复**：zh-CN 改为 `"第 {0}-{1} 条，共 {2} 条"`，en-US 改为 `"{0}-{1} of {2}"`。

## 测试

- `tests/test_main.py::TestBook::test_read_waits_for_conversion`：mobi/azw3 阅读页包含轮询等待逻辑，epub 阅读页直接初始化（Docker 内全量 270 passed, 1 skipped）
- `app/test/components/DataFooterPageText.spec.ts`：挂载 `v-data-table-server` 验证两种语言页脚渲染为条目范围+总条数（注：测试中用 fs 读取语言包原始 JSON，因为直接 import 会被 @nuxtjs/i18n 预编译成 AST）
- `make lint-py`（ruff）通过；`BookCards.nuxt.spec.ts` 中 `$t is not a function` 的失败在 master 上即存在，与本 PR 无关

🤖 Generated with [Claude Code](https://claude.com/claude-code)