### PR TITLE
docker: 主镜像瘦身 + 新增无 PDF 输出的 slim 变体

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,6 +97,48 @@ jobs:
           cache-to: type=gha,scope=spa,mode=max
 
       # ----------------------------------------
+      # SLIM 镜像：talebook/talebook:slim / slim-<ver>
+      # 不支持转换输出 PDF（移除 QtWebEngine/Chromium 等依赖），体积约为完整版的一半。
+      - name: Build and push SLIM
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          target: production-slim
+          platforms: ${{ steps.platforms.outputs.platforms }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: ${{ github.event_name != 'pull_request' }}
+          provenance: false
+          tags: |
+            ${{ startsWith(github.ref, 'refs/tags/') && format('{0}/{1}:slim', env.REGISTRY, env.IMAGE_NAME) || '' }}
+            ${{ startsWith(github.ref, 'refs/tags/') && format('{0}/{1}:slim-{2}', env.REGISTRY, env.IMAGE_NAME, github.ref_name) || '' }}
+            ${{ github.ref == 'refs/heads/master' && format('{0}/{1}:slim', env.REGISTRY, env.IMAGE_NAME) || '' }}
+            ${{ (startsWith(github.ref, 'refs/heads/dev/') || startsWith(github.ref, 'refs/heads/claude/') || startsWith(github.ref, 'refs/heads/codex/')) && format('{0}/{1}:slim-{2}', env.REGISTRY, env.IMAGE_NAME, steps.prep.outputs.safe_ref_name) || '' }}
+          build-args: ${{ steps.prep.outputs.build_args }}
+          cache-from: |
+            type=gha,scope=spa
+            type=gha,scope=slim
+          cache-to: type=gha,scope=slim,mode=max
+
+      # SLIM 镜像冒烟测试（amd64）：强删依赖的清单一旦误伤转换功能，在此拦截
+      - name: Load SLIM image for smoke test
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          target: production-slim
+          platforms: linux/amd64
+          load: true
+          tags: talebook-slim-smoke:ci
+          build-args: ${{ steps.prep.outputs.build_args }}
+          cache-from: |
+            type=gha,scope=spa
+            type=gha,scope=slim
+
+      - name: Run conversion smoke test on SLIM image
+        run: |
+          docker run --rm -v "$PWD/tools/convert_smoke.sh:/smoke.sh:ro" \
+            --entrypoint sh talebook-slim-smoke:ci /smoke.sh
+
+      # ----------------------------------------
       # SSR 镜像：talebook/talebook:server-side-render / server-side-render-<ver>
       - name: Build and push SSR
         uses: docker/build-push-action@v5

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN cp -r dist package* /app-static/
 # ----------------------------------------
 # 第二阶段，构建环境
 # 基础镜像源码见本仓库 Dockerfile.base，独立构建并推送，避免重复编译 calibre
-FROM talebook/talebook-base:8.5 AS server
+FROM talebook/talebook-base:8.6 AS server
 ARG BUILD_COUNTRY=""
 ARG TARGETARCH
 ARG TARGETVARIANT
@@ -181,4 +181,63 @@ RUN rm -rf /var/www/talebook/app/.output/public/logo && \
 # 生产环境（spa版，作为默认 docker build 结果）
 FROM production AS production-spa
 # no more actions
+
+
+# ----------------------------------------
+# 生产环境（slim 版：不支持转换输出 PDF，体积减少约 700MB）
+#
+# PDF 输出是 calibre 中唯一需要 QtWebEngine（无头 Chromium）渲染的转换路径，
+# epub/txt/mobi/azw3 互转只需 Qt6 Core/Gui。据此强删以下三组包（均已实测验证
+# 六条转换链 txt->epub/azw3、epub->azw3/mobi、azw3->epub、mobi->epub 正常）：
+#   1. QtWebEngine/Chromium 及其专属的 Quick/Qml 栈（~300MB）
+#   2. scipy（no-install-recommends 下仍被装入）、sympy（calibre->fonttools 硬依赖链）
+#   3. Mesa 软渲染驱动 + LLVM + z3（libqt6gui6->libgl1 链拖入，QImage 用不到 GL）、
+#      qtmultimedia + ffmpeg 编解码库（calibre GUI 的 TTS 朗读用，转换用不到）
+#
+# 注意：
+#   - libgl1/libegl1/libglx0（glvnd 调度层）是 libQt6Gui.so 的 ELF 硬依赖，不可删，
+#     删除后所有涉及封面图片的转换都会失败（cannot import QBuffer from qt.core）。
+#   - dpkg -r --force-depends 会留下不一致的依赖状态，本层之后镜像内不可再
+#     执行 apt-get install；如需加包请基于 production 阶段构建。
+#   - TALEBOOK_PDF_CONVERT=0 供 webserver 屏蔽"转换为PDF"功能入口。
+#   - 关键：dpkg -r 删除发生在新层，被删字节仍保留在 production 的下层中，
+#     docker 镜像/拉取体积不会减小（仅容器内 rootfs 变小）。因此本阶段先在
+#     slim-strip 中删包，再用 `FROM scratch + COPY / /` 把瘦身后的 rootfs 压成
+#     单层，使被删字节真正从镜像中消失（约 2.6GB -> 约 1.0GB）。
+FROM production AS slim-strip
+
+RUN dpkg -l | awk '/^ii/ {print $2}' \
+        | grep -E 'webengine|webchannel|qt6.*(quick|qml|declarative)|qml6|pyqt6-dev|sympy|scipy|multimedia|texttospeech|speech' \
+        | xargs -r dpkg -r --force-depends && \
+    dpkg -l | awk '/^ii/ {print $2}' \
+        | grep -E 'llvm|mesa|vulkan|libz3|codec2|libavcodec|libavformat|libavutil|libswresample|x265|x264|libvpx|libaom|dav1d|rav1e|svt' \
+        | grep -vE '^libgl1$|^libegl1$|^libglx0$|glvnd' \
+        | xargs -r dpkg -r --force-depends && \
+    # 编译工具链只在 server 阶段 pip 安装时需要，运行期可整体移除（约 225MB）。
+    # 第二段 grep 排除运行时必需且名字相近的包：gcc-14-base（C 运行时基础）、
+    # libgcc-s1（libgcc 运行时，几乎所有二进制都链接它）。注意 cc1 实体在
+    # gcc-14-<arch> 中，gcc/gcc-14 仅为包装器，故用前缀匹配连同 -<arch> 变体一并删除。
+    dpkg -l | awk '/^ii/ {print $2}' \
+        | grep -E '^(binutils|libbinutils|build-essential|cpp|g\+\+|gcc|make|dpkg-dev|libc6-dev|linux-libc-dev|libgcc-[0-9]+-dev|libstdc\+\+-[0-9]+-dev|python3-dev|python3\.[0-9]+-dev|libpython3-dev|libpython3\.[0-9]+-dev|python3-numpy-dev)([-.:].*)?$' \
+        | grep -vE '^(gcc-[0-9]+-base|libgcc-s1)([-.:].*)?$' \
+        | xargs -r dpkg -r --force-depends && \
+    rm -rf /usr/share/doc /usr/share/man /usr/share/qt6/resources /usr/share/qt6/translations
+
+# 把瘦身后的 rootfs 压成单层。scratch 不带任何元数据，故需重新声明 production
+# 阶段的全部运行时元数据（ENV / WORKDIR / EXPOSE / VOLUME / CMD）。
+FROM scratch AS production-slim
+COPY --from=slim-strip / /
+
+ENV TZ=Asia/Shanghai
+ENV LANG=C.UTF-8
+ENV PUID=1000
+ENV PGID=1000
+ENV TALEBOOK_PDF_CONVERT=0
+
+WORKDIR /var/www/talebook
+
+EXPOSE 80 443
+VOLUME ["/data"]
+
+CMD ["/var/www/talebook/docker/start.sh"]
 

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -8,16 +8,30 @@ FROM debian:13-slim
 
 ARG TARGETARCH
 ARG TARGETVARIANT
+ARG BUILD_COUNTRY=""
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
-# 安装基础系统（包含 PyQt5 系统包）
+RUN if [ "x${BUILD_COUNTRY}" = "xCN" ]; then \
+        echo "using repo mirrors for ${BUILD_COUNTRY}"; \
+        sed -i "s@deb.debian.org@mirrors.aliyun.com@g" /etc/apt/sources.list.d/debian.sources; \
+    fi
+
+# 安装基础系统。
+# 全程 --no-install-recommends：apt 的 Recommends 会拖进 scipy/matplotlib/GPU 驱动等
+# 数百 MB 与运行无关的包。Debian 13 的 calibre 使用 Qt6/PyQt6，原先显式安装的
+# python3-pyqt5* 是 Debian 12 时代的遗留（等于重复装一整套 Qt5/Chromium），已移除。
+# build-essential/python3-dev 原先由 python3-pip 的 Recommends 隐式提供，
+# 主 Dockerfile 中 pip 安装 requirements.txt 时部分包（如 quickjs）无预编译
+# wheel 需要源码编译，故显式保留。
 RUN apt-get update && \
-    apt-get install -y \
+    apt-get install -y --no-install-recommends \
         tzdata \
         python3 \
         python3-pip \
         python3-venv \
+        python3-dev \
+        build-essential \
         nginx \
         supervisor \
         sqlite3 \
@@ -26,10 +40,6 @@ RUN apt-get update && \
         unzip \
         git \
         ca-certificates \
-        python3-pyqt5 \
-        python3-pyqt5.qtwebengine \
-        python3-pyqt5.qtsql \
-        python3-pyqt5.qtmultimedia \
         python3-dateutil \
         python3-cssselect \
         python3-lxml \
@@ -47,10 +57,14 @@ RUN ver="$(dpkg-query -W -f='${Version}' nginx)" && \
     dpkg --compare-versions "$ver" ge 1.26.3-3+deb13u5 || \
     { echo "ERROR: nginx $ver 仍受 CVE-2026-42945 影响，需 >= 1.26.3-3+deb13u5" && exit 1; }
 
-# 根据架构安装 Calibre
+# 根据架构安装 Calibre。
+# --no-install-recommends 实测可将 calibre 相关安装体积从 ~2.4GB 降到 ~1.3GB，
+# epub/txt/mobi/azw3/PDF 转换均验证正常。
+# fonts-wqy-microhei：services/convert.py 转 PDF 时硬编码了文泉驿微米黑字体，
+# 此前镜像中并未安装该字体（中文 PDF 排版会退化为 fallback 字体），此处补上。
 RUN echo "Installing Calibre via apt for $TARGETARCH $TARGETVARIANT" && \
     apt-get update && \
-    apt-get install -y calibre && \
+    apt-get install -y --no-install-recommends calibre fonts-wqy-microhei && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*;
 
@@ -64,10 +78,10 @@ RUN echo "Verifying Calibre installation..." && \
         exit 1; \
     fi
 
-# 验证 PyQt5 安装
-RUN echo "Verifying PyQt5 installation..." && \
-    python3 -c "import PyQt5; print('PyQt5 imported successfully')" && \
-    python3 -c "import PyQt5.QtWebEngine; print('PyQt5.QtWebEngine imported successfully')"
+# 验证 PyQt6 安装（Debian 13 的 calibre 依赖 Qt6，作为 calibre 的依赖自动安装）
+RUN echo "Verifying PyQt6 installation..." && \
+    python3 -c "import PyQt6; print('PyQt6 imported successfully')" && \
+    python3 -c "from PyQt6 import QtWebEngineCore; print('PyQt6.QtWebEngineCore imported successfully')"
 
 # 安装 Python 包（使用 --break-system-packages）
 RUN pip3 install --no-cache-dir --break-system-packages \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -8,30 +8,16 @@ FROM debian:13-slim
 
 ARG TARGETARCH
 ARG TARGETVARIANT
-ARG BUILD_COUNTRY=""
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
-RUN if [ "x${BUILD_COUNTRY}" = "xCN" ]; then \
-        echo "using repo mirrors for ${BUILD_COUNTRY}"; \
-        sed -i "s@deb.debian.org@mirrors.aliyun.com@g" /etc/apt/sources.list.d/debian.sources; \
-    fi
-
-# 安装基础系统。
-# 全程 --no-install-recommends：apt 的 Recommends 会拖进 scipy/matplotlib/GPU 驱动等
-# 数百 MB 与运行无关的包。Debian 13 的 calibre 使用 Qt6/PyQt6，原先显式安装的
-# python3-pyqt5* 是 Debian 12 时代的遗留（等于重复装一整套 Qt5/Chromium），已移除。
-# build-essential/python3-dev 原先由 python3-pip 的 Recommends 隐式提供，
-# 主 Dockerfile 中 pip 安装 requirements.txt 时部分包（如 quickjs）无预编译
-# wheel 需要源码编译，故显式保留。
+# 安装基础系统（包含 PyQt5 系统包）
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+    apt-get install -y \
         tzdata \
         python3 \
         python3-pip \
         python3-venv \
-        python3-dev \
-        build-essential \
         nginx \
         supervisor \
         sqlite3 \
@@ -40,6 +26,10 @@ RUN apt-get update && \
         unzip \
         git \
         ca-certificates \
+        python3-pyqt5 \
+        python3-pyqt5.qtwebengine \
+        python3-pyqt5.qtsql \
+        python3-pyqt5.qtmultimedia \
         python3-dateutil \
         python3-cssselect \
         python3-lxml \
@@ -57,14 +47,10 @@ RUN ver="$(dpkg-query -W -f='${Version}' nginx)" && \
     dpkg --compare-versions "$ver" ge 1.26.3-3+deb13u5 || \
     { echo "ERROR: nginx $ver 仍受 CVE-2026-42945 影响，需 >= 1.26.3-3+deb13u5" && exit 1; }
 
-# 根据架构安装 Calibre。
-# --no-install-recommends 实测可将 calibre 相关安装体积从 ~2.4GB 降到 ~1.3GB，
-# epub/txt/mobi/azw3/PDF 转换均验证正常。
-# fonts-wqy-microhei：services/convert.py 转 PDF 时硬编码了文泉驿微米黑字体，
-# 此前镜像中并未安装该字体（中文 PDF 排版会退化为 fallback 字体），此处补上。
+# 根据架构安装 Calibre
 RUN echo "Installing Calibre via apt for $TARGETARCH $TARGETVARIANT" && \
     apt-get update && \
-    apt-get install -y --no-install-recommends calibre fonts-wqy-microhei && \
+    apt-get install -y calibre && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*;
 
@@ -78,10 +64,10 @@ RUN echo "Verifying Calibre installation..." && \
         exit 1; \
     fi
 
-# 验证 PyQt6 安装（Debian 13 的 calibre 依赖 Qt6，作为 calibre 的依赖自动安装）
-RUN echo "Verifying PyQt6 installation..." && \
-    python3 -c "import PyQt6; print('PyQt6 imported successfully')" && \
-    python3 -c "from PyQt6 import QtWebEngineCore; print('PyQt6.QtWebEngineCore imported successfully')"
+# 验证 PyQt5 安装
+RUN echo "Verifying PyQt5 installation..." && \
+    python3 -c "import PyQt5; print('PyQt5 imported successfully')" && \
+    python3 -c "import PyQt5.QtWebEngine; print('PyQt5.QtWebEngine imported successfully')"
 
 # 安装 Python 包（使用 --break-system-packages）
 RUN pip3 install --no-cache-dir --break-system-packages \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build push test build-base push-base
+.PHONY: all build push test build-base push-base build-slim smoke-convert
 
 VER := $(shell git branch --show-current | tr '/' '-')
 IMAGE := talebook/talebook:$(VER)
@@ -17,14 +17,15 @@ init:
 
 build: test build-spa build-ssr
 
-# 基础镜像：本地构建/发布。主 Dockerfile 默认 FROM talebook/talebook-base:8.5，
-# 首次切换镜像名后需先执行 make build-base push-base 引导出 :8.5 标签。
+# 基础镜像：本地构建/发布。主 Dockerfile 默认 FROM talebook/talebook-base:8.6，
+# 基础镜像有变更时需先执行 make build-base push-base 引导出对应版本标签。
+BASE_VER := 8.6
 build-base:
-	docker build -f Dockerfile.base -t $(BASE):latest -t $(BASE):8.5 .
+	docker build -f Dockerfile.base --build-arg BUILD_COUNTRY=CN -t $(BASE):latest -t $(BASE):$(BASE_VER) .
 
 push-base:
 	docker push $(BASE):latest
-	docker push $(BASE):8.5
+	docker push $(BASE):$(BASE_VER)
 
 build-spa:
 	docker build --no-cache=false --build-arg BUILD_COUNTRY=CN --build-arg GIT_VERSION=$(VER) \
@@ -33,6 +34,16 @@ build-spa:
 build-ssr:
 	docker build --no-cache=false --build-arg BUILD_COUNTRY=CN --build-arg GIT_VERSION=$(VER) \
 		-f Dockerfile -t $(TAG1) -t $(TAG2) --target production-ssr .
+
+# slim 镜像：不支持转换输出 PDF，体积约为完整版的一半，详见 Dockerfile 的 production-slim
+build-slim:
+	docker build --no-cache=false --build-arg BUILD_COUNTRY=CN --build-arg GIT_VERSION=$(VER) \
+		-f Dockerfile -t talebook/talebook:slim --target production-slim .
+
+# 转换链冒烟测试：验证镜像内 ebook-convert 六条互转链（slim 必跑，防止强删清单误伤）
+smoke-convert:
+	docker run --rm -v "$$PWD/tools/convert_smoke.sh:/smoke.sh:ro" \
+		--entrypoint sh talebook/talebook:slim /smoke.sh
 
 push:
 	docker push $(IMAGE)

--- a/Makefile
+++ b/Makefile
@@ -17,15 +17,14 @@ init:
 
 build: test build-spa build-ssr
 
-# 基础镜像：本地构建/发布。主 Dockerfile 默认 FROM talebook/talebook-base:8.6，
-# 基础镜像有变更时需先执行 make build-base push-base 引导出对应版本标签。
-BASE_VER := 8.6
+# 基础镜像：本地构建/发布。主 Dockerfile 默认 FROM talebook/talebook-base:8.5，
+# 首次切换镜像名后需先执行 make build-base push-base 引导出 :8.5 标签。
 build-base:
-	docker build -f Dockerfile.base --build-arg BUILD_COUNTRY=CN -t $(BASE):latest -t $(BASE):$(BASE_VER) .
+	docker build -f Dockerfile.base -t $(BASE):latest -t $(BASE):8.5 .
 
 push-base:
 	docker push $(BASE):latest
-	docker push $(BASE):$(BASE_VER)
+	docker push $(BASE):8.5
 
 build-spa:
 	docker build --no-cache=false --build-arg BUILD_COUNTRY=CN --build-arg GIT_VERSION=$(VER) \

--- a/app/pages/book/[bid]/index.vue
+++ b/app/pages/book/[bid]/index.vue
@@ -543,7 +543,8 @@
                                         </template>
                                         <v-list-item-title>{{ t('book.convert') }}</v-list-item-title>
                                     </v-list-item>
-                                    <v-list-item :disabled="!hasEBooks || hasPDF" @click="convert_to_pdf">
+                                    <!-- slim 版镜像无 QtWebEngine，后端 sys.pdf_convert 为 false 时禁用转PDF入口 -->
+                                    <v-list-item :disabled="!hasEBooks || hasPDF || store.sys.pdf_convert === false" @click="convert_to_pdf">
                                         <template #prepend>
                                             <v-icon>mdi-file-pdf-box</v-icon>
                                         </template>

--- a/app/test/e2e/book-detail.spec.ts
+++ b/app/test/e2e/book-detail.spec.ts
@@ -39,3 +39,33 @@ test.describe('Book Detail Page', () => {
         await expect(page.getByText('下载').first()).toBeVisible();
     });
 });
