### PR TITLE
feat: 支持 MySQL/MariaDB 作为 Talebook 用户数据库

### DIFF
--- a/app/i18n/locales/en-US.json
+++ b/app/i18n/locales/en-US.json
@@ -641,7 +641,8 @@
         "opdsSettings": "OPDS Settings",
         "captchaSettings": "CAPTCHA Settings",
         "trashManagement": "Trash Management",
-        "updateCheck": "Check for Updates"
+        "updateCheck": "Check for Updates",
+        "databaseManagement": "Database Management"
       },
       "button": {
         "saveSettings": "Save Settings",
@@ -649,7 +650,9 @@
         "trashClear": "Clear Trash",
         "trashClearConfirm": "Confirm Clear",
         "checkUpdate": "Check for Updates",
-        "viewRelease": "View Release"
+        "viewRelease": "View Release",
+        "testDbConnection": "Test Connection",
+        "migrateDb": "Migrate Database"
       },
       "label": {
         "siteTitle": "Site Title",
@@ -711,10 +714,18 @@
         "defaultPageSize": "Book List Page Size",
         "currentVersion": "Current Version",
         "latestVersion": "Latest Version",
-        "lastCheckTime": "Last Check Time"
+        "lastCheckTime": "Last Check Time",
+        "dbType": "Database Type",
+        "dbHost": "Database Host",
+        "dbPort": "Port",
+        "dbName": "Database Name",
+        "dbUser": "Database Username",
+        "dbPass": "Database Password"
       },
       "option": {
         "ssl": "SSL",
+        "dbSqlite": "SQLite",
+        "dbMysql": "MySQL / MariaDB",
         "tls": "TLS (most email services use this)",
         "pinyinDir": "Use Pinyin directory names (better compatibility)",
         "chineseDir": "Use Chinese directory names (UTF8, more beautiful)",
@@ -741,7 +752,14 @@
         "trashClearConfirm": "Confirm clearing trash and upload temporary directory? This action cannot be undone!",
         "upToDate": "Already up to date",
         "updateAvailable": "New version {version} available. Please update to get the latest features and security fixes.",
-        "checkError": "Failed to check for updates"
+        "checkError": "Failed to check for updates",
+        "dbInfo": "Talebook's own data (users, bookshelves, configuration) can be migrated to MySQL/MariaDB. Calibre book metadata remains in SQLite. A server restart is required after migration.",
+        "dbMigrateWarning": "Migration will copy all current database data to the new database. A server restart is required. This action cannot be undone — please backup first!",
+        "dbMigrateConfirmTitle": "Confirm database migration?",
+        "dbMigrateSuccess": "Migration successful. Please restart the server for changes to take effect.",
+        "dbConnectSuccess": "Database connection successful",
+        "currentDb": "Current Database",
+        "newDbConfig": "Migrate to New Database"
       },
       "meta_source": {
         "douban": "Douban",
@@ -851,7 +869,19 @@
     "writingConfig": "Writing configuration file...",
     "configWriteSuccess": "Configuration written successfully!",
     "checkingServer": "Checking server...",
-    "networkError": "Network error"
+    "networkError": "Network error",
+    "dbConfig": "Database Configuration",
+    "dbType": "Database Type",
+    "dbTypeSqlite": "SQLite (default, suitable for personal use)",
+    "dbTypeMysql": "MySQL / MariaDB (suitable for high concurrency)",
+    "dbHost": "Database Host",
+    "dbPort": "Port",
+    "dbName": "Database Name",
+    "dbUser": "Database Username",
+    "dbPass": "Database Password",
+    "testConnection": "Test Connection",
+    "dbConnectSuccess": "Database connection successful",
+    "dbConnectFailed": "Database connection failed"
   },
   "settings": {
     "deviceMgt": "Global Device Management",

--- a/app/i18n/locales/en-US.json
+++ b/app/i18n/locales/en-US.json
@@ -653,7 +653,8 @@
         "checkUpdate": "Check for Updates",
         "viewRelease": "View Release",
         "testDbConnection": "Test Connection",
-        "migrateDb": "Migrate Database"
+        "migrateDb": "Migrate Database",
+        "forceMigrateDb": "Force Migrate"
       },
       "label": {
         "siteTitle": "Site Title",
@@ -760,7 +761,9 @@
         "dbMigrateSuccess": "Migration successful. Please restart the server for changes to take effect.",
         "dbConnectSuccess": "Database connection successful",
         "currentDb": "Current Database",
-        "newDbConfig": "Migrate to New Database"
+        "newDbConfig": "Migrate to New Database",
+        "dbForceTitle": "Target database has existing data — confirm forced migration?",
+        "dbForceWarning": "The target database already contains {count} records. A forced migration will permanently erase all existing data before writing. This cannot be undone — please back up first!"
       },
       "meta_source": {
         "douban": "Douban",

--- a/app/i18n/locales/en-US.json
+++ b/app/i18n/locales/en-US.json
@@ -196,7 +196,8 @@
     "scopedBooks": "Private Books",
     "localLibrary": "Local Library",
     "networkLibrary": "Network Library",
-    "bookSources": "Book Sources"
+    "bookSources": "Book Sources",
+    "systemLogs": "System Logs"
   },
   "network": {
     "title": "Network Library",
@@ -848,6 +849,21 @@
       "host": "Enter host address",
       "path": "Enter path",
       "port": "Enter port"
+    },
+    "logs": {
+      "title": "System Logs",
+      "button": {
+        "refresh": "Refresh",
+        "download": "Download Logs"
+      },
+      "label": {
+        "lines": "Show last N lines",
+        "file": "Log file"
+      },
+      "message": {
+        "noLogs": "No log content available",
+        "loadError": "Failed to load logs"
+      }
     }
   },
   "install": {

--- a/app/i18n/locales/zh-CN.json
+++ b/app/i18n/locales/zh-CN.json
@@ -201,7 +201,8 @@
     "scopedBooks": "私有书籍",
     "localLibrary": "本地书库",
     "networkLibrary": "网络书库",
-    "bookSources": "书源管理"
+    "bookSources": "书源管理",
+    "systemLogs": "系统日志"
   },
   "network": {
     "title": "网络书库",
@@ -868,6 +869,21 @@
       },
       "actions": {},
       "permissions": {}
