### PR TITLE
fix: 网络书库分类点击后无书籍时显示空状态提示

### DIFF
--- a/app/i18n/locales/en-US.json
+++ b/app/i18n/locales/en-US.json
@@ -226,6 +226,7 @@
     "partialFailedCount": "{n} sources returned no result",
     "explorePickSource": "Pick a source",
     "exploreEmpty": "This source has no explore categories",
+    "exploreNoBooks": "No books found in this category. The source rules may not support category page parsing.",
     "prevPage": "Prev",
     "nextPage": "Next",
     "page": "Page {n}",

--- a/app/i18n/locales/zh-CN.json
+++ b/app/i18n/locales/zh-CN.json
@@ -231,6 +231,7 @@
     "partialFailedCount": "{n} 个书源未返回结果",
     "explorePickSource": "选择书源",
     "exploreEmpty": "该书源未配置发现分类",
+    "exploreNoBooks": "该分类下暂无书籍，可能是书源规则不支持分类页解析",
     "prevPage": "上一页",
     "nextPage": "下一页",
     "page": "第 {n} 页",

--- a/app/pages/network/index.vue
+++ b/app/pages/network/index.vue
@@ -281,6 +281,15 @@
                                 </v-btn>
                             </div>
                         </div>
+                        <v-alert
+                            v-else-if="exploreCategoryUrl && !exploreLoading"
+                            type="info"
+                            variant="tonal"
+                            density="compact"
+                            class="mt-3"
+                        >
+                            {{ $t('network.exploreNoBooks') }}
+                        </v-alert>
                     </v-col>
                 </v-row>
             </v-tabs-window-item>

--- a/tests/test_network_library.py
+++ b/tests/test_network_library.py
@@ -147,6 +147,52 @@ class TestNetworkLibrary(TestWithUserLogin):
         self.assertEqual(len(d["items"]), 2)
         self.assertEqual(d["items"][0]["name"], "玄幻")
 
+    @mock.patch("webserver.services.booksource.engine.build_session")
+    def test_explore(self, m_session):
+        # 分类 URL 含 {{page}} 模板，后端应替换为实际页码后再发 HTTP 请求
+        session = get_db()
+        session.query(models.BookSourceModel).delete()
+        session.commit()
+        raw = dict(CSS_SOURCE, exploreUrl="玄幻::/explore/{{page}}.html")
+        source = models.BookSourceModel(raw)
+        source.save()
+        sid = source.id
+        m_session.return_value = FakeSession({"/explore/1.html": text("search.html")})
+        category_url = "/explore/{{page}}.html"
+        d = self.json("/api/network/explore?source_id=%d&url=%s&page=1" % (sid, Q(category_url)))
+        self.assertEqual(d["err"], "ok")
+        self.assertEqual(len(d["books"]), 2)
+        self.assertEqual(d["books"][0]["name"], "剑来")
+        # 验证 {{page}} 被替换为 1，即访问了 /explore/1.html
+        calls = m_session.return_value.calls
+        self.assertTrue(any("explore/1.html" in url for _, url in calls))
+
+    @mock.patch("webserver.services.booksource.engine.build_session")
+    def test_explore_page_substitution(self, m_session):
+        # page=2 时，{{page}} 应替换为 2，访问不同 URL
+        session = get_db()
+        session.query(models.BookSourceModel).delete()
+        session.commit()
+        raw = dict(CSS_SOURCE, exploreUrl="玄幻::/explore/{{page}}.html")
+        source = models.BookSourceModel(raw)
+        source.save()
+        sid = source.id
+        m_session.return_value = FakeSession({"/explore/2.html": text("search.html")})
+        category_url = "/explore/{{page}}.html"
+        d = self.json("/api/network/explore?source_id=%d&url=%s&page=2" % (sid, Q(category_url)))
+        self.assertEqual(d["err"], "ok")
+        calls = m_session.return_value.calls
+        self.assertTrue(any("explore/2.html" in url for _, url in calls))
+        self.assertFalse(any("explore/1.html" in url for _, url in calls))
+
+    def test_explore_missing_source(self):
+        d = self.json("/api/network/explore?source_id=99999&url=%s&page=1" % Q("/x"))
+        self.assertEqual(d["err"], "params.not_found")
+
+    def test_explore_missing_url(self):
+        d = self.json("/api/network/explore?source_id=%d&url=&page=1" % self.sid)
+        self.assertEqual(d["err"], "params.error")
+
     def test_status_get_set(self):
         session = get_db()
         meta = models.OnlineBookMeta(book_id=123456, source_url="http://x.com")


### PR DESCRIPTION
修复 #809 网络书库浏览中，点击分类标签后下方为空没有显示出任何书籍的问题。

原因：书源规则无法解析分类页时，前端仅通过 v-if 控制显示，结果为空时页面完全空白。

Generated with [Claude Code](https://claude.ai/code)