### PR TITLE
fix: PDF扫描时使用文件名作为书名，而非元数据中的无意义书名

### DIFF
--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -231,3 +231,148 @@ class TestScanPDFTitle(TestWithUserLogin):
                 if row:
                     self.session.delete(row)
             self.session.commit()
+
+    @mock.patch("calibre.ebooks.metadata.meta.get_metadata")
+    def test_txt_scan_uses_filename_not_metadata_title(self, mock_get_metadata):
+        """TXT 文件与 PDF 使用相同逻辑（scan.py 第189行），应同样用文件名而非元数据书名"""
+        from calibre.ebooks.metadata.book.base import Metadata
+
+        mock_get_metadata.return_value = Metadata("Untitled", ["Unknown"])
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            txt_path = os.path.join(tmpdir, "my_text_book.txt")
+            with open(txt_path, "wb") as f:
+                f.write(b"This is a text book content")
+
+            ScanService().do_scan(tmpdir)
+
+            self.session.rollback()
+            row = self.session.query(ScanFile).filter(ScanFile.path == txt_path).first()
+            self.assertIsNotNone(row, "应当为 TXT 文件创建ScanFile记录")
+            self.assertEqual(row.title, "my_text_book", "TXT 书名应使用文件名，不应是元数据中的'Untitled'")
+
+            self.session.delete(row)
+            self.session.commit()
+
+    @mock.patch("calibre.ebooks.metadata.meta.get_metadata")
+    def test_pdf_filename_with_multiple_dots(self, mock_get_metadata):
+        """含多个点的文件名用 os.path.splitext 才能正确提取（只去掉最后的 .pdf）"""
+        from calibre.ebooks.metadata.book.base import Metadata
+
+        mock_get_metadata.return_value = Metadata("副本", ["某作者"])
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pdf_path = os.path.join(tmpdir, "my.book.chapter1.pdf")
+            with open(pdf_path, "wb") as f:
+                f.write(b"%PDF-1.4 minimal pdf")
+
+            ScanService().do_scan(tmpdir)
+
+            self.session.rollback()
+            row = self.session.query(ScanFile).filter(ScanFile.path == pdf_path).first()
+            self.assertIsNotNone(row)
+            self.assertEqual(row.title, "my.book.chapter1")
+
+            if row:
+                self.session.delete(row)
+                self.session.commit()
+
+    @mock.patch("calibre.ebooks.metadata.meta.get_metadata")
+    def test_epub_scan_uses_metadata_title_not_filename(self, mock_get_metadata):
+        """EPUB 不在 ['txt','pdf'] 范围内，应使用元数据书名而非文件名（回归验证）"""
+        from calibre.ebooks.metadata.book.base import Metadata
+
+        good_mi = Metadata("这是一本好书", ["著名作者"])
+        good_mi.tags = ["小说"]
+        good_mi.publisher = "某出版社"
+        mock_get_metadata.return_value = good_mi
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            epub_path = os.path.join(tmpdir, "filename_is_irrelevant.epub")
+            with open(epub_path, "wb") as f:
+                f.write(b"PK\x03\x04")
+
+            ScanService().do_scan(tmpdir)
+
+            self.session.rollback()
+            row = self.session.query(ScanFile).filter(ScanFile.path == epub_path).first()
+            if row:
+                self.assertEqual(row.title, "这是一本好书", "EPUB 书名应来自元数据，不是文件名")
+                self.session.delete(row)
+                self.session.commit()
+
+    @mock.patch("calibre.ebooks.metadata.meta.get_metadata")
+    def test_pdf_in_subdirectory_uses_filename(self, mock_get_metadata):
+        """do_scan 会递归扫描子目录（os.walk），子目录中的 PDF 也应使用文件名"""
+        from calibre.ebooks.metadata.book.base import Metadata
+
+        mock_get_metadata.return_value = Metadata("副本", ["某作者"])
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            subdir = os.path.join(tmpdir, "fiction", "sci-fi")
+            os.makedirs(subdir)
+            pdf_path = os.path.join(subdir, "deep_scan_book.pdf")
+            with open(pdf_path, "wb") as f:
+                f.write(b"%PDF-1.4 minimal pdf")
+
+            ScanService().do_scan(tmpdir)
+
+            self.session.rollback()
+            row = self.session.query(ScanFile).filter(ScanFile.path == pdf_path).first()
+            self.assertIsNotNone(row, "子目录中的 PDF 应被递归扫描到")
+            self.assertEqual(row.title, "deep_scan_book", "子目录中的 PDF 书名应使用文件名")
+
+            self.session.delete(row)
+            self.session.commit()
+
+    @mock.patch("calibre.ebooks.metadata.meta.get_metadata")
+    def test_pdf_chinese_filename(self, mock_get_metadata):
+        """中文文件名的 PDF 应正确提取书名（os.path.splitext 对 Unicode 安全）"""
+        from calibre.ebooks.metadata.book.base import Metadata
+
+        mock_get_metadata.return_value = Metadata("副本", ["某作者"])
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pdf_path = os.path.join(tmpdir, "三体全集.pdf")
+            with open(pdf_path, "wb") as f:
+                f.write(b"%PDF-1.4 minimal pdf")
+
+            ScanService().do_scan(tmpdir)
+
+            self.session.rollback()
+            row = self.session.query(ScanFile).filter(ScanFile.path == pdf_path).first()
+            self.assertIsNotNone(row, "中文文件名的 PDF 应被正确扫描")
+            self.assertEqual(row.title, "三体全集")
+
+            self.session.delete(row)
+            self.session.commit()
+
+    @mock.patch("calibre.ebooks.metadata.meta.get_metadata")
+    def test_pdf_scan_three_files_all_use_own_filename(self, mock_get_metadata):
+        """3个PDF同时扫描，全部各用自己的文件名（fname 变量泄漏修复的更强验证）"""
+        from calibre.ebooks.metadata.book.base import Metadata
+
+        mock_get_metadata.side_effect = lambda s, stream_type, use_libprs_metadata: Metadata("副本", ["某作者"])
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            names = ["alpha", "beta", "gamma"]
+            paths = {}
+            for name in names:
+                path = os.path.join(tmpdir, f"{name}.pdf")
+                with open(path, "wb") as f:
+                    f.write(f"%PDF-1.4 content for {name}".encode())
+                paths[name] = path
+
+            ScanService().do_scan(tmpdir)
+
+            self.session.rollback()
+            for name, path in paths.items():
+                row = self.session.query(ScanFile).filter(ScanFile.path == path).first()
+                self.assertIsNotNone(row, f"应当为 {name}.pdf 创建ScanFile记录")
+                self.assertEqual(row.title, name, f"{name}.pdf 的书名应为 {name}，不是其他文件的文件名")
+
+            for path in paths.values():
+                row = self.session.query(ScanFile).filter(ScanFile.path == path).first()
+                if row:
+                    self.session.delete(row)
+            self.session.commit()

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -208,9 +208,13 @@ class TestScanPDFTitle(TestWithUserLogin):
         with tempfile.TemporaryDirectory() as tmpdir:
             pdf_a = os.path.join(tmpdir, "book_a.pdf")
             pdf_b = os.path.join(tmpdir, "book_b.pdf")
