### PR TITLE
feat: add system log viewer for admins

### DIFF
--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -485,6 +485,7 @@ const items = computed(() => {
                 { icon: 'mdi-library-shelves', href: '/admin/books', text: $t('navigation.books') },
                 { icon: 'mdi-import', href: '/admin/imports', text: $t('navigation.import') },
                 { icon: 'mdi-book-cog', href: '/admin/booksources', text: $t('navigation.bookSources') },
+                { icon: 'mdi-text-box-outline', href: '/admin/logs', text: $t('navigation.systemLogs') },
             ],
         },
     ];

--- a/app/i18n/locales/en-US.json
+++ b/app/i18n/locales/en-US.json
@@ -196,7 +196,8 @@
     "scopedBooks": "Private Books",
     "localLibrary": "Local Library",
     "networkLibrary": "Network Library",
-    "bookSources": "Book Sources"
+    "bookSources": "Book Sources",
+    "systemLogs": "System Logs"
   },
   "network": {
     "title": "Network Library",
@@ -830,6 +831,21 @@
       "host": "Enter host address",
       "path": "Enter path",
       "port": "Enter port"
+    },
+    "logs": {
+      "title": "System Logs",
+      "button": {
+        "refresh": "Refresh",
+        "download": "Download Logs"
+      },
+      "label": {
+        "lines": "Show last N lines",
+        "file": "Log file"
+      },
+      "message": {
+        "noLogs": "No log content available",
+        "loadError": "Failed to load logs"
+      }
     }
   },
   "install": {

--- a/app/i18n/locales/zh-CN.json
+++ b/app/i18n/locales/zh-CN.json
@@ -201,7 +201,8 @@
     "scopedBooks": "私有书籍",
     "localLibrary": "本地书库",
     "networkLibrary": "网络书库",
-    "bookSources": "书源管理"
+    "bookSources": "书源管理",
+    "systemLogs": "系统日志"
   },
   "network": {
     "title": "网络书库",
@@ -850,6 +851,21 @@
       },
       "actions": {},
       "permissions": {}
