### PR TITLE
fix: 并发请求下偶发 "Object is already attached to session" 报错

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -307,6 +307,54 @@ class TestReadingState(unittest.TestCase):
         self.assertEqual(s.download, 0)
 
 
+class TestSaveAcrossScopedSessionRemove(unittest.TestCase):
+    """issue #782：并发请求下 scoped session 被 remove 后 save() 报 already attached"""
+
+    def setUp(self):
+        from social_sqlalchemy.storage import SQLAlchemyMixin
+        from sqlalchemy import create_engine
+        from sqlalchemy.orm import scoped_session, sessionmaker
+
+        self.engine = create_engine("sqlite://")
+        models.Base.metadata.create_all(self.engine)
+        self.ScopedSession = scoped_session(sessionmaker(bind=self.engine))
+        # 保存并在 tearDown 中恢复全局绑定，避免影响其它用例
+        self._old_bindings = [
+            (cls, name, vars(cls).get(name))
+            for cls, name in [
+                (models.Base, "_session"),
+                (SQLAlchemyMixin, "_session"),
+                (SQLAlchemyMixin, "_save_instance"),
+            ]
+        ]
+        models.bind_session(self.ScopedSession)
+
+    def tearDown(self):
+        self.ScopedSession.remove()
+        for cls, name, old in self._old_bindings:
+            if old is None:
+                delattr(cls, name)
+            else:
+                setattr(cls, name, old)
+
+    def test_save_after_scoped_session_removed(self):
+        seed = self.ScopedSession()
+        seed.add(models.Message(1, "success", "hello"))
+        seed.commit()
+
+        # 请求 B 在 initialize 时捕获了注册表中的当前 session
+        stale = self.ScopedSession()
+        # 请求 A 结束，on_finish 调用 remove()，该 session 被从注册表摘除
+        self.ScopedSession.remove()
+        # 请求 B 继续处理：用持有的旧 session 查询并保存，不应抛 InvalidRequestError
+        msg = stale.query(models.Message).first()
+        msg.unread = False
+        msg.save()
+
+        check = self.ScopedSession().query(models.Message).first()
+        self.assertFalse(check.unread)
+
+
 if __name__ == "__main__":
     logging.basicConfig(
         level=logging.DEBUG,

--- a/webserver/models.py
+++ b/webserver/models.py
@@ -12,7 +12,7 @@ import bcrypt
 from social_sqlalchemy.storage import JSONType, SQLAlchemyMixin
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String
 from sqlalchemy.ext.mutable import Mutable
-from sqlalchemy.orm import declarative_base, relationship
+from sqlalchemy.orm import declarative_base, object_session, relationship
 
 from webserver.constants import BOOK_TYPE_EBOOK
 from webserver.i18n import _
@@ -43,8 +43,20 @@ def bind_session(session):
     def _session(self):
         return session
 
+    def _save_instance(cls, instance):
+        # Tornado 同一线程内多个并发请求共享 scoped session：请求 A 结束时 on_finish
+        # 调用 remove()，会把请求 B 在 initialize 中已捕获的 session 从注册表摘除。
+        # 此后 B 查询出的对象仍属于旧 session，若再用注册表里的新 session add，
+        # 会抛 "Object is already attached to session"（issue #782）。
+        # 因此优先用对象自身所属的 session 保存。
+        db = object_session(instance) or session
+        db.add(instance)
+        db.commit()
+        return instance
+
     Base._session = classmethod(_session)
     SQLAlchemyMixin._session = classmethod(_session)
+    SQLAlchemyMixin._save_instance = classmethod(_save_instance)
     logging.info("Bind modles._session()")
 
 


### PR DESCRIPTION
Fixes #782

## 根因

Tornado 在同一线程内处理并发请求，而 SQLAlchemy 的 `scoped_session` 是线程级注册表，两者相遇产生竞态：

1. 请求 B 到达，Tornado 构造 handler 时运行 `initialize()`，`self.session = ScopedSession()` 捕获了注册表中的当前 session（与还在处理中的请求 A 是**同一个**），随后 B 的执行被调度到事件循环；
2. 请求 A 先完成，`on_finish()` 调用 `ScopedSession.remove()`，把这个 session 从注册表摘除并关闭；
3. 请求 B 开始执行业务逻辑，用持有的旧 session 查询出 `Message` 对象（对象 attach 到旧 session）；
4. `msg.save()` 走 social_sqlalchemy 的 `_save_instance` → `cls._session().add()`，此时注册表已为空，会新建一个 session，向新 session add 一个已 attach 到旧 session 的对象 → `InvalidRequestError: Object is already attached to session '337' (this is '338')`。

issue 日志完全吻合：三个 `/api/user/messages` POST 几乎同时到达（前端批量标记已读），报错分别是 `this is '338'`、`'339'`、`'340'`——每个请求的 on_finish 都 remove 掉了上一个新建的注册表 session。

同类写法（`user.save()`、`item.save()` 等先查询后 `.save()`）遍布各 handler，均存在同样的竞态，故在 `models.py` 的绑定层统一修复。

## 修复

`bind_session()` 中同时覆写 `SQLAlchemyMixin._save_instance`：通过 `object_session(instance)` 优先使用对象自身所属的 session 执行 add + commit，对象未绑定 session 时回退到原有的注册表 session。social-auth 自身的模型不受影响（其对象的 object_session 本就等于注册表 session）。

## 测试

- 新增 `tests/test_models.py::TestSaveAcrossScopedSessionRemove`，按上述时序精确复现竞态：修复前抛出与线上完全一致的 `InvalidRequestError: Object ... is already attached to session '1' (this is '2')`，修复后通过且数据正确落库（红/绿均已验证）。
- Docker 内全量测试 271 passed, 1 skipped；`make lint-py`（ruff check + format）通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)