-            for p in [pdf_a, pdf_b]:
-                with open(p, "wb") as f:
-                    f.write(b"%PDF-1.4 minimal pdf")
+            # Use different content so each file gets a distinct SHA256 hash;
+            # identical content would trigger the duplicate-hash cleanup path in do_scan()
+            # and cause the first file's ScanFile record to be deleted.
+            with open(pdf_a, "wb") as f:
+                f.write(b"%PDF-1.4 minimal pdf for book_a")
+            with open(pdf_b, "wb") as f:
+                f.write(b"%PDF-1.4 minimal pdf for book_b")
 
             ScanService().do_scan(tmpdir)
 

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -3,6 +3,8 @@
 
 import json
 import logging
+import os
+import tempfile
 import threading
 import time
 import unittest
@@ -141,3 +143,57 @@ class TestImport(TestWithUserLogin):
         req = {"hashlist": "all"}
         d = self.json("/api/admin/import/run", method="POST", body=json.dumps(req))
         self.assertEqual(d["err"], "ok")
+
+
+class TestScanPDFTitle(TestWithUserLogin):
+    """PDF文件扫描时应使用文件名作为书名，而不是PDF元数据中的书名（issue #770）"""
+
+    def setUp(self):
+        self.session = self.get_app().settings["ScopedSession"]
+        self.session.rollback()
+        return super().setUp()
+
+    @mock.patch("calibre.ebooks.metadata.meta.get_metadata")
+    def test_pdf_scan_uses_filename_not_metadata_title(self, mock_get_metadata):
+        """当PDF元数据书名为'副本'等无意义值时，扫描记录应使用文件名作为书名"""
+        from calibre.ebooks.metadata.book.base import Metadata
+
+        bad_mi = Metadata("副本", ["某作者"])
+        bad_mi.tags = []
+        bad_mi.publisher = None
+        mock_get_metadata.return_value = bad_mi
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pdf_path = os.path.join(tmpdir, "my_real_book.pdf")
+            with open(pdf_path, "wb") as f:
+                f.write(b"%PDF-1.4 minimal pdf")
+
+            ScanService().do_scan(tmpdir)
+
+            self.session.rollback()
+            row = self.session.query(ScanFile).filter(ScanFile.path == pdf_path).first()
+            self.assertIsNotNone(row, "应当创建ScanFile记录")
+            self.assertEqual(row.title, "my_real_book", "PDF书名应使用文件名，不应是元数据中的'副本'")
+
+            self.session.delete(row)
+            self.session.commit()
+
+    @mock.patch("calibre.ebooks.metadata.meta.get_metadata")
+    def test_pdf_scan_uses_filename_when_metadata_fails(self, mock_get_metadata):
+        """当PDF元数据解析失败时，扫描记录应使用文件名（不含扩展名）作为书名"""
+        mock_get_metadata.side_effect = Exception("failed to parse PDF metadata")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pdf_path = os.path.join(tmpdir, "my_book_file.pdf")
+            with open(pdf_path, "wb") as f:
+                f.write(b"%PDF-1.4 minimal pdf")
+
+            ScanService().do_scan(tmpdir)
+
+            self.session.rollback()
+            row = self.session.query(ScanFile).filter(ScanFile.path == pdf_path).first()
+            self.assertIsNotNone(row, "应当创建ScanFile记录")
+            self.assertEqual(row.title, "my_book_file", "PDF解析失败时书名应使用文件名（不含扩展名）")
+
+            self.session.delete(row)
+            self.session.commit()

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -197,3 +197,33 @@ class TestScanPDFTitle(TestWithUserLogin):
 
             self.session.delete(row)
             self.session.commit()