+    },
+    "logs": {
+      "title": "系统日志",
+      "button": {
+        "refresh": "刷新",
+        "download": "下载日志"
+      },
+      "label": {
+        "lines": "显示最近行数",
+        "file": "日志文件"
+      },
+      "message": {
+        "noLogs": "暂无日志内容",
+        "loadError": "加载日志失败"
+      }
     }
   },
   "install": {

--- a/app/pages/admin/logs.vue
+++ b/app/pages/admin/logs.vue
@@ -1,0 +1,155 @@
+
+<template>
+    <v-card>
+        <v-card-title class="pl-4">
+            {{ t('admin.logs.title') }}
+        </v-card-title>
+        <v-card-actions class="px-4">
+            <v-select
+                v-model="lineCount"
+                :items="lineOptions"
+                :label="t('admin.logs.label.lines')"
+                density="compact"
+                hide-details
+                style="max-width: 160px"
+                class="mr-2"
+            />
+            <v-spacer />
+            <v-btn
+                color="primary"
+                class="mr-2"
+                :loading="loading"
+                @click="loadLogs"
+            >
+                <v-icon start>
+                    mdi-refresh
+                </v-icon>
+                {{ t('admin.logs.button.refresh') }}
+            </v-btn>
+            <v-btn
+                color="secondary"
+                :href="downloadUrl"
+            >
+                <v-icon start>
+                    mdi-download
+                </v-icon>
+                {{ t('admin.logs.button.download') }}
+            </v-btn>
+        </v-card-actions>
+
+        <v-card-text class="pa-2">
+            <div
+                v-if="errorMsg"
+                class="text-error pa-2"
+            >
+                {{ errorMsg }}
+            </div>
+            <div
+                v-else-if="!loading && lines.length === 0"
+                class="text-medium-emphasis pa-2"
+            >
+                {{ t('admin.logs.message.noLogs') }}
+            </div>
+            <div
+                v-else
+                ref="logContainer"
+                class="log-container"
+            >
+                <div
+                    v-for="(line, idx) in lines"
+                    :key="idx"
+                    :class="['log-line', levelClass(line)]"
+                >{{ line || ' ' }}</div>
+            </div>
+        </v-card-text>
+    </v-card>
+</template>
+
+<script setup>
+import { ref, onMounted, computed, nextTick } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useMainStore } from '@/stores/main';
+
+const store = useMainStore();
+const { $backend } = useNuxtApp();
+const { t } = useI18n();
+
+store.setNavbar(true);
+
+const lines = ref([]);
+const loading = ref(false);
+const errorMsg = ref('');
+const lineCount = ref(500);
+const logContainer = ref(null);
+
+const lineOptions = [100, 200, 500, 1000, 2000];
+
+const downloadUrl = computed(() => '/api/admin/log/download');
+
+const levelClass = (line) => {
+    if (/\[E\]|\[ERROR\]|ERROR/.test(line)) return 'log-error';
+    if (/\[W\]|\[WARNING\]|WARNING/.test(line)) return 'log-warning';
+    if (/\[D\]|\[DEBUG\]|DEBUG/.test(line)) return 'log-debug';
+    return 'log-info';
+};
+
+const loadLogs = async () => {
+    loading.value = true;
+    errorMsg.value = '';
+    try {
+        const rsp = await $backend(`/admin/log?lines=${lineCount.value}`);
+        if (rsp.err !== 'ok') {
+            errorMsg.value = rsp.msg || t('admin.logs.message.loadError');
+            lines.value = [];
+        } else {
+            lines.value = rsp.lines || [];
+            await nextTick();
+            if (logContainer.value) {
+                logContainer.value.scrollTop = logContainer.value.scrollHeight;
+            }
+        }
+    } catch {
+        errorMsg.value = t('admin.logs.message.loadError');
+    } finally {
+        loading.value = false;
+    }
+};
+
+onMounted(loadLogs);
+</script>
+
+<style scoped>
+.log-container {
+    font-family: 'Courier New', Courier, monospace;
+    font-size: 12px;
+    background: #1e1e1e;
+    color: #d4d4d4;
+    border-radius: 4px;
+    padding: 8px;
+    max-height: 70vh;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    word-break: break-all;
+}
+
+.log-line {
+    line-height: 1.5;
+    padding: 1px 0;
+}
+
+.log-error {
+    color: #f48771;
+}
+
+.log-warning {
+    color: #cca700;
+}
+
+.log-debug {
+    color: #9cdcfe;
+}
+
+.log-info {
+    color: #b5cea8;
+}
+</style>

--- a/app/pages/admin/logs.vue
+++ b/app/pages/admin/logs.vue
@@ -56,17 +56,17 @@
                 class="log-container"
             >
                 <div
-                    v-for="(line, idx) in lines"
+                    v-for="(entry, idx) in lines"
                     :key="idx"
-                    :class="['log-line', levelClass(line)]"
-                >{{ line || ' ' }}</div>
+                    :class="['log-line', entry.cls]"
+                >{{ entry.text }}</div>
             </div>
         </v-card-text>
     </v-card>
 </template>
 
 <script setup>
-import { ref, onMounted, computed, nextTick } from 'vue';
+import { ref, onMounted, nextTick } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useMainStore } from '@/stores/main';
 
@@ -84,7 +84,7 @@ const logContainer = ref(null);
 
 const lineOptions = [100, 200, 500, 1000, 2000];
 