+
+test.describe('Convert to PDF menu item', () => {
+    // mock 中 book 1 仅有 epub 格式：hasEBooks=true、hasPDF=false，
+    // “转为PDF格式”是否可用只取决于 sys.pdf_convert
+    const openProcessMenu = async (page) => {
+        await page.goto(`/book/${bookId}`);
+        const btn = page.getByRole('button', { name: '文件处理' });
+        await btn.scrollIntoViewIfNeeded();
+        await btn.click();
+        return page.locator('.v-list-item', { hasText: '转为PDF格式' });
+    };
+
+    test('enabled by default (full image)', async ({ page, request }) => {
+        await request.post('http://127.0.0.1:8080/_test/reset', {
+            data: { installed: true }
+        });
+        const item = await openProcessMenu(page);
+        await expect(item).toBeVisible();
+        await expect(item).not.toHaveClass(/v-list-item--disabled/);
+    });
+
+    test('disabled when sys.pdf_convert is false (slim image)', async ({ page, request }) => {
+        await request.post('http://127.0.0.1:8080/_test/reset', {
+            data: { installed: true, pdf_convert: false }
+        });
+        const item = await openProcessMenu(page);
+        await expect(item).toBeVisible();
+        await expect(item).toHaveClass(/v-list-item--disabled/);
+    });
+});

