### PR TITLE
fix(app): 书源检测进行中保留按钮文字，仅以内联转圈提示

### DIFF
--- a/app/pages/admin/booksources.vue
+++ b/app/pages/admin/booksources.vue
@@ -66,11 +66,20 @@
             <v-btn
                 variant="outlined"
                 color="warning"
-                :loading="checkingSources"
                 :disabled="checkingSources"
                 @click="checkSourceValidity"
             >
-                <v-icon start>
+                <v-progress-circular
+                    v-if="checkingSources"
+                    indeterminate
+                    size="16"
+                    width="2"
+                    class="mr-2"
+                />
+                <v-icon
+                    v-else
+                    start
+                >
                     mdi-shield-check
                 </v-icon>{{ $t('booksource.checkValidity') }}
             </v-btn>

--- a/app/test/e2e/booksources.spec.ts
+++ b/app/test/e2e/booksources.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Admin Book Sources', () => {
+    test.beforeEach(async ({ request }) => {
+        await request.post('http://127.0.0.1:8080/_test/reset', {
+            data: { installed: true }
+        });
+    });
+
+    test('check validity button keeps text visible while checking', async ({ page }) => {
+        const listPromise = page.waitForResponse(resp => resp.url().includes('/api/admin/booksource/list'));
+        await page.goto('/admin/booksources');
+        await listPromise;
+        await expect(page.locator('.loading-page')).toBeHidden();
+
+        const checkBtn = page.getByRole('button', { name: '检测书源有效性' });
+        await expect(checkBtn).toBeVisible();
+
+        page.on('dialog', dialog => dialog.accept());
+        await checkBtn.click();
+
+        // 检测进行中：按钮禁用、显示转圈，文字保持可见
+        await expect(checkBtn).toBeDisabled();
+        await expect(checkBtn.locator('.v-progress-circular')).toBeVisible();
+        await expect(checkBtn).toContainText('检测书源有效性');
+        // 回归保护：v-btn 的 :loading 会把 .v-btn__content 透明度置 0 导致文字隐藏
+        const opacity = await checkBtn
+            .locator('.v-btn__content')
+            .evaluate(el => getComputedStyle(el).opacity);
+        expect(parseFloat(opacity)).toBe(1);
+
+        // 检测结束（首次轮询后）：按钮恢复可用，转圈消失
+        await expect(checkBtn).toBeEnabled({ timeout: 10000 });
+        await expect(checkBtn.locator('.v-progress-circular')).toHaveCount(0);
+    });
+});

--- a/app/test/mock-server.js
+++ b/app/test/mock-server.js
@@ -14,6 +14,8 @@ let isInstalled = true;
 let users = [];
 let saveStarted = false;
 let saveStatusPolls = 0;
+let booksourceCheckRunning = false;
+let booksourceCheckPolls = 0;
 
 const app = createApp();
 const router = createRouter();
@@ -39,6 +41,8 @@ router.post('/_test/reset', eventHandler(async (event) => {
   users = [];
   saveStarted = false;
   saveStatusPolls = 0;
+  booksourceCheckRunning = false;
+  booksourceCheckPolls = 0;
   return { status: 'ok' };
 }));
 
@@ -274,6 +278,40 @@ router.get('/api/book/:id', eventHandler((event) => {
   }
     
   return { err: 'ok', msg: 'mock action' };
+}));
+
+// Admin book sources
+router.get('/api/admin/booksource/list', eventHandler(() => ({
+  err: 'ok',
+  count: 1,
+  items: [
+    {
+      id: 1,
+      name: '测试书源',
+      url: 'http://x.com',
+      group: '测试',
+      enabled: true,
+      check_status: 'ok',
+      check_message: '',
+      check_tags: [],
+    },
+  ],
+  check_task: { running: booksourceCheckRunning },
+})));
+
+router.post('/api/admin/booksource/check', eventHandler(() => {
+  booksourceCheckRunning = true;
+  booksourceCheckPolls = 0;
+  return { err: 'ok', running: true, checking: 1 };
+}));
+
+router.get('/api/admin/booksource/check/status', eventHandler(() => {
+  // 首次轮询后结束检测，便于用例观察"检测中→完成"的状态切换
+  if (booksourceCheckRunning) {
+    booksourceCheckPolls += 1;
+    if (booksourceCheckPolls >= 1) booksourceCheckRunning = false;
+  }
+  return { err: 'ok', running: booksourceCheckRunning };
 }));
 
 // Network library (book sources)


### PR DESCRIPTION
## 问题

书源管理页点击「检测书源有效性」后，`v-btn` 的 `:loading` 把按钮内容透明度置 0，检测期间按钮上只剩转圈，看不到文字。

## 修复

去掉 `:loading`，检测中把盾形图标替换为 16px 内联 `v-progress-circular`，文字始终可见；按钮保持 `:disabled` 防止重复点击。

## 测试

- `app/test/mock-server.js` 新增 `/api/admin/booksource/{list,check,check/status}` 三个带状态的 mock 接口（发起检测后首次轮询返回检测中、之后返回完成）。
- 新增 `app/test/e2e/booksources.spec.ts`：点击检测后断言按钮禁用、转圈出现、文字可见且 `.v-btn__content` 透明度为 1（旧 `:loading` 写法该断言会失败，已做反向验证），检测结束后按钮恢复、转圈消失。
- Playwright 本地运行通过；eslint 无新增问题。

🤖 Generated with [Claude Code](https://claude.com/claude-code)