-const downloadUrl = computed(() => '/api/admin/log/download');
+const downloadUrl = '/api/admin/log/download';
 
 const levelClass = (line) => {
     if (/\[E\]|\[ERROR\]|ERROR/.test(line)) return 'log-error';
@@ -102,7 +102,7 @@ const loadLogs = async () => {
             errorMsg.value = rsp.msg || t('admin.logs.message.loadError');
             lines.value = [];
         } else {
-            lines.value = rsp.lines || [];
+            lines.value = (rsp.lines || []).map(line => ({ text: line || ' ', cls: levelClass(line) }));
             await nextTick();
             if (logContainer.value) {
                 logContainer.value.scrollTop = logContainer.value.scrollHeight;
@@ -110,6 +110,7 @@ const loadLogs = async () => {
         }
     } catch {
         errorMsg.value = t('admin.logs.message.loadError');
+        lines.value = [];
     } finally {
         loading.value = false;
     }

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -90,3 +90,58 @@ class TestAdminSettingsSecurity(TestWithAdminUser):
             exec(compile(code, path, "exec"), namespace)
 
         self.assertEqual(namespace["settings"][key], "value")
+
+
+class TestAdminSystemLog(TestWithAdminUser):
+    def test_log_returns_ok_when_file_missing(self):
+        """日志文件不存在时，接口应返回 ok 且 lines 为空列表"""
+        with mock.patch("webserver.handlers.admin._get_log_file", return_value="/nonexistent/talebook.log"):
+            d = self.json("/api/admin/log")
+        self.assertEqual(d["err"], "ok")
+        self.assertEqual(d["lines"], [])
+
+    def test_log_returns_lines_from_file(self):
+        """日志文件存在时，接口应返回对应行数"""
+        log_content = "\n".join(["line %d" % i for i in range(10)])
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".log", delete=False) as f:
+            f.write(log_content)
+            log_path = f.name
+        try:
+            with mock.patch("webserver.handlers.admin._get_log_file", return_value=log_path):
+                d = self.json("/api/admin/log?lines=5")
+            self.assertEqual(d["err"], "ok")
+            self.assertEqual(len(d["lines"]), 5)
+            self.assertEqual(d["total"], 10)
+        finally:
+            os.unlink(log_path)
+
+    def test_log_download_returns_file(self):
+        """下载接口应以附件形式返回日志文件内容"""
+        log_content = "test log line\n"
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".log", delete=False) as f:
+            f.write(log_content)
+            log_path = f.name
+        try:
+            with mock.patch("webserver.handlers.admin._get_log_file", return_value=log_path):
+                rsp = self.fetch("/api/admin/log/download")
+            self.assertEqual(rsp.code, 200)
+            self.assertIn(b"test log line", rsp.body)
+            self.assertIn("attachment", rsp.headers.get("Content-Disposition", ""))
+        finally:
+            os.unlink(log_path)
+
+    def test_log_permission_denied_for_non_admin(self):
+        """普通用户不能访问系统日志"""
+        from webserver import models
+
+        session = get_db()
+        user = session.query(models.Reader).filter(models.Reader.id == 1).first()
+        original_admin = user.admin
+        user.admin = False
+        session.commit()
+        try:
+            d = self.json("/api/admin/log")
+            self.assertNotEqual(d["err"], "ok")
+        finally:
+            user.admin = original_admin
+            session.commit()

--- a/webserver/handlers/admin.py
+++ b/webserver/handlers/admin.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
 
+import collections
 import datetime
 import hashlib
 import logging
+import os
 import re
 import ssl
 import subprocess
@@ -12,6 +14,7 @@ import traceback
 import uuid
 
 import tornado
+from tornado.options import options as tornado_options
 
 from webserver import loader, utils
 from webserver.base.trash_manager import TrashManager
@@ -1067,8 +1070,6 @@ DEFAULT_LOG_LINES = 500
 
 
 def _get_log_file():
-    from tornado.options import options as tornado_options
-
     return getattr(tornado_options, "log_file_prefix", None) or "/data/log/talebook.log"
 
 
@@ -1077,21 +1078,28 @@ class AdminSystemLog(BaseHandler):
     @is_admin
     def get(self):
         log_file = _get_log_file()
-        lines_count = int(self.get_argument("lines", DEFAULT_LOG_LINES))
-        lines_count = min(lines_count, MAX_LOG_LINES)
+        try:
+            lines_count = int(self.get_argument("lines", DEFAULT_LOG_LINES))
+        except (ValueError, TypeError):
+            lines_count = DEFAULT_LOG_LINES
+        lines_count = max(1, min(lines_count, MAX_LOG_LINES))
 
         if not os.path.exists(log_file):
             return {"err": "ok", "lines": [], "total": 0, "file": log_file}
 
+        total = 0
+        tail_deque = collections.deque(maxlen=lines_count)
         with open(log_file, "r", encoding="utf-8", errors="replace") as f:
-            all_lines = f.readlines()
+            for line in f:
+                total += 1
+                tail_deque.append(line)
 