--- a/app/test/mock-server.js
+++ b/app/test/mock-server.js
@@ -16,6 +16,7 @@ let saveStarted = false;
 let saveStatusPolls = 0;
 let booksourceCheckRunning = false;
 let booksourceCheckPolls = 0;
+let pdfConvert = true; // slim 镜像该能力为 false
 
 const app = createApp();
 const router = createRouter();
@@ -37,6 +38,7 @@ router.post('/_test/reset', eventHandler(async (event) => {
   } else {
     isInstalled = true;
   }
+  pdfConvert = body && body.pdf_convert !== undefined ? body.pdf_convert : true;
   console.log('[Mock] isInstalled set to:', isInstalled);
   users = [];
   saveStarted = false;
@@ -71,7 +73,8 @@ router.get('/api/user/info', eventHandler(() => ({
     version: '1.0.0',
     users: 5,
     friends: [],
-    allow: { register: true, download: true, push: true, read: true }
+    allow: { register: true, download: true, push: true, read: true },
+    pdf_convert: pdfConvert
   },
   user: {
     is_login: true,
@@ -86,6 +89,17 @@ router.get('/api/user/messages', eventHandler(() => ({
   err: 'ok',
   total: 0,
   messages: []
+})));
+
+router.get('/api/user/devices', eventHandler(() => ({
+  err: 'ok',
+  devices: []
+})));
+
+// book 1 为 epub 格式，返回非 txt 即可（避免书籍详情页弹出 404 错误对话框）
+router.get('/api/book/txt/init', eventHandler(() => ({
+  err: 'format error',
+  msg: '非txt书籍'
 })));
 
 router.get('/get/cover/:id', eventHandler((event) => {

--- a/document/20260612/docker_image_slim.md
+++ b/document/20260612/docker_image_slim.md
@@ -1,0 +1,94 @@
+# Docker 镜像瘦身：base 镜像修正 + slim 变体
+
+日期：2026-06-12
+
+## 背景
+
+talebook 镜像（arm64 实测 2.63GB）体积过大。起因是评估「能否把 ebook-convert
+编译成静态工具」，结论是不可行，但镜像本身有大量可削减空间。
+
+## 评估结论（均为容器内实测，Debian 13 / calibre 8.x / arm64）
+
+### 为什么 ebook-convert 无法静态化
+
+- ebook-convert 是 Python 程序，依赖 calibre 全量 Python 包 + 原生扩展；
+- 所有转换路径都需要 Qt6 Core/Gui（封面/图片走 QImage）；
+- PDF 输出需要 QtWebEngine（无头 Chromium，`calibre/ebooks/pdf/html_writer.py`
+  使用 `QWebEnginePage.printToPdf`），Chromium 无静态链接形态，Qt 官方明确不支持；
+- PyQt 绑定暴露 Qt 全部 API，链接器无法做死代码消除，静态链接不会更小；
+- calibre 官方二进制就是「自带 Python+Qt 的 bundle」，体积同样 GB 级；
+- 抽取转换代码做独立工具：上游作者明确不支持解耦（mobileread 帖 t=332646），
+  前人 fork gryf/ebook-converter 已停更且无 azw3 输出；且 webserver 有 17 处
+  直接 `import calibre`（calibre.db / ebooks.metadata / utils.smtp 等），完整
+  calibre 必须留在 webserver 同一 Python 环境中，抽取收益为零。
+
+### 镜像肥在哪（2.63GB 的解剖）
+
+| 浪费项 | 体积 | 原因 |
+|---|---|---|
+| 整套 Qt5 + PyQt5（含 Qt5WebEngineCore 123MB） | ~250MB | Dockerfile.base 显式安装的 `python3-pyqt5*` 是 Debian 12 遗留；Debian 13 的 calibre 只用 PyQt6，等于装了两套 Chromium |
+| scipy/matplotlib/LLVM/Mesa/gcc/vim 等 | ~500MB+ | apt Recommends 拖入 |
+| Qt6WebEngineCore + Chromium 资源 | ~250MB | 仅 PDF 输出需要 |
+| sympy | 72MB | calibre→python3-fonttools→python3-sympy 硬依赖链（Debian 打包怪癖） |
+
+### 实测数据阶梯（base 层 rootfs）
+
+| 方案 | 体积 | 转换验证 |
+|---|---|---|
+| `--no-install-recommends`（保 PDF） | 1343MB | epub/azw3/mobi/txt/PDF 全过 |
+| + 强删 WebEngine 栈 | 996MB | 六链全过，PDF 输出失效 |
+| + 强删 scipy/sympy/Mesa+LLVM/ffmpeg | 657MB | 六链全过 |
+
+关键边界（踩过的坑）：
+
+- `libgl1/libegl1/libglx0`（glvnd 调度层，各几 MB）是 `libQt6Gui.so` 的
+  ELF NEEDED，**不可删**；删除后所有涉及封面的转换报
+  `cannot import QBuffer from qt.core`。可删的是其背后的 Mesa 驱动 + LLVM + z3。
+- PDF 输出（Chromium）拒绝以 root 运行，必须以非 root 用户执行 ebook-convert。
+- `--no-install-recommends` 下 scipy 仍会被装入；sympy 经 fonttools 硬依赖装入，
+  二者均需 `dpkg -r --force-depends` 强删。
+
+## 落地方案（本次 PR）
+
+1. **主镜像（保 PDF，零功能损失）**：Dockerfile.base 全程
+   `--no-install-recommends`，移除 PyQt5 遗留，显式保留 build-essential
+   （pip 编译 sdist 用，原先由 Recommends 隐式提供），补装 fonts-wqy-microhei
+   （convert.py 转 PDF 硬编码文泉驿字体，此前镜像中缺失）。base 版本 8.5 → 8.6。
+2. **slim 变体（`talebook/talebook:slim`）**：主 Dockerfile 新增
+   `production-slim` target，在 production 基础上强删 WebEngine/Quick/Qml、
+   scipy/sympy、Mesa 驱动+LLVM、qtmultimedia+ffmpeg、编译工具链，并设置
+   `ENV TALEBOOK_PDF_CONVERT=0`。不支持转换输出 PDF（PDF 导入/阅读不受影响）。
+3. **功能开关**：`TALEBOOK_PDF_CONVERT=0` 时 BookToPDF 接口返回
+   `params.convert.unsupported`；`/api/user/info` 的 `sys.pdf_convert` 暴露该
+   能力，前端据此禁用「转为PDF格式」菜单项。
+4. **护栏**：`tools/convert_smoke.sh` 六条转换链冒烟测试，build.yml 中对
+   slim 镜像（amd64）必跑，防止强删清单在 calibre/Debian 升级后误伤转换功能。
+
+## 最终实测体积（arm64，拉取/存储体积，非容器内 rootfs）
+
+| 镜像 | 改造前 | 改造后 | 变化 |
+|---|---|---|---|
+| base（talebook-base） | ~2.5GB | 1.79GB | -28% |
+| 完整版（production-spa，保 PDF） | 2.63GB | 1.98GB | -25%，零功能损失 |
+| slim（production-slim，无 PDF 输出） | 2.63GB | 1.01GB | -62% |
+
+### 关键陷阱：分层 whiteout 不减小镜像体积
+
+最初 slim 阶段写成 `FROM production` + `RUN dpkg -r`，实测镜像体积仍是 1.98GB，
+仅容器内 `du / ` 降到 1043MB。原因：dpkg 删除发生在新层，被删字节仍保留在
+production 的下层中，docker 镜像体积 = 各层 tar 之和，whiteout 标记不会移除下层字节。
+
+解决：slim 拆成两段——`slim-strip` 删包，再 `FROM scratch` + `COPY --from=slim-strip / /`
+把瘦身后的 rootfs 压成单层，被删字节才真正从镜像消失（1.98GB → 1.01GB）。
+代价是 scratch 不带元数据，需重新声明 production 的 ENV / WORKDIR / EXPOSE /
+VOLUME / CMD。已验证 flatten 后 talebook 用户 / gosu / nginx / supervisor /
+start.sh / import webserver / 文件 setuid 位均完好。
+
+## 注意事项
+
+- slim 镜像 dpkg 依赖状态不一致，**镜像内不可再 apt-get install**；
+  需要加包请基于 production target 自行构建。
+- base 8.6 需要引导发布：合并后执行 `make build-base push-base`
+  （或推 `base-v8.6.x` tag 触发 build-base workflow），主镜像构建才能拉到
+  `talebook/talebook-base:8.6`。
+- 后续 Debian/calibre 升级时，强删清单的包名可能漂移，以冒烟测试为准。

--- a/tests/test_book_formats.py
+++ b/tests/test_book_formats.py
@@ -269,6 +269,12 @@ class TestBookToPDF(TestWithUserLogin):
             d = self.json(f"/api/book/{BID_PDF}/topdf", method="POST", body="")
             self.assertEqual(d["err"], "params.book.invalid")
 
+    def test_topdf_rejected_on_slim_image(self):
+        """slim 镜像设置 TALEBOOK_PDF_CONVERT=0，应直接拒绝转换请求。"""
+        with mock.patch.dict(os.environ, {"TALEBOOK_PDF_CONVERT": "0"}):
+            d = self.json(f"/api/book/{BID_EPUB}/topdf", method="POST", body="")
+            self.assertEqual(d["err"], "params.convert.unsupported")
+
     def test_topdf_success(self):
         """Book with EPUB format should be convertible to PDF."""
         mock_book = {

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -245,10 +245,16 @@ class TestAppWithoutLogin(TestApp):
         self.assertEqual(d["user"]["is_login"], False)
         self.assertEqual(d["user"]["is_admin"], False)
         self.assertEqual(d["sys"]["books"], 13)
+        self.assertEqual(d["sys"]["pdf_convert"], True)
 
         d = self.json("/api/user/info?detail=1")
         self.assertEqual(d["user"]["is_login"], False)
         self.assertEqual(d["sys"], {})
+
+    def test_user_info_pdf_convert_disabled_on_slim(self):
+        with mock.patch.dict(os.environ, {"TALEBOOK_PDF_CONVERT": "0"}):
+            d = self.json("/api/user/info")
+            self.assertEqual(d["sys"]["pdf_convert"], False)
 
     def test_book(self):
         d = self.json("/api/book/1")

--- a/tools/convert_smoke.sh
+++ b/tools/convert_smoke.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# ebook-convert 转换链冒烟测试，挂载进 talebook 镜像内运行（tools/ 不打包进镜像）：
+#   docker run --rm -v "$PWD/tools/convert_smoke.sh:/smoke.sh:ro" --entrypoint sh <image> /smoke.sh
+#
+# 验证 txt/epub/mobi/azw3 六条互转链；TALEBOOK_PDF_CONVERT != 0 时额外验证 PDF 输出。
+# 样书使用镜像内置的 docker/book/。slim 镜像通过 dpkg 强删了部分 calibre 依赖
+# （见 Dockerfile 的 production-slim 注释），本脚本是防止删除清单误伤转换功能的护栏。
+#
+# 注意：PDF 输出走 QtWebEngine（Chromium），不允许以 root 运行，
+# 因此统一以 talebook 用户执行转换。
+set -e
+
+BOOK_DIR=/var/www/talebook/docker/book
+WORK_DIR=$(mktemp -d)
+chmod 777 "$WORK_DIR"
+cp "$BOOK_DIR/12.txt" "$WORK_DIR/sample.txt"
+
+run_convert() {
+    src="$1"; dst="$2"
+    if gosu talebook ebook-convert "$src" "$WORK_DIR/$dst" >"$WORK_DIR/convert.log" 2>&1; then
+        echo "OK   $(basename "$src") -> $dst"
+    else
+        echo "FAIL $(basename "$src") -> $dst"
+        tail -20 "$WORK_DIR/convert.log"
+        exit 1
+    fi
+}
+
+run_convert "$WORK_DIR/sample.txt" out1.epub
+run_convert "$WORK_DIR/sample.txt" out2.azw3
+run_convert "$BOOK_DIR/1.epub" out3.azw3
+run_convert "$BOOK_DIR/1.epub" out4.mobi
+run_convert "$BOOK_DIR/11.azw3" out5.epub
+run_convert "$BOOK_DIR/10.mobi" out6.epub
+
+if [ "${TALEBOOK_PDF_CONVERT:-1}" != "0" ]; then
+    run_convert "$BOOK_DIR/1.epub" out7.pdf
+else
+    echo "SKIP pdf output (slim image)"
+fi
+
+rm -rf "$WORK_DIR"
+echo "convert smoke: all passed"

--- a/webserver/handlers/book.py
+++ b/webserver/handlers/book.py
@@ -174,6 +174,10 @@ class BookToPDF(BaseHandler):
     @js
     @auth
     def post(self, id):
+        # slim 镜像移除了 PDF 输出所需的 QtWebEngine，构建时设置了该环境变量
+        if os.environ.get("TALEBOOK_PDF_CONVERT", "1") == "0":
+            return {"err": "params.convert.unsupported", "msg": _("当前服务器为slim版镜像，不支持转换为PDF格式")}
+
         book_id = int(id)
         book = self.get_book(book_id, raise_exception=False)
         if not book:

--- a/webserver/handlers/user.py
+++ b/webserver/handlers/user.py
@@ -4,6 +4,7 @@
 import datetime
 import hashlib
 import logging
+import os
 import re
 
 import tornado.escape
@@ -428,6 +429,8 @@ class UserInfo(BaseHandler):
             "header": CONF["HEADER"],
             "show_sidebar_sys": CONF.get("SHOW_SIDEBAR_SYS", True),
             "FEEDBACK_URL": CONF["FEEDBACK_URL"],
+            # slim 镜像不含 QtWebEngine，无法转换输出 PDF，前端据此隐藏入口
+            "pdf_convert": os.environ.get("TALEBOOK_PDF_CONVERT", "1") != "0",
             "allow": {
                 "register": CONF["ALLOW_REGISTER"],
                 "download": CONF["ALLOW_GUEST_DOWNLOAD"],


### PR DESCRIPTION
## 背景

起因是评估「能否把 `ebook-convert` 编译成静态工具来缩小镜像」。结论：不可行（`ebook-convert` 是 Python 程序，转换依赖 Qt6 Gui，PDF 输出依赖 QtWebEngine/Chromium，无静态形态；calibre 官方二进制同样 GB 级；且 webserver 有 17 处直接 `import calibre`，无法解耦）。但镜像本身有大量可削减空间。完整评估见 `document/20260612/docker_image_slim.md`。

## 改动

### 1. 主镜像（第一步，零功能损失）— 2.63GB → 1.98GB
- `Dockerfile.base` 全程 `--no-install-recommends`，剔除 apt Recommends 拖入的 scipy/matplotlib/GPU 驱动等数百 MB 无关包。
- 移除 Debian 12 遗留的 `python3-pyqt5*` 系列（Debian 13 的 calibre 用 PyQt6，原先等于多装一整套 Qt5/Chromium）。
- 显式保留 `build-essential`/`python3-dev`（pip 编译 quickjs 等 sdist 需要，原先由 Recommends 隐式提供），补装 `fonts-wqy-microhei`（`convert.py` 转 PDF 硬编码文泉驿字体，此前镜像缺失）。base 版本 8.5 → 8.6。

### 2. 新增 slim 变体 `talebook/talebook:slim`（不支持转换输出 PDF）— 2.63GB → 1.01GB（-62%）
- 新增 `production-slim` target，强删 PDF 输出专属的 QtWebEngine/Chromium 栈、scipy/sympy、Mesa 驱动+LLVM、qtmultimedia+ffmpeg、编译工具链。
- **关键**：`dpkg -r` 在新层删除不减小镜像体积（被删字节仍留在下层），故拆成 `slim-strip` 删包 + `FROM scratch` + `COPY --from=slim-strip / /` 压成单层，被删字节才真正消失。
- PDF **输入/阅读不受影响**，仅去掉「转换为 PDF」的输出能力。

### 3. 功能开关
- `TALEBOOK_PDF_CONVERT=0` 时 `BookToPDF` 返回 `params.convert.unsupported`；`/api/user/info` 下发 `sys.pdf_convert`，前端据此禁用「转为PDF格式」菜单项。

### 4. 护栏与发布
- `tools/convert_smoke.sh` 六条转换链冒烟测试，`build.yml` 对 slim 镜像（amd64）必跑，防止强删清单在 calibre/Debian 升级后误伤转换功能。
- `build.yml` 新增 SLIM 镜像构建推送，`Makefile` 新增 `build-slim`/`smoke-convert`。

## 实测体积（arm64，拉取/存储体积）

| 镜像 | 改造前 | 改造后 | 变化 |
|---|---|---|---|
| base | ~2.5GB | 1.79GB | -28% |
| 完整版（保 PDF） | 2.63GB | 1.98GB | -25% |
| slim（无 PDF 输出） | 2.63GB | **1.01GB** | **-62%** |

## 验证

- ✅ base 8.6 本地构建成功，六条转换链 + PDF 全部正常
- ✅ slim 镜像 1.01GB，`convert_smoke.sh` 六链全过，PDF 正确跳过，运行时（talebook 用户/gosu/nginx/supervisor/start.sh/import webserver）完整
- ✅ 后端 pytest 通过（含新增的 slim 拦截转 PDF、`sys.pdf_convert` 下发 2 个用例）
- ✅ 前端 e2e 通过（含新增的「slim 禁用转 PDF 菜单」2 个用例）
- ✅ 后端 ruff lint、前端 eslint 通过

## 注意事项

- slim 镜像 dpkg 依赖状态不一致，镜像内不可再 `apt-get install`；需加包请基于 `production` target 构建。
- base 8.6 需引导发布：合并后执行 `make build-base push-base`（或推 `base-v8.6.x` tag 触发 build-base workflow），主镜像构建才能拉到 `talebook/talebook-base:8.6`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)