+    },
+    "logs": {
+      "title": "系统日志",
+      "button": {
+        "refresh": "刷新",
+        "download": "下载日志"
+      },
+      "label": {
+        "lines": "显示最近行数",
+        "file": "日志文件"
+      },
+      "message": {
+        "noLogs": "暂无日志内容",
+        "loadError": "加载日志失败"
+      }
     }
   },
   "install": {

--- a/app/i18n/locales/zh-CN.json
+++ b/app/i18n/locales/zh-CN.json
@@ -671,7 +671,8 @@
         "opdsSettings": "OPDS 设置",
         "captchaSettings": "人机验证设置",
         "trashManagement": "回收站管理",
-        "updateCheck": "检查更新"
+        "updateCheck": "检查更新",
+        "databaseManagement": "数据库管理"
       },
       "button": {
         "saveSettings": "保存配置",
@@ -679,7 +680,9 @@
         "trashClear": "清理回收站",
         "trashClearConfirm": "确认清理",
         "checkUpdate": "检查更新",
-        "viewRelease": "查看发布"
+        "viewRelease": "查看发布",
+        "testDbConnection": "测试连接",
+        "migrateDb": "迁移数据库"
       },
       "label": {
         "siteTitle": "网站标题",
@@ -741,11 +744,19 @@
         "defaultPageSize": "书籍列表中分页大小",
         "currentVersion": "当前版本",
         "latestVersion": "最新版本",
-        "lastCheckTime": "上次检查时间"
+        "lastCheckTime": "上次检查时间",
+        "dbType": "数据库类型",
+        "dbHost": "数据库主机",
+        "dbPort": "端口",
+        "dbName": "数据库名",
+        "dbUser": "数据库用户名",
+        "dbPass": "数据库密码"
       },
       "option": {
         "ssl": "SSL",
         "tls": "TLS(多数邮箱为此选项)",
+        "dbSqlite": "SQLite",
+        "dbMysql": "MySQL / MariaDB",
         "pinyinDir": "使用拼音字母目录名 (兼容性高)",
         "chineseDir": "使用中文目录名 (UTF8 编码，更美观)",
         "oldEpubReader": "Epub Reader（旧版）",
@@ -771,7 +782,14 @@
         "trashClearConfirm": "确认清理回收站和上传临时目录？此操作不可逆！",
         "upToDate": "已是最新版本",
         "updateAvailable": "发现新版本 {version}，请及时更新以获取最新功能和安全修复",
-        "checkError": "检查更新失败"
+        "checkError": "检查更新失败",
+        "dbInfo": "Talebook 自身数据（用户、书架、配置等）支持迁移至 MySQL/MariaDB，Calibre 书籍元数据仍保持使用 SQLite。迁移完成后需重启服务器生效。",
+        "dbMigrateWarning": "迁移将把当前数据库所有数据复制到新数据库，完成后需要重启服务器。操作不可逆，请提前备份！",
+        "dbMigrateConfirmTitle": "确认迁移数据库？",
+        "dbMigrateSuccess": "数据迁移成功，请重启服务器以生效",
+        "dbConnectSuccess": "数据库连接成功",
+        "currentDb": "当前数据库",
+        "newDbConfig": "迁移到新数据库"
       },
       "meta_source": {
         "douban": "豆瓣",
@@ -871,7 +889,19 @@
     "writingConfig": "正在写入配置文件...",
     "configWriteSuccess": "配置写入成功！",
     "checkingServer": "正在检测服务器...",
-    "networkError": "网络错误"
+    "networkError": "网络错误",
+    "dbConfig": "数据库配置",
+    "dbType": "数据库类型",
+    "dbTypeSqlite": "SQLite（默认，适合个人使用）",
+    "dbTypeMysql": "MySQL / MariaDB（适合高并发）",
+    "dbHost": "数据库主机",
+    "dbPort": "端口",
+    "dbName": "数据库名",
+    "dbUser": "数据库用户名",
+    "dbPass": "数据库密码",
+    "testConnection": "测试连接",
+    "dbConnectSuccess": "数据库连接成功",
+    "dbConnectFailed": "数据库连接失败"
   },
   "settings": {
     "deviceMgt": "全局设备管理",

--- a/app/i18n/locales/zh-CN.json
+++ b/app/i18n/locales/zh-CN.json
@@ -683,7 +683,8 @@
         "checkUpdate": "检查更新",
         "viewRelease": "查看发布",
         "testDbConnection": "测试连接",
-        "migrateDb": "迁移数据库"
+        "migrateDb": "迁移数据库",
+        "forceMigrateDb": "强制迁移"
       },
       "label": {
         "siteTitle": "网站标题",
@@ -790,7 +791,9 @@
         "dbMigrateSuccess": "数据迁移成功，请重启服务器以生效",
         "dbConnectSuccess": "数据库连接成功",
         "currentDb": "当前数据库",
-        "newDbConfig": "迁移到新数据库"
+        "newDbConfig": "迁移到新数据库",
+        "dbForceTitle": "目标数据库已有数据，确认强制迁移？",
+        "dbForceWarning": "目标数据库中已存在 {count} 条记录，强制迁移将永久清空这些数据后再写入。操作不可逆，请确认已备份！"
       },
       "meta_source": {
         "douban": "豆瓣",

--- a/app/pages/admin/settings.vue
+++ b/app/pages/admin/settings.vue
@@ -635,7 +635,19 @@
                 <v-card-actions>
                     <v-spacer />
                     <v-btn text @click="dbMigrateDialog = false">{{ t('common.cancel') }}</v-btn>
-                    <v-btn color="warning" dark @click="migrateDb">{{ t('admin.settings.button.migrateDb') }}</v-btn>
+                    <v-btn color="warning" dark @click="migrateDb(false)">{{ t('admin.settings.button.migrateDb') }}</v-btn>
+                </v-card-actions>
+            </v-card>
+        </v-dialog>
+
+        <v-dialog v-model="dbForceDialog" max-width="480" persistent>
+            <v-card>
+                <v-card-title>{{ t('admin.settings.message.dbForceTitle') }}</v-card-title>
+                <v-card-text>{{ t('admin.settings.message.dbForceWarning', { count: dbTargetDataCount }) }}</v-card-text>
+                <v-card-actions>
+                    <v-spacer />
+                    <v-btn text @click="dbForceDialog = false">{{ t('common.cancel') }}</v-btn>
+                    <v-btn color="error" dark @click="forceMigrateDb">{{ t('admin.settings.button.forceMigrateDb') }}</v-btn>
                 </v-card-actions>
             </v-card>
         </v-dialog>
@@ -714,6 +726,8 @@ const dbNewPass = ref('');
 const dbTesting = ref(false);
 const dbMigrating = ref(false);
 const dbMigrateDialog = ref(false);
+const dbForceDialog = ref(false);
+const dbTargetDataCount = ref(0);
 const dbTypeOptions = computed(() => [
     { text: t('admin.settings.option.dbSqlite'), value: 'sqlite' },
     { text: t('admin.settings.option.dbMysql'), value: 'mysql' },
@@ -1075,7 +1089,7 @@ const testDbConnection = () => {
         .finally(() => { dbTesting.value = false; });
 };
 
-const migrateDb = () => {
+const migrateDb = (force = false) => {
     dbMigrateDialog.value = false;
     dbMigrating.value = true;
     var data = new URLSearchParams();
@@ -1085,16 +1099,25 @@ const migrateDb = () => {
     data.append('db_name', dbNewName.value);
     data.append('db_user', dbNewUser.value);
     data.append('db_pass', dbNewPass.value);
+    if (force) data.append('force', '1');
     $backend('/admin/migratedb', { method: 'POST', body: data })
         .then(rsp => {
             if (rsp.err === 'ok') {
                 if ($alert) $alert('success', t('admin.settings.message.dbMigrateSuccess'));
                 settings.value.user_database = `mysql+pymysql://${dbNewUser.value}:***@${dbNewHost.value}:${dbNewPort.value}/${dbNewName.value}`;
+            } else if (rsp.err === 'db.target_has_data') {
+                dbTargetDataCount.value = rsp.count || 0;
+                dbForceDialog.value = true;
             } else {
                 if ($alert) $alert('error', rsp.msg);
             }
         })
         .finally(() => { dbMigrating.value = false; });
+};
+
+const forceMigrateDb = () => {
+    dbForceDialog.value = false;
+    migrateDb(true);
 };
 
 const fetchTrashSize = () => {

--- a/app/pages/admin/settings.vue
+++ b/app/pages/admin/settings.vue
@@ -733,6 +733,12 @@ const dbTypeOptions = computed(() => [
     { text: t('admin.settings.option.dbMysql'), value: 'mysql' },
 ]);
 
+const buildUserDatabaseUrl = () => {
+    const user = encodeURIComponent(dbNewUser.value);
+    const pass = encodeURIComponent(dbNewPass.value);
+    return `mysql+pymysql://${user}:${pass}@${dbNewHost.value}:${dbNewPort.value}/${dbNewName.value}?charset=utf8mb4`;
+};
+
 // 人机验证提供商选项
 const captchaProviders = [
     { text: t('admin.settings.option.none'), value: '' },
@@ -1072,12 +1078,7 @@ const run = (func) => {
 const testDbConnection = () => {
     dbTesting.value = true;
     var data = new URLSearchParams();
-    data.append('db_type', dbNewType.value);
-    data.append('db_host', dbNewHost.value);
-    data.append('db_port', dbNewPort.value);
-    data.append('db_name', dbNewName.value);
-    data.append('db_user', dbNewUser.value);
-    data.append('db_pass', dbNewPass.value);
+    data.append('user_database', buildUserDatabaseUrl());
     $backend('/admin/testdb', { method: 'POST', body: data })
         .then(rsp => {
             if (rsp.err === 'ok') {
@@ -1093,18 +1094,13 @@ const migrateDb = (force = false) => {
     dbMigrateDialog.value = false;
     dbMigrating.value = true;
     var data = new URLSearchParams();
-    data.append('db_type', dbNewType.value);
-    data.append('db_host', dbNewHost.value);
-    data.append('db_port', dbNewPort.value);
-    data.append('db_name', dbNewName.value);
-    data.append('db_user', dbNewUser.value);
-    data.append('db_pass', dbNewPass.value);
+    data.append('user_database', buildUserDatabaseUrl());
     if (force) data.append('force', '1');
     $backend('/admin/migratedb', { method: 'POST', body: data })
         .then(rsp => {
             if (rsp.err === 'ok') {
                 if ($alert) $alert('success', t('admin.settings.message.dbMigrateSuccess'));
-                settings.value.user_database = `mysql+pymysql://${dbNewUser.value}:***@${dbNewHost.value}:${dbNewPort.value}/${dbNewName.value}`;
+                settings.value.user_database = buildUserDatabaseUrl().replace(`:${encodeURIComponent(dbNewPass.value)}@`, ':***@');
             } else if (rsp.err === 'db.target_has_data') {
                 dbTargetDataCount.value = rsp.count || 0;
                 dbForceDialog.value = true;

--- a/app/pages/admin/settings.vue
+++ b/app/pages/admin/settings.vue
@@ -429,6 +429,98 @@
                             </div>
                         </template>
 
+                        <template v-if="card.show_db">
+                            <div class="pa-2">
+                                <p class="text-body-2 text-medium-emphasis mb-4">
+                                    {{ t('admin.settings.message.dbInfo') }}
+                                </p>
+                                <div class="mb-4">
+                                    <span class="text-subtitle-2 font-weight-medium">{{ t('admin.settings.message.currentDb') }}:</span>
+                                    <v-chip
+                                        size="small"
+                                        class="ml-2"
+                                        color="primary"
+                                    >
+                                        {{ settings.user_database && settings.user_database.startsWith('sqlite') ? t('admin.settings.option.dbSqlite') : t('admin.settings.option.dbMysql') }}
+                                    </v-chip>
+                                </div>
+                                <p class="text-subtitle-2 font-weight-medium mb-2">
+                                    {{ t('admin.settings.message.newDbConfig') }}
+                                </p>
+                                <v-select
+                                    v-model="dbNewType"
+                                    prepend-icon="mdi-database"
+                                    :label="t('admin.settings.label.dbType')"
+                                    :items="dbTypeOptions"
+                                    item-title="text"
+                                    item-value="value"
+                                    hide-details
+                                    class="mb-4"
+                                />
+                                <template v-if="dbNewType === 'mysql'">
+                                    <v-row dense>
+                                        <v-col cols="9">
+                                            <v-text-field
+                                                v-model="dbNewHost"
+                                                prepend-icon="mdi-server"
+                                                :label="t('admin.settings.label.dbHost')"
+                                                density="compact"
+                                                hide-details
+                                            />
+                                        </v-col>
+                                        <v-col cols="3">
+                                            <v-text-field
+                                                v-model.number="dbNewPort"
+                                                :label="t('admin.settings.label.dbPort')"
+                                                type="number"
+                                                density="compact"
+                                                hide-details
+                                            />
+                                        </v-col>
+                                    </v-row>
+                                    <v-text-field
+                                        v-model="dbNewName"
+                                        prepend-icon="mdi-database"
+                                        :label="t('admin.settings.label.dbName')"
+                                        density="compact"
+                                        class="mt-2"
+                                    />
+                                    <v-text-field
+                                        v-model="dbNewUser"
+                                        prepend-icon="mdi-account"
+                                        :label="t('admin.settings.label.dbUser')"
+                                        density="compact"
+                                    />
+                                    <v-text-field
+                                        v-model="dbNewPass"
+                                        prepend-icon="mdi-lock"
+                                        :label="t('admin.settings.label.dbPass')"
+                                        type="password"
+                                        density="compact"
+                                    />
+                                    <div class="mt-2 d-flex gap-2">
+                                        <v-btn
+                                            variant="outlined"
+                                            :loading="dbTesting"
+                                            class="mr-2"
+                                            @click="testDbConnection"
+                                        >
+                                            <v-icon start>mdi-connection</v-icon>
+                                            {{ t('admin.settings.button.testDbConnection') }}
+                                        </v-btn>
+                                        <v-btn
+                                            color="warning"
+                                            :loading="dbMigrating"
+                                            @click="dbMigrateDialog = true"
+                                        >
+                                            <v-icon start>mdi-database-arrow-right</v-icon>
+                                            {{ t('admin.settings.button.migrateDb') }}
+                                        </v-btn>
+                                    </div>
+                                </template>
+                            </div>
+                        </template>
+
                         <template v-if="card.show_ssl">
                             <SSLManager />
                         </template>
@@ -535,6 +627,18 @@
                 </v-card-actions>
             </v-card>
         </v-dialog>
+
+        <v-dialog v-model="dbMigrateDialog" max-width="440" persistent>
+            <v-card>
+                <v-card-title>{{ t('admin.settings.message.dbMigrateConfirmTitle') }}</v-card-title>
+                <v-card-text>{{ t('admin.settings.message.dbMigrateWarning') }}</v-card-text>
+                <v-card-actions>
+                    <v-spacer />
+                    <v-btn text @click="dbMigrateDialog = false">{{ t('common.cancel') }}</v-btn>
+                    <v-btn color="warning" dark @click="migrateDb">{{ t('admin.settings.button.migrateDb') }}</v-btn>
+                </v-card-actions>
+            </v-card>
+        </v-dialog>
     </div>
 </template>
 
@@ -597,7 +701,23 @@ const cardShows = ref({
     captchaSettings: false,
     trashManagement: false,
     updateCheck: false,
+    databaseManagement: false,
 });
+
+// Database management state
+const dbNewType = ref('mysql');
+const dbNewHost = ref('localhost');
+const dbNewPort = ref(3306);
+const dbNewName = ref('talebook');
+const dbNewUser = ref('');
+const dbNewPass = ref('');
+const dbTesting = ref(false);
+const dbMigrating = ref(false);
+const dbMigrateDialog = ref(false);
+const dbTypeOptions = computed(() => [
+    { text: t('admin.settings.option.dbSqlite'), value: 'sqlite' },
+    { text: t('admin.settings.option.dbMysql'), value: 'mysql' },
+]);
 
 // 人机验证提供商选项
 const captchaProviders = [
@@ -816,6 +936,12 @@ const cards = computed(() => [
     },
 
     {
+        key: 'databaseManagement',
+        title: t('admin.settings.section.databaseManagement'),
+        fields: [],
+        show_db: true,
+    },
+    {
         key: 'sslManagement',
         title: t('admin.settings.section.sslManagement'),
         fields: [],
@@ -927,6 +1053,48 @@ const test_email = () => {
 
 const run = (func) => {
     if (func === 'test_email') test_email();
+};
+
+const testDbConnection = () => {
+    dbTesting.value = true;
+    var data = new URLSearchParams();
+    data.append('db_type', dbNewType.value);
+    data.append('db_host', dbNewHost.value);
+    data.append('db_port', dbNewPort.value);
+    data.append('db_name', dbNewName.value);
+    data.append('db_user', dbNewUser.value);
+    data.append('db_pass', dbNewPass.value);
+    $backend('/admin/testdb', { method: 'POST', body: data })
+        .then(rsp => {
+            if (rsp.err === 'ok') {
+                if ($alert) $alert('success', t('admin.settings.message.dbConnectSuccess'));
+            } else {
+                if ($alert) $alert('error', rsp.msg);
+            }
+        })
+        .finally(() => { dbTesting.value = false; });
+};
+
+const migrateDb = () => {
+    dbMigrateDialog.value = false;
+    dbMigrating.value = true;
+    var data = new URLSearchParams();
+    data.append('db_type', dbNewType.value);
+    data.append('db_host', dbNewHost.value);
+    data.append('db_port', dbNewPort.value);
+    data.append('db_name', dbNewName.value);
+    data.append('db_user', dbNewUser.value);
+    data.append('db_pass', dbNewPass.value);
+    $backend('/admin/migratedb', { method: 'POST', body: data })
+        .then(rsp => {
+            if (rsp.err === 'ok') {
+                if ($alert) $alert('success', t('admin.settings.message.dbMigrateSuccess'));
+                settings.value.user_database = `mysql+pymysql://${dbNewUser.value}:***@${dbNewHost.value}:${dbNewPort.value}/${dbNewName.value}`;
+            } else {
+                if ($alert) $alert('error', rsp.msg);
+            }
+        })
+        .finally(() => { dbMigrating.value = false; });
 };
 
 const fetchTrashSize = () => {

--- a/app/pages/install.vue
+++ b/app/pages/install.vue
@@ -240,6 +240,13 @@ const dbTypeItems = computed(() => [
     { text: t('install.dbTypeMysql'), value: 'mysql' },
 ]);
 
+const buildUserDatabaseUrl = () => {
+    if (db_type.value === 'sqlite') return 'sqlite:////data/books/calibre-webserver.db';
+    const user = encodeURIComponent(db_user.value);
+    const pass = encodeURIComponent(db_pass.value);
+    return `mysql+pymysql://${user}:${pass}@${db_host.value}:${db_port.value}/${db_name.value}?charset=utf8mb4`;
+};
+
 const rules = {
     user: v => ( v && 20 >= v.length && v.length >= 5) || $t('install.userRule'),
     pass: v => ( v && 20 >= v.length && v.length >= 8) || $t('install.passRule'),
@@ -280,12 +287,7 @@ const check_install = () => {
 const testDbConnection = async () => {
     dbTesting.value = true;
     var data = new URLSearchParams();
-    data.append('db_type', db_type.value);
-    data.append('db_host', db_host.value);
-    data.append('db_port', db_port.value);
-    data.append('db_name', db_name.value);
-    data.append('db_user', db_user.value);
-    data.append('db_pass', db_pass.value);
+    data.append('user_database', buildUserDatabaseUrl());
     try {
         const rsp = await $backend('/admin/testdb', { method: 'POST', body: data });
         if (rsp.err === 'ok') {
@@ -312,14 +314,7 @@ const do_install = async () => {
     data.append('code', code.value);
     data.append('invite', invite.value);
     data.append('title', title.value);
-    data.append('db_type', db_type.value);
-    if (db_type.value !== 'sqlite') {
-        data.append('db_host', db_host.value);
-        data.append('db_port', db_port.value);
-        data.append('db_name', db_name.value);
-        data.append('db_user', db_user.value);
-        data.append('db_pass', db_pass.value);
-    }
+    data.append('user_database', buildUserDatabaseUrl());
 
     tips.value = $t('install.writingConfig');
 

--- a/app/pages/install.vue
+++ b/app/pages/install.vue
@@ -106,6 +106,71 @@
                                     :rules="[rules.code]"
                                 />
                             </template>
+
+                            <v-divider class="my-4" />
+                            <div class="text-subtitle-2 mb-2">
+                                {{ $t('install.dbConfig') }}
+                            </div>
+                            <v-select
+                                v-model="db_type"
+                                prepend-icon="mdi-database"
+                                :label="$t('install.dbType')"
+                                :items="dbTypeItems"
+                                item-title="text"
+                                item-value="value"
+                                hide-details
+                                class="mb-4"
+                            />
+                            <template v-if="db_type !== 'sqlite'">
+                                <v-row dense>
+                                    <v-col cols="9">
+                                        <v-text-field
+                                            v-model="db_host"
+                                            prepend-icon="mdi-server"
+                                            :label="$t('install.dbHost')"
+                                            type="text"
+                                        />
+                                    </v-col>
+                                    <v-col cols="3">
+                                        <v-text-field
+                                            v-model="db_port"
+                                            :label="$t('install.dbPort')"
+                                            type="number"
+                                        />
+                                    </v-col>
+                                </v-row>
+                                <v-text-field
+                                    v-model="db_name"
+                                    prepend-icon="mdi-database"
+                                    :label="$t('install.dbName')"
+                                    type="text"
+                                />
+                                <v-text-field
+                                    v-model="db_user"
+                                    prepend-icon="mdi-account"
+                                    :label="$t('install.dbUser')"
+                                    type="text"
+                                    autocomplete="off"
+                                />
+                                <v-text-field
+                                    v-model="db_pass"
+                                    prepend-icon="mdi-lock"
+                                    :label="$t('install.dbPass')"
+                                    type="password"
+                                    autocomplete="new-password"
+                                />
+                                <div class="mb-4">
+                                    <v-btn
+                                        variant="outlined"
+                                        :loading="dbTesting"
+                                        @click="testDbConnection"
+                                    >
+                                        <v-icon start>mdi-connection</v-icon>
+                                        {{ $t('install.testConnection') }}
+                                    </v-btn>
+                                </div>
+                            </template>
+
                             <div
                                 align="center"
                                 class="mt-4"
@@ -141,7 +206,7 @@ import { useI18n } from '#i18n';
 const router = useRouter();
 const store = useMainStore();
 const { $backend, $alert } = useNuxtApp();
-const { locale, locales, setLocale } = useI18n();
+const { locale, locales, setLocale, t } = useI18n();
 
 // 多语言相关
 const allLocales = computed(() => {
@@ -161,7 +226,19 @@ const invite = ref(false);
 const title = ref('TaleBook');
 const tips = ref('');
 const loading = ref(false);
+const dbTesting = ref(false);
+const db_type = ref('sqlite');
+const db_host = ref('localhost');
+const db_port = ref(3306);
+const db_name = ref('talebook');
+const db_user = ref('');
+const db_pass = ref('');
 let retry = 20;
+
+const dbTypeItems = computed(() => [
+    { text: t('install.dbTypeSqlite'), value: 'sqlite' },
+    { text: t('install.dbTypeMysql'), value: 'mysql' },
+]);
 
 const rules = {
     user: v => ( v && 20 >= v.length && v.length >= 5) || $t('install.userRule'),
@@ -200,6 +277,29 @@ const check_install = () => {
     });
 };
 
+const testDbConnection = async () => {
+    dbTesting.value = true;
+    var data = new URLSearchParams();
+    data.append('db_type', db_type.value);
+    data.append('db_host', db_host.value);
+    data.append('db_port', db_port.value);
+    data.append('db_name', db_name.value);
+    data.append('db_user', db_user.value);
+    data.append('db_pass', db_pass.value);
+    try {
+        const rsp = await $backend('/admin/testdb', { method: 'POST', body: data });
+        if (rsp.err === 'ok') {
+            if ($alert) $alert('success', $t('install.dbConnectSuccess'));
+        } else {
+            if ($alert) $alert('error', rsp.msg || $t('install.dbConnectFailed'));
+        }
+    } catch (e) {
+        if ($alert) $alert('error', $t('install.networkError'));
+    } finally {
+        dbTesting.value = false;
+    }
+};
+
 const do_install = async () => {
     const { valid } = await form.value.validate();
     if (!valid) return;
@@ -212,15 +312,23 @@ const do_install = async () => {
     data.append('code', code.value);
     data.append('invite', invite.value);
     data.append('title', title.value);
-    
+    data.append('db_type', db_type.value);
+    if (db_type.value !== 'sqlite') {
+        data.append('db_host', db_host.value);
+        data.append('db_port', db_port.value);
+        data.append('db_name', db_name.value);
+        data.append('db_user', db_user.value);
+        data.append('db_pass', db_pass.value);
+    }
+
     tips.value = $t('install.writingConfig');
-    
+
     try {
         const rsp = await $backend('/admin/install', {
             method: 'POST',
             body: data,
         });
-        
+
         if ( rsp.err != 'ok' ) {
             if ($alert) $alert('error', rsp.msg);
             loading.value = false;

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -123,6 +123,21 @@ class TestAdminTestDB(TestWithAdminUser):
         d = self.json("/api/admin/testdb", method="POST", body=body)
         self.assertEqual(d["err"], "db.connect_failed")
 
+    def test_invalid_port_rejected(self):
+        """端口号超出范围时返回 params.invalid"""
+        body = urllib.parse.urlencode(
+            {
+                "db_type": "mysql",
+                "db_host": "localhost",
+                "db_port": "0",
+                "db_name": "testdb",
+                "db_user": "root",
+                "db_pass": "pass",
+            }
+        )
+        d = self.json("/api/admin/testdb", method="POST", body=body)
+        self.assertEqual(d["err"], "params.invalid")
+
     def test_requires_admin_after_install(self):
         """安装后非管理员无法访问"""
         from webserver import models
@@ -201,6 +216,86 @@ class TestAdminMigrateDB(TestWithAdminUser):
                 self.assertTrue(d.get("need_restart"))
         finally:
             # restore original db url in CONF
+            main.CONF["user_database"] = original_db_url
+            loader.get_settings()["user_database"] = original_db_url
+
+    def test_invalid_port_rejected(self):
+        """端口号超出范围时返回 params.invalid"""
+        body = urllib.parse.urlencode(
+            {
+                "db_type": "mysql",
+                "db_host": "localhost",
+                "db_port": "99999",
+                "db_name": "testdb",
+                "db_user": "root",
+                "db_pass": "pass",
+            }
+        )
+        d = self.json("/api/admin/migratedb", method="POST", body=body)
+        self.assertEqual(d["err"], "params.invalid")
+
+    def test_target_has_data_warning(self):
+        """目标库有数据且不带 force 时，返回 db.target_has_data 警告"""
+        import tempfile
+
+        from webserver import loader, main
+        from webserver.migrate_db import TargetNotEmptyError
+
+        original_db_url = main.CONF["user_database"]
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+
+                def fake_migrate_nonempty(source_url, target_url, force=False):
+                    raise TargetNotEmptyError(42)
+
+                with mock.patch("webserver.migrate_db.migrate_data", side_effect=fake_migrate_nonempty):
+                    with mock.patch("webserver.loader.SettingsLoader.set_store_path", return_value=tmpdir):
+                        body = urllib.parse.urlencode(
+                            {
+                                "db_type": "mysql",
+                                "db_host": "localhost",
+                                "db_port": "3306",
+                                "db_name": "testdb",
+                                "db_user": "root",
+                                "db_pass": "pass",
+                            }
+                        )
+                        d = self.json("/api/admin/migratedb", method="POST", body=body)
+                self.assertEqual(d["err"], "db.target_has_data")
+                self.assertEqual(d["count"], 42)
+        finally:
+            main.CONF["user_database"] = original_db_url
+            loader.get_settings()["user_database"] = original_db_url
+
+    def test_target_has_data_force_succeeds(self):
+        """目标库有数据且带 force=1 时，迁移正常完成"""
+        import tempfile
+
+        from webserver import loader, main
+
+        original_db_url = main.CONF["user_database"]
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+
+                def fake_migrate(source_url, target_url, force=False):
+                    pass
+
+                with mock.patch("webserver.migrate_db.migrate_data", side_effect=fake_migrate):
+                    with mock.patch("webserver.loader.SettingsLoader.set_store_path", return_value=tmpdir):
+                        body = urllib.parse.urlencode(
+                            {
+                                "db_type": "mysql",
+                                "db_host": "localhost",
+                                "db_port": "3306",
+                                "db_name": "testdb",
+                                "db_user": "root",
+                                "db_pass": "pass",
+                                "force": "1",
+                            }
+                        )
+                        d = self.json("/api/admin/migratedb", method="POST", body=body)
+                self.assertEqual(d["err"], "ok")
+        finally:
             main.CONF["user_database"] = original_db_url
             loader.get_settings()["user_database"] = original_db_url
 

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -220,3 +220,58 @@ class TestAdminMigrateDB(TestWithAdminUser):
         finally:
             user.admin = original_admin
             session.commit()
+
+
+class TestAdminSystemLog(TestWithAdminUser):
+    def test_log_returns_ok_when_file_missing(self):
+        """日志文件不存在时，接口应返回 ok 且 lines 为空列表"""
+        with mock.patch("webserver.handlers.admin._get_log_file", return_value="/nonexistent/talebook.log"):
+            d = self.json("/api/admin/log")
+        self.assertEqual(d["err"], "ok")
+        self.assertEqual(d["lines"], [])
+
+    def test_log_returns_lines_from_file(self):
+        """日志文件存在时，接口应返回对应行数"""
+        log_content = "\n".join(["line %d" % i for i in range(10)])
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".log", delete=False) as f:
+            f.write(log_content)
+            log_path = f.name
+        try:
+            with mock.patch("webserver.handlers.admin._get_log_file", return_value=log_path):
+                d = self.json("/api/admin/log?lines=5")
+            self.assertEqual(d["err"], "ok")
+            self.assertEqual(len(d["lines"]), 5)
+            self.assertEqual(d["total"], 10)
+        finally:
+            os.unlink(log_path)
+
+    def test_log_download_returns_file(self):
+        """下载接口应以附件形式返回日志文件内容"""
+        log_content = "test log line\n"
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".log", delete=False) as f:
+            f.write(log_content)
+            log_path = f.name
+        try:
+            with mock.patch("webserver.handlers.admin._get_log_file", return_value=log_path):
+                rsp = self.fetch("/api/admin/log/download")
+            self.assertEqual(rsp.code, 200)
+            self.assertIn(b"test log line", rsp.body)
+            self.assertIn("attachment", rsp.headers.get("Content-Disposition", ""))
+        finally:
+            os.unlink(log_path)
+
+    def test_log_permission_denied_for_non_admin(self):
+        """普通用户不能访问系统日志"""
+        from webserver import models
+
+        session = get_db()
+        user = session.query(models.Reader).filter(models.Reader.id == 1).first()
+        original_admin = user.admin
+        user.admin = False
+        session.commit()
+        try:
+            d = self.json("/api/admin/log")
+            self.assertNotEqual(d["err"], "ok")
+        finally:
+            user.admin = original_admin
+            session.commit()

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -196,7 +196,7 @@ class TestAdminMigrateDB(TestWithAdminUser):
         try:
             with tempfile.TemporaryDirectory() as tmpdir:
 
-                def fake_migrate(source_url, target_url):
+                def fake_migrate(source_url, target_url, force=False):
                     pass
 
                 with mock.patch("webserver.migrate_db.migrate_data", side_effect=fake_migrate):

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -203,17 +203,15 @@ class TestAdminMigrateDB(TestWithAdminUser):
                     with mock.patch("webserver.loader.SettingsLoader.set_store_path", return_value=tmpdir):
                         body = urllib.parse.urlencode(
                             {
-                                "db_type": "mysql",
-                                "db_host": "localhost",
-                                "db_port": "3306",
-                                "db_name": "testdb",
-                                "db_user": "root",
-                                "db_pass": "pass",
+                                "user_database": "mysql+pymysql://root:pass@localhost:3306/testdb?charset=utf8mb4",
                             }
                         )
                         d = self.json("/api/admin/migratedb", method="POST", body=body)
                 self.assertEqual(d["err"], "ok")
                 self.assertTrue(d.get("need_restart"))
+                self.assertEqual(
+                    main.CONF["user_database"], "mysql+pymysql://root:pass@localhost:3306/testdb?charset=utf8mb4"
+                )
         finally:
             # restore original db url in CONF
             main.CONF["user_database"] = original_db_url
@@ -252,12 +250,7 @@ class TestAdminMigrateDB(TestWithAdminUser):
                     with mock.patch("webserver.loader.SettingsLoader.set_store_path", return_value=tmpdir):
                         body = urllib.parse.urlencode(
                             {
-                                "db_type": "mysql",
-                                "db_host": "localhost",
-                                "db_port": "3306",
-                                "db_name": "testdb",
-                                "db_user": "root",
-                                "db_pass": "pass",
+                                "user_database": "mysql+pymysql://root:pass@localhost:3306/testdb?charset=utf8mb4",
                             }
                         )
                         d = self.json("/api/admin/migratedb", method="POST", body=body)
@@ -284,12 +277,7 @@ class TestAdminMigrateDB(TestWithAdminUser):
                     with mock.patch("webserver.loader.SettingsLoader.set_store_path", return_value=tmpdir):
                         body = urllib.parse.urlencode(
                             {
-                                "db_type": "mysql",
-                                "db_host": "localhost",
-                                "db_port": "3306",
-                                "db_name": "testdb",
-                                "db_user": "root",
-                                "db_pass": "pass",
+                                "user_database": "mysql+pymysql://root:pass@localhost:3306/testdb?charset=utf8mb4",
                                 "force": "1",
                             }
                         )

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -4,6 +4,7 @@
 import json
 import os
 import tempfile
+import urllib.parse
 from unittest import mock
 
 from tests.test_main import TestWithAdminUser, TestWithUserLogin, get_db
@@ -90,3 +91,132 @@ class TestAdminSettingsSecurity(TestWithAdminUser):
             exec(compile(code, path, "exec"), namespace)
 
         self.assertEqual(namespace["settings"][key], "value")
+
+
+class TestAdminTestDB(TestWithAdminUser):
+    """AdminTestDB 接口测试"""
+
+    def test_sqlite_always_ok(self):
+        """SQLite 类型直接返回 ok"""
+        body = urllib.parse.urlencode({"db_type": "sqlite"})
+        d = self.json("/api/admin/testdb", method="POST", body=body)
+        self.assertEqual(d["err"], "ok")
+
+    def test_mysql_missing_params(self):
+        """缺少必填参数时返回 params.invalid"""
+        body = urllib.parse.urlencode({"db_type": "mysql", "db_host": "localhost"})
+        d = self.json("/api/admin/testdb", method="POST", body=body)
+        self.assertEqual(d["err"], "params.invalid")
+
+    def test_mysql_connect_failed(self):
+        """MySQL 连接失败时返回 db.connect_failed"""
+        body = urllib.parse.urlencode(
+            {
+                "db_type": "mysql",
+                "db_host": "127.0.0.1",
+                "db_port": "3306",
+                "db_name": "nonexistent_db",
+                "db_user": "bad_user",
+                "db_pass": "bad_pass",
+            }
+        )
+        d = self.json("/api/admin/testdb", method="POST", body=body)
+        self.assertEqual(d["err"], "db.connect_failed")
+
+    def test_requires_admin_after_install(self):
+        """安装后非管理员无法访问"""
+        from webserver import models
+
+        session = get_db()
+        user = session.query(models.Reader).filter(models.Reader.id == 1).first()
+        original_admin = user.admin
+        user.admin = False
+        session.commit()
+        try:
+            body = urllib.parse.urlencode({"db_type": "sqlite"})
+            d = self.json("/api/admin/testdb", method="POST", body=body)
+            self.assertEqual(d["err"], "permission")
+        finally:
+            user.admin = original_admin
+            session.commit()
+
+
+class TestAdminMigrateDB(TestWithAdminUser):
+    """AdminMigrateDB 接口测试"""
+
+    def test_sqlite_target_rejected(self):
+        """目标类型为 sqlite 时返回 params.invalid"""
+        body = urllib.parse.urlencode({"db_type": "sqlite"})
+        d = self.json("/api/admin/migratedb", method="POST", body=body)
+        self.assertEqual(d["err"], "params.invalid")
+
+    def test_missing_params_rejected(self):
+        """缺少必填参数时返回 params.invalid"""
+        body = urllib.parse.urlencode({"db_type": "mysql", "db_host": "localhost"})
+        d = self.json("/api/admin/migratedb", method="POST", body=body)
+        self.assertEqual(d["err"], "params.invalid")
+
+    def test_bad_connection_returns_error(self):
+        """无法连接的 MySQL 返回 db.migrate_failed 或 db.connect_failed 类错误"""
+        body = urllib.parse.urlencode(
+            {
+                "db_type": "mysql",
+                "db_host": "127.0.0.1",
+                "db_port": "3306",
+                "db_name": "nonexistent_db",
+                "db_user": "bad_user",
+                "db_pass": "bad_pass",
+            }
+        )
+        d = self.json("/api/admin/migratedb", method="POST", body=body)
+        self.assertIn(d["err"], ("db.migrate_failed",))
+
+    def test_migrate_success_via_mock(self):
+        """使用 mock 测试迁移逻辑: 迁移成功时返回 ok 并写入 user_database 配置"""
+        import tempfile
+
+        from webserver import loader, main
+
+        original_db_url = main.CONF["user_database"]
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+
+                def fake_migrate(source_url, target_url):
+                    pass
+
+                with mock.patch("webserver.migrate_db.migrate_data", side_effect=fake_migrate):
+                    with mock.patch("webserver.loader.SettingsLoader.set_store_path", return_value=tmpdir):
+                        body = urllib.parse.urlencode(
+                            {
+                                "db_type": "mysql",
+                                "db_host": "localhost",
+                                "db_port": "3306",
+                                "db_name": "testdb",
+                                "db_user": "root",
+                                "db_pass": "pass",
+                            }
+                        )
+                        d = self.json("/api/admin/migratedb", method="POST", body=body)
+                self.assertEqual(d["err"], "ok")
+                self.assertTrue(d.get("need_restart"))
+        finally:
+            # restore original db url in CONF
+            main.CONF["user_database"] = original_db_url
+            loader.get_settings()["user_database"] = original_db_url
+
+    def test_requires_admin(self):
+        """非管理员无法访问"""
+        from webserver import models
+
+        session = get_db()
+        user = session.query(models.Reader).filter(models.Reader.id == 1).first()
+        original_admin = user.admin
+        user.admin = False
+        session.commit()
+        try:
+            body = urllib.parse.urlencode({"db_type": "mysql"})
+            d = self.json("/api/admin/migratedb", method="POST", body=body)
+            self.assertEqual(d["err"], "permission")
+        finally:
+            user.admin = original_admin
+            session.commit()

--- a/webserver/handlers/admin.py
+++ b/webserver/handlers/admin.py
@@ -449,6 +449,8 @@ class AdminTestDB(BaseHandler):
             db_port = int(db_port)
         except ValueError:
             return {"err": "params.invalid", "msg": _("端口号无效")}
+        if not (1 <= db_port <= 65535):
+            return {"err": "params.invalid", "msg": _("端口号范围无效，应在 1-65535 之间")}
 
         db_url = _build_mysql_url(db_host, db_port, db_name, db_user, db_pass)
         try:
@@ -490,6 +492,10 @@ class AdminMigrateDB(BaseHandler):
             db_port = int(db_port)
         except ValueError:
             return {"err": "params.invalid", "msg": _("端口号无效")}
+        if not (1 <= db_port <= 65535):
+            return {"err": "params.invalid", "msg": _("端口号范围无效，应在 1-65535 之间")}
+
+        force = self.get_argument("force", "0").strip() == "1"
 
         new_db_url = _build_mysql_url(db_host, db_port, db_name, db_user, db_pass)
         source_url = CONF["user_database"]
@@ -498,9 +504,15 @@ class AdminMigrateDB(BaseHandler):
             return {"err": "params.invalid", "msg": _("目标数据库与当前数据库相同")}
 
         try:
-            from webserver.migrate_db import migrate_data
+            from webserver.migrate_db import TargetNotEmptyError, migrate_data
 
-            migrate_data(source_url, new_db_url)
+            migrate_data(source_url, new_db_url, force=force)
+        except TargetNotEmptyError as e:
+            return {
+                "err": "db.target_has_data",
+                "count": e.count,
+                "msg": _("目标数据库已有 %d 条记录，继续迁移将清空这些数据。如需强制迁移，请再次确认。") % e.count,
+            }
         except Exception as e:
             logging.error(traceback.format_exc())
             return {"err": "db.migrate_failed", "msg": _("数据迁移失败: %s") % str(e)}
@@ -570,6 +582,8 @@ class AdminInstall(BaseHandler):
                 db_port = int(db_port)
             except ValueError:
                 return {"err": "params.invalid", "msg": _("端口号无效")}
+            if not (1 <= db_port <= 65535):
+                return {"err": "params.invalid", "msg": _("端口号范围无效，应在 1-65535 之间")}
 
             target_db_url = _build_mysql_url(db_host, db_port, db_name, db_user, db_pass)
             try:

--- a/webserver/handlers/admin.py
+++ b/webserver/handlers/admin.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
 
+import collections
 import datetime
 import hashlib
 import logging
+import os
 import re
 import ssl
 import subprocess
@@ -12,6 +14,7 @@ import traceback
 import uuid
 
 import tornado
+from tornado.options import options as tornado_options
 
 from webserver import loader, utils
 from webserver.base.trash_manager import TrashManager
@@ -1220,6 +1223,72 @@ class AdminUpdateCheck(BaseHandler):
         return {"err": "ok", "status": status}
 
 
+MAX_LOG_LINES = 2000
+DEFAULT_LOG_LINES = 500
+
+
+def _get_log_file():
+    return getattr(tornado_options, "log_file_prefix", None) or "/data/log/talebook.log"
+
+
+class AdminSystemLog(BaseHandler):
+    @js
+    @is_admin
+    def get(self):
+        log_file = _get_log_file()
+        try:
+            lines_count = int(self.get_argument("lines", DEFAULT_LOG_LINES))
+        except (ValueError, TypeError):
+            lines_count = DEFAULT_LOG_LINES
+        lines_count = max(1, min(lines_count, MAX_LOG_LINES))
+
+        if not os.path.exists(log_file):
+            return {"err": "ok", "lines": [], "total": 0, "file": log_file}
+
+        total = 0
+        tail_deque = collections.deque(maxlen=lines_count)
+        with open(log_file, "r", encoding="utf-8", errors="replace") as f:
+            for line in f:
+                total += 1
+                tail_deque.append(line)
+
+        tail = [line.rstrip("\n") for line in tail_deque]
+        return {"err": "ok", "lines": tail, "total": total, "file": log_file}
+
+
+class AdminSystemLogDownload(BaseHandler):
+    async def get(self):
+        if not self.current_user:
+            self.set_status(403)
+            self.finish({"err": "user.need_login", "msg": _("请先登录")})
+            return
+        if not self.admin_user:
+            self.set_status(403)
+            self.finish({"err": "permission.not_admin", "msg": _("当前用户非管理员")})
+            return
+
+        log_file = _get_log_file()
+
+        if not os.path.exists(log_file):
+            self.set_status(404)
+            self.finish()
+            return
+
+        file_size = os.path.getsize(log_file)
+        self.set_header("Content-Type", "text/plain; charset=utf-8")
+        self.set_header("Content-Disposition", 'attachment; filename="talebook.log"')
+        self.set_header("Content-Length", str(file_size))
+        chunk_size = 64 * 1024
+        with open(log_file, "rb") as f:
+            while True:
+                chunk = f.read(chunk_size)
+                if not chunk:
+                    break
+                self.write(chunk)
+                await self.flush()
+        self.finish()
+
+
 def routes():
     return [
         (r"/api/admin/ssl", AdminSSL),
@@ -1242,4 +1311,6 @@ def routes():
         (r"/api/admin/opds/sources", AdminOpdsSources),
         (r"/api/admin/trash/size", AdminTrashSize),
         (r"/api/admin/trash/clear", AdminTrashClear),
+        (r"/api/admin/log", AdminSystemLog),
+        (r"/api/admin/log/download", AdminSystemLogDownload),
     ]

--- a/webserver/handlers/admin.py
+++ b/webserver/handlers/admin.py
@@ -401,6 +401,121 @@ class AdminSettings(BaseHandler):
         return logic.save_extra_settings(args)
 
 
+def _build_mysql_url(db_host, db_port, db_name, db_user, db_pass):
+    """Construct a MySQL+pymysql connection URL from individual parameters."""
+    import urllib.parse
+
+    safe_pass = urllib.parse.quote(db_pass, safe="")
+    safe_user = urllib.parse.quote(db_user, safe="")
+    return f"mysql+pymysql://{safe_user}:{safe_pass}@{db_host}:{db_port}/{db_name}?charset=utf8mb4"
+
+
+class AdminTestDB(BaseHandler):
+    """Test whether a database connection is reachable.
+
+    Accessible before install (for the install wizard) and by admins after install.
+    """
+
+    def should_be_installed(self):
+        pass
+
+    @js
+    def post(self):
+        # Before install: allow without auth (install wizard use case)
+        # After install: require admin
+        if CONF.get("installed", True):
+            if not self.current_user:
+                return {"err": "user.need_login", "msg": _("请先登录")}
+            if not self.admin_user:
+                return {"err": "permission", "msg": _("无权访问此接口")}
+
+        db_type = self.get_argument("db_type", "sqlite")
+        if db_type == "sqlite":
+            return {"err": "ok", "msg": _("SQLite 无需测试连接")}
+
+        db_host = self.get_argument("db_host", "localhost").strip()
+        db_port = self.get_argument("db_port", "3306").strip()
+        db_name = self.get_argument("db_name", "").strip()
+        db_user = self.get_argument("db_user", "").strip()
+        db_pass = self.get_argument("db_pass", "").strip()
+
+        if not db_name or not db_user:
+            return {"err": "params.invalid", "msg": _("数据库连接参数不完整")}
+
+        try:
+            db_port = int(db_port)
+        except ValueError:
+            return {"err": "params.invalid", "msg": _("端口号无效")}
+
+        db_url = _build_mysql_url(db_host, db_port, db_name, db_user, db_pass)
+        try:
+            from sqlalchemy import create_engine, text
+
+            engine = create_engine(db_url, pool_pre_ping=True, pool_size=1, max_overflow=0)
+            with engine.connect() as conn:
+                conn.execute(text("SELECT 1"))
+            engine.dispose()
+            return {"err": "ok", "msg": _("数据库连接成功")}
+        except Exception as e:
+            logging.error(traceback.format_exc())
+            return {"err": "db.connect_failed", "msg": str(e)}
+
+
+class AdminMigrateDB(BaseHandler):
+    """Migrate all Talebook user-data tables from the current database to a new one."""
+
+    @js
+    @auth
+    def post(self):
+        if not self.admin_user:
+            return {"err": "permission", "msg": _("无权访问此接口")}
+
+        db_type = self.get_argument("db_type", "").strip()
+        if not db_type or db_type == "sqlite":
+            return {"err": "params.invalid", "msg": _("请选择有效的目标数据库类型")}
+
+        db_host = self.get_argument("db_host", "localhost").strip()
+        db_port = self.get_argument("db_port", "3306").strip()
+        db_name = self.get_argument("db_name", "").strip()
+        db_user = self.get_argument("db_user", "").strip()
+        db_pass = self.get_argument("db_pass", "").strip()
+
+        if not db_name or not db_user:
+            return {"err": "params.invalid", "msg": _("数据库连接参数不完整")}
+
+        try:
+            db_port = int(db_port)
+        except ValueError:
+            return {"err": "params.invalid", "msg": _("端口号无效")}
+
+        new_db_url = _build_mysql_url(db_host, db_port, db_name, db_user, db_pass)
+        source_url = CONF["user_database"]
+
+        if new_db_url == source_url:
+            return {"err": "params.invalid", "msg": _("目标数据库与当前数据库相同")}
+
+        try:
+            from webserver.migrate_db import migrate_data
+
+            migrate_data(source_url, new_db_url)
+        except Exception as e:
+            logging.error(traceback.format_exc())
+            return {"err": "db.migrate_failed", "msg": _("数据迁移失败: %s") % str(e)}
+
+        # Persist new user_database — load ALL current settings so other keys aren't lost
+        try:
+            args = loader.SettingsLoader()
+            args["user_database"] = new_db_url
+            args["installed"] = True
+            args.dumpfile()
+        except Exception as e:
+            logging.error(traceback.format_exc())
+            return {"err": "file.permission", "msg": _("保存配置失败: %s") % str(e)}
+
+        CONF["user_database"] = new_db_url
+        return {"err": "ok", "msg": _("数据迁移成功，请重启服务器以生效"), "need_restart": True}
+
+
 class AdminInstall(BaseHandler):
     def should_be_invited(self):
         pass
@@ -433,8 +548,43 @@ class AdminInstall(BaseHandler):
         if len(password) < 8 or len(password) > 20 or not re.match(Reader.RE_PASSWORD, password):
             return {"err": "params.password.invalid", "msg": _("密码无效")}
 
+        # Optional database configuration
+        db_type = self.get_argument("db_type", "sqlite").strip()
+        target_session = self.session
+        target_db_url = None
+
+        if db_type in ("mysql", "mariadb"):
+            db_host = self.get_argument("db_host", "localhost").strip()
+            db_port = self.get_argument("db_port", "3306").strip()
+            db_name = self.get_argument("db_name", "").strip()
+            db_user = self.get_argument("db_user", "").strip()
+            db_pass = self.get_argument("db_pass", "").strip()
+
+            if not db_name or not db_user:
+                return {"err": "params.invalid", "msg": _("数据库连接参数不完整")}
+
+            try:
+                db_port = int(db_port)
+            except ValueError:
+                return {"err": "params.invalid", "msg": _("端口号无效")}
+
+            target_db_url = _build_mysql_url(db_host, db_port, db_name, db_user, db_pass)
+            try:
+                from sqlalchemy import create_engine
+                from sqlalchemy.orm import sessionmaker
+
+                from webserver import models
+
+                new_engine = create_engine(target_db_url, pool_pre_ping=True, pool_size=1, max_overflow=0)
+                models.user_syncdb(new_engine)
+                NewSession = sessionmaker(bind=new_engine, autoflush=True, autocommit=False)
+                target_session = NewSession()
+            except Exception as e:
+                logging.error(traceback.format_exc())
+                return {"err": "db.connect_failed", "msg": _("数据库连接失败: %s") % str(e)}
+
         # 避免重复创建
-        user = self.session.query(Reader).filter(Reader.username == username).first()
+        user = target_session.query(Reader).filter(Reader.username == username).first()
         if not user:
             user = Reader()
             user.username = username
@@ -451,8 +601,13 @@ class AdminInstall(BaseHandler):
         user.extra = {"kindle_email": ""}
         user.set_secure_password(password)
         try:
-            user.save()
-        except:
+            if target_session is self.session:
+                user.save()
+            else:
+                target_session.add(user)
+                target_session.commit()
+                target_session.close()
+        except Exception:
             logging.error(traceback.format_exc())
             return {"err": "db.error", "msg": _("系统异常，请重试或更换注册信息")}
 
@@ -475,6 +630,9 @@ class AdminInstall(BaseHandler):
             args["INVITE_CODE"] = code
         else:
             args["INVITE_MODE"] = False
+
+        if target_db_url:
+            args["user_database"] = target_db_url
 
         logic = SettingsSaverLogic()
         return logic.save_extra_settings(args)
@@ -1069,6 +1227,8 @@ def routes():
         (r"/api/admin/install", AdminInstall),
         (r"/api/admin/settings", AdminSettings),
         (r"/api/admin/testmail", AdminTestMail),
+        (r"/api/admin/testdb", AdminTestDB),
+        (r"/api/admin/migratedb", AdminMigrateDB),
         (r"/api/admin/update", AdminUpdateCheck),
         (r"/api/admin/book/list", AdminBookList),
         (r"/api/admin/book/fill", AdminBookFill),

--- a/webserver/handlers/admin.py
+++ b/webserver/handlers/admin.py
@@ -413,6 +413,55 @@ def _build_mysql_url(db_host, db_port, db_name, db_user, db_pass):
     return f"mysql+pymysql://{safe_user}:{safe_pass}@{db_host}:{db_port}/{db_name}?charset=utf8mb4"
 
 
+def _get_database_url(handler, allow_sqlite=True):
+    """Read and validate the user_database SQLAlchemy URL submitted by the UI.
+
+    The persisted configuration remains the existing single user_database field;
+    the Vue form may expose host/port/user inputs but must submit the composed URL.
+    Legacy split parameters are accepted as a compatibility fallback only.
+    """
+    from sqlalchemy.engine import make_url
+
+    db_url = handler.get_argument("user_database", "").strip() or handler.get_argument("db_url", "").strip()
+    if not db_url:
+        db_type = handler.get_argument("db_type", "sqlite" if allow_sqlite else "").strip()
+        if allow_sqlite and db_type == "sqlite":
+            return (
+                CONF["user_database"]
+                if CONF["user_database"].startswith("sqlite")
+                else "sqlite:////data/books/calibre-webserver.db"
+            )
+        if db_type in ("mysql", "mariadb"):
+            db_host = handler.get_argument("db_host", "localhost").strip()
+            db_port = handler.get_argument("db_port", "3306").strip()
+            db_name = handler.get_argument("db_name", "").strip()
+            db_user = handler.get_argument("db_user", "").strip()
+            db_pass = handler.get_argument("db_pass", "").strip()
+            if not db_name or not db_user:
+                raise ValueError(_("数据库连接参数不完整"))
+            db_url = _build_mysql_url(db_host, db_port, db_name, db_user, db_pass)
+        else:
+            raise ValueError(_("请选择有效的目标数据库类型"))
+
+    try:
+        parsed = make_url(db_url)
+    except Exception as e:
+        raise ValueError(_("数据库连接地址无效: %s") % str(e))
+
+    driver = parsed.drivername.split("+")[0]
+    if driver == "sqlite":
+        if allow_sqlite:
+            return db_url
+        raise ValueError(_("请选择有效的目标数据库类型"))
+    if driver not in ("mysql", "mariadb"):
+        raise ValueError(_("仅支持 SQLite 或 MySQL/MariaDB 数据库"))
+    if not parsed.database or not parsed.username:
+        raise ValueError(_("数据库连接参数不完整"))
+    if parsed.port is not None and not (1 <= parsed.port <= 65535):
+        raise ValueError(_("端口号范围无效，应在 1-65535 之间"))
+    return db_url
+
+
 class AdminTestDB(BaseHandler):
     """Test whether a database connection is reachable.
 
@@ -432,27 +481,12 @@ class AdminTestDB(BaseHandler):
             if not self.admin_user:
                 return {"err": "permission", "msg": _("无权访问此接口")}
 
-        db_type = self.get_argument("db_type", "sqlite")
-        if db_type == "sqlite":
-            return {"err": "ok", "msg": _("SQLite 无需测试连接")}
-
-        db_host = self.get_argument("db_host", "localhost").strip()
-        db_port = self.get_argument("db_port", "3306").strip()
-        db_name = self.get_argument("db_name", "").strip()
-        db_user = self.get_argument("db_user", "").strip()
-        db_pass = self.get_argument("db_pass", "").strip()
-
-        if not db_name or not db_user:
-            return {"err": "params.invalid", "msg": _("数据库连接参数不完整")}
-
         try:
-            db_port = int(db_port)
-        except ValueError:
-            return {"err": "params.invalid", "msg": _("端口号无效")}
-        if not (1 <= db_port <= 65535):
-            return {"err": "params.invalid", "msg": _("端口号范围无效，应在 1-65535 之间")}
-
-        db_url = _build_mysql_url(db_host, db_port, db_name, db_user, db_pass)
+            db_url = _get_database_url(self)
+        except ValueError as e:
+            return {"err": "params.invalid", "msg": str(e)}
+        if db_url.startswith("sqlite"):
+            return {"err": "ok", "msg": _("SQLite 无需测试连接")}
         try:
             from sqlalchemy import create_engine, text
 
@@ -475,29 +509,12 @@ class AdminMigrateDB(BaseHandler):
         if not self.admin_user:
             return {"err": "permission", "msg": _("无权访问此接口")}
 
-        db_type = self.get_argument("db_type", "").strip()
-        if not db_type or db_type == "sqlite":
-            return {"err": "params.invalid", "msg": _("请选择有效的目标数据库类型")}
-
-        db_host = self.get_argument("db_host", "localhost").strip()
-        db_port = self.get_argument("db_port", "3306").strip()
-        db_name = self.get_argument("db_name", "").strip()
-        db_user = self.get_argument("db_user", "").strip()
-        db_pass = self.get_argument("db_pass", "").strip()
-
-        if not db_name or not db_user:
-            return {"err": "params.invalid", "msg": _("数据库连接参数不完整")}
-
         try:
-            db_port = int(db_port)
-        except ValueError:
-            return {"err": "params.invalid", "msg": _("端口号无效")}
-        if not (1 <= db_port <= 65535):
-            return {"err": "params.invalid", "msg": _("端口号范围无效，应在 1-65535 之间")}
+            new_db_url = _get_database_url(self, allow_sqlite=False)
+        except ValueError as e:
+            return {"err": "params.invalid", "msg": str(e)}
 
         force = self.get_argument("force", "0").strip() == "1"
-
-        new_db_url = _build_mysql_url(db_host, db_port, db_name, db_user, db_pass)
         source_url = CONF["user_database"]
 
         if new_db_url == source_url:
@@ -563,29 +580,15 @@ class AdminInstall(BaseHandler):
         if len(password) < 8 or len(password) > 20 or not re.match(Reader.RE_PASSWORD, password):
             return {"err": "params.password.invalid", "msg": _("密码无效")}
 
-        # Optional database configuration
-        db_type = self.get_argument("db_type", "sqlite").strip()
+        # Optional database configuration. Persist only the existing user_database setting;
+        # the UI may collect separate fields but submits the composed SQLAlchemy URL.
         target_session = self.session
-        target_db_url = None
+        try:
+            target_db_url = _get_database_url(self)
+        except ValueError as e:
+            return {"err": "params.invalid", "msg": str(e)}
 
-        if db_type in ("mysql", "mariadb"):
-            db_host = self.get_argument("db_host", "localhost").strip()
-            db_port = self.get_argument("db_port", "3306").strip()
-            db_name = self.get_argument("db_name", "").strip()
-            db_user = self.get_argument("db_user", "").strip()
-            db_pass = self.get_argument("db_pass", "").strip()
-
-            if not db_name or not db_user:
-                return {"err": "params.invalid", "msg": _("数据库连接参数不完整")}
-
-            try:
-                db_port = int(db_port)
-            except ValueError:
-                return {"err": "params.invalid", "msg": _("端口号无效")}
-            if not (1 <= db_port <= 65535):
-                return {"err": "params.invalid", "msg": _("端口号范围无效，应在 1-65535 之间")}
-
-            target_db_url = _build_mysql_url(db_host, db_port, db_name, db_user, db_pass)
+        if not target_db_url.startswith("sqlite"):
             try:
                 from sqlalchemy import create_engine
                 from sqlalchemy.orm import sessionmaker
@@ -648,7 +651,7 @@ class AdminInstall(BaseHandler):
         else:
             args["INVITE_MODE"] = False
 
-        if target_db_url:
+        if target_db_url and target_db_url != CONF["user_database"]:
             args["user_database"] = target_db_url
 
         logic = SettingsSaverLogic()

--- a/webserver/main.py
+++ b/webserver/main.py
@@ -178,6 +178,16 @@ def bind_topdir_book_names(cache):
     return
 
 
+def build_db_engine_args(db_url):
+    """Return SQLAlchemy engine kwargs appropriate for the given database URL."""
+    args = {"echo": False, "pool_size": 10, "max_overflow": 20, "pool_recycle": 3600}
+    if db_url.startswith("sqlite"):
+        args["connect_args"] = {"check_same_thread": False, "timeout": 30}
+    else:
+        args["pool_pre_ping"] = True
+    return args
+
+
 def make_app():
     auth_db_path = CONF["user_database"]
     logging.debug("Init library with [%s]" % options.with_library)
@@ -197,7 +207,7 @@ def make_app():
         sys.exit(0)
 
     # build sql session factory
-    engine = create_engine(auth_db_path, **CONF["db_engine_args"])
+    engine = create_engine(auth_db_path, **build_db_engine_args(auth_db_path))
     SessionMaker = sessionmaker(bind=engine, autoflush=True, autocommit=False)
     # ScopedSession（线程级注册表）仅供 social-auth 存储层及 models.save() 对新建对象的兜底；
     # 业务代码（handler / 后台服务）一律通过 SessionMaker 创建各自独立的 session

--- a/webserver/migrate_db.py
+++ b/webserver/migrate_db.py
@@ -284,6 +284,55 @@ def main():
         return False
 
 
+def build_engine_args(db_url):
+    """Return SQLAlchemy engine kwargs appropriate for the given database URL."""
+    args = {"echo": False, "pool_size": 5, "max_overflow": 10, "pool_recycle": 3600}
+    if db_url.startswith("sqlite"):
+        args["connect_args"] = {"check_same_thread": False, "timeout": 30}
+    else:
+        args["pool_pre_ping"] = True
+    return args
+
+
+def migrate_data(source_url, target_url):
+    """Copy all data from source database to target database.
+
+    Creates all tables in the target, then copies every row.  The target is
+    cleared table-by-table before inserting so the operation is idempotent.
+    """
+    from sqlalchemy import text
+
+    logger.info(f"Migrating data: {source_url!r} -> {target_url!r}")
+
+    source_engine = create_engine(source_url, **build_engine_args(source_url))
+    target_engine = create_engine(target_url, **build_engine_args(target_url))
+
+    models.Base.metadata.create_all(target_engine)
+    logger.info("Tables created in target database")
+
+    is_mysql_target = not target_url.startswith("sqlite")
+
+    with source_engine.connect() as src:
+        with target_engine.connect() as tgt:
+            if is_mysql_target:
+                tgt.execute(text("SET FOREIGN_KEY_CHECKS=0"))
+
+            for table in models.Base.metadata.sorted_tables:
+                rows = src.execute(table.select()).fetchall()
+                tgt.execute(table.delete())
+                if rows:
+                    tgt.execute(table.insert(), [dict(r._mapping) for r in rows])
+                logger.info(f"Migrated table {table.name}: {len(rows)} rows")
+
+            if is_mysql_target:
+                tgt.execute(text("SET FOREIGN_KEY_CHECKS=1"))
+            tgt.commit()
+
+    source_engine.dispose()
+    target_engine.dispose()
+    logger.info("Migration completed successfully")
+
+
 if __name__ == "__main__":
     success = main()
     sys.exit(0 if success else 1)

--- a/webserver/migrate_db.py
+++ b/webserver/migrate_db.py
@@ -42,6 +42,14 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(mess
 logger = logging.getLogger(__name__)
 
 
+class TargetNotEmptyError(Exception):
+    """Raised when the target database already has data and force=False."""
+
+    def __init__(self, count):
+        self.count = count
+        super().__init__(f"Target database has {count} existing rows")
+
+
 def get_column_type(column):
     """Convert SQLAlchemy Column type to SQLite type string"""
     from social_sqlalchemy.storage import JSONType
@@ -294,11 +302,15 @@ def build_engine_args(db_url):
     return args
 
 
-def migrate_data(source_url, target_url):
+def migrate_data(source_url, target_url, force=False):
     """Copy all data from source database to target database.
 
     Creates all tables in the target, then copies every row.  The target is
     cleared table-by-table before inserting so the operation is idempotent.
+
+    If the target already contains data and force=False, raises TargetNotEmptyError
+    with the total existing row count so the caller can prompt for confirmation.
+    Pass force=True to skip the check and overwrite existing data.
     """
     from sqlalchemy import text
 
@@ -311,6 +323,17 @@ def migrate_data(source_url, target_url):
     logger.info("Tables created in target database")
 
     is_mysql_target = not target_url.startswith("sqlite")
+
+    if not force:
+        total_existing = 0
+        with target_engine.connect() as check_conn:
+            for table in models.Base.metadata.sorted_tables:
+                count = check_conn.execute(text(f"SELECT COUNT(*) FROM `{table.name}`")).scalar()
+                total_existing += count or 0
+        if total_existing > 0:
+            source_engine.dispose()
+            target_engine.dispose()
+            raise TargetNotEmptyError(total_existing)
 
     with source_engine.connect() as src:
         with target_engine.connect() as tgt:

--- a/webserver/models.py
+++ b/webserver/models.py
@@ -532,7 +532,9 @@ class BookSourceModel(Base, SQLAlchemyMixin):
 
     id = Column(Integer, primary_key=True)
     name = Column(String(200), nullable=False, index=True)
-    url = Column(String(767), nullable=False, index=True)  # bookSourceUrl，导入时按此 upsert；767×4=3068 ≤ MySQL utf8mb4 索引上限 3072 字节
+    url = Column(
+        String(767), nullable=False, index=True
+    )  # bookSourceUrl，导入时按此 upsert；767×4=3068 ≤ MySQL utf8mb4 索引上限 3072 字节
     group = Column(String(200), default="", index=True)
     source_type = Column(Integer, default=0)
     enabled = Column(Boolean, default=True, index=True)

--- a/webserver/models.py
+++ b/webserver/models.py
@@ -532,7 +532,7 @@ class BookSourceModel(Base, SQLAlchemyMixin):
 
     id = Column(Integer, primary_key=True)
     name = Column(String(200), nullable=False, index=True)
-    url = Column(String(1000), nullable=False, index=True)  # bookSourceUrl，导入时按此 upsert
+    url = Column(String(767), nullable=False, index=True)  # bookSourceUrl，导入时按此 upsert；767×4=3068 ≤ MySQL utf8mb4 索引上限 3072 字节
     group = Column(String(200), default="", index=True)
     source_type = Column(Integer, default=0)
     enabled = Column(Boolean, default=True, index=True)


### PR DESCRIPTION
## Summary

- 新增 `AdminTestDB` 接口：安装向导和管理员设置中可测试数据库连接
- 新增 `AdminMigrateDB` 接口：将现有数据迁移至新 MySQL/MariaDB
- 安装界面新增数据库类型选择和测试连接功能
- 管理员设置新增数据库管理卡片，支持切换及迁移

Closes #803

Generated with [Claude Code](https://claude.ai/code)