-        tail = [line.rstrip("\n") for line in all_lines[-lines_count:]]
-        return {"err": "ok", "lines": tail, "total": len(all_lines), "file": log_file}
+        tail = [line.rstrip("\n") for line in tail_deque]
+        return {"err": "ok", "lines": tail, "total": total, "file": log_file}
 
 
 class AdminSystemLogDownload(BaseHandler):
-    def get(self):
+    async def get(self):
         if not self.current_user:
             self.set_status(403)
             self.finish({"err": "user.need_login", "msg": _("请先登录")})
@@ -1108,10 +1116,18 @@ class AdminSystemLogDownload(BaseHandler):
             self.finish()
             return
 
+        file_size = os.path.getsize(log_file)
         self.set_header("Content-Type", "text/plain; charset=utf-8")
         self.set_header("Content-Disposition", 'attachment; filename="talebook.log"')
+        self.set_header("Content-Length", str(file_size))
+        chunk_size = 64 * 1024
         with open(log_file, "rb") as f:
-            self.write(f.read())
+            while True:
+                chunk = f.read(chunk_size)
+                if not chunk:
+                    break
+                self.write(chunk)
+                await self.flush()
         self.finish()
 
 

--- a/webserver/handlers/admin.py
+++ b/webserver/handlers/admin.py
@@ -1062,6 +1062,59 @@ class AdminUpdateCheck(BaseHandler):
         return {"err": "ok", "status": status}
 
 
+MAX_LOG_LINES = 2000
+DEFAULT_LOG_LINES = 500
+
+
+def _get_log_file():
+    from tornado.options import options as tornado_options
+
+    return getattr(tornado_options, "log_file_prefix", None) or "/data/log/talebook.log"
+
+
+class AdminSystemLog(BaseHandler):
+    @js
+    @is_admin
+    def get(self):
+        log_file = _get_log_file()
+        lines_count = int(self.get_argument("lines", DEFAULT_LOG_LINES))
+        lines_count = min(lines_count, MAX_LOG_LINES)
+
+        if not os.path.exists(log_file):
+            return {"err": "ok", "lines": [], "total": 0, "file": log_file}
+
+        with open(log_file, "r", encoding="utf-8", errors="replace") as f:
+            all_lines = f.readlines()
+
+        tail = [line.rstrip("\n") for line in all_lines[-lines_count:]]
+        return {"err": "ok", "lines": tail, "total": len(all_lines), "file": log_file}
+
+
+class AdminSystemLogDownload(BaseHandler):
+    def get(self):
+        if not self.current_user:
+            self.set_status(403)
+            self.finish({"err": "user.need_login", "msg": _("请先登录")})
+            return
+        if not self.admin_user:
+            self.set_status(403)
+            self.finish({"err": "permission.not_admin", "msg": _("当前用户非管理员")})
+            return
+
+        log_file = _get_log_file()
+
+        if not os.path.exists(log_file):
+            self.set_status(404)
+            self.finish()
+            return
+
+        self.set_header("Content-Type", "text/plain; charset=utf-8")
+        self.set_header("Content-Disposition", 'attachment; filename="talebook.log"')
+        with open(log_file, "rb") as f:
+            self.write(f.read())
+        self.finish()
+
+
 def routes():
     return [
         (r"/api/admin/ssl", AdminSSL),
@@ -1082,4 +1135,6 @@ def routes():
         (r"/api/admin/opds/sources", AdminOpdsSources),
         (r"/api/admin/trash/size", AdminTrashSize),
         (r"/api/admin/trash/clear", AdminTrashClear),
+        (r"/api/admin/log", AdminSystemLog),
+        (r"/api/admin/log/download", AdminSystemLogDownload),
     ]


### PR DESCRIPTION
Closes #778

## Summary

- Backend: admin-only API `GET /api/admin/log` returns the tail of the log file as JSON; `GET /api/admin/log/download` serves the full log as a text attachment
- Frontend: new `/admin/logs` page with color-coded log levels, configurable line count, and download button
- Navigation: System Logs entry added to admin sidebar
- Tests: `TestAdminSystemLog` covers missing file, line count, download, and permission check

Generated with [Claude Code](https://claude.ai/code)