+
+    @mock.patch("calibre.ebooks.metadata.meta.get_metadata")
+    def test_pdf_scan_multiple_files_use_own_filename(self, mock_get_metadata):
+        """多文件扫描时，每个PDF都应使用自己的文件名作为书名，而非最后一个文件的文件名"""
+        from calibre.ebooks.metadata.book.base import Metadata
+
+        mock_get_metadata.side_effect = lambda stream, stream_type, use_libprs_metadata: Metadata("副本", ["某作者"])
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pdf_a = os.path.join(tmpdir, "book_a.pdf")
+            pdf_b = os.path.join(tmpdir, "book_b.pdf")
+            for p in [pdf_a, pdf_b]:
+                with open(p, "wb") as f:
+                    f.write(b"%PDF-1.4 minimal pdf")
+
+            ScanService().do_scan(tmpdir)
+
+            self.session.rollback()
+            row_a = self.session.query(ScanFile).filter(ScanFile.path == pdf_a).first()
+            row_b = self.session.query(ScanFile).filter(ScanFile.path == pdf_b).first()
+
+            self.assertIsNotNone(row_a, "应当为 book_a.pdf 创建ScanFile记录")
+            self.assertIsNotNone(row_b, "应当为 book_b.pdf 创建ScanFile记录")
+            self.assertEqual(row_a.title, "book_a", "book_a.pdf 的书名应为 book_a，而非其他文件的文件名")
+            self.assertEqual(row_b.title, "book_b", "book_b.pdf 的书名应为 book_b")
+
+            for row in [row_a, row_b]:
+                if row:
+                    self.session.delete(row)
+            self.session.commit()

--- a/webserver/services/scan.py
+++ b/webserver/services/scan.py
@@ -122,6 +122,7 @@ class ScanService(AsyncService):
         # 检查文件哈希值，检查DB重复情况
         for row in rows:
             fpath = row.path
+            fname = os.path.basename(fpath)
 
             # 读取文件，计算哈希值
             sha256 = hashlib.sha256()
@@ -186,7 +187,7 @@ class ScanService(AsyncService):
 
                 # 非结构化的格式，calibre无法识别准确的信息，直接从文件名提取
                 if fmt in ["txt", "pdf"]:
-                    mi.title = fname.replace("." + fmt, "")
+                    mi.title = os.path.splitext(fname)[0]
 
                 row.title = mi.title
                 # 使用mi.authors列表而不是mi.author_sort，避免作者信息丢失
@@ -195,7 +196,7 @@ class ScanService(AsyncService):
                 row.tags = ", ".join(mi.tags)
                 row.status = ScanFile.READY  # 设置为可处理
             else:
-                row.title = fname.replace("." + fmt, "")
+                row.title = os.path.splitext(fname)[0]
                 row.author = "Unknown"
                 row.status = ScanFile.READY  # 设置为可处理，尽管解析失败
                 self.save_or_rollback(row)

--- a/webserver/services/scan.py
+++ b/webserver/services/scan.py
@@ -184,6 +184,10 @@ class ScanService(AsyncService):
                 mi.title = utils.super_strip(mi.title)
                 mi.authors = [utils.super_strip(s) for s in mi.authors]
 
+                # 非结构化的格式，calibre无法识别准确的信息，直接从文件名提取
+                if fmt in ["txt", "pdf"]:
+                    mi.title = fname.replace("." + fmt, "")
+
                 row.title = mi.title
                 # 使用mi.authors列表而不是mi.author_sort，避免作者信息丢失
                 row.author = mi.authors[0] if mi.authors else ""
@@ -191,9 +195,11 @@ class ScanService(AsyncService):
                 row.tags = ", ".join(mi.tags)
                 row.status = ScanFile.READY  # 设置为可处理
             else:
-                row.title = fname
+                row.title = fname.replace("." + fmt, "")
                 row.author = "Unknown"
                 row.status = ScanFile.READY  # 设置为可处理，尽管解析失败
+                self.save_or_rollback(row)
+                continue
 
             # TODO calibre提供的书籍重复接口只有对比title；应当提前对整个书库的文件做哈希，才能准确去重
             ids = self.db.books_with_same_title(mi)


### PR DESCRIPTION
fixes #770

## 修复说明

在 do_scan() 中对 PDF/TXT 文件应用与 do_import() 一致的逻辑：使用文件名（不含扩展名）作为书名，避免显示 PDF 内嵌的"副本"、"Untitled" 等无意义元数据书名。

Generated with [Claude Code](https://claude.ai/code)