### PR TITLE
docker: 基础镜像瘦身（第一步，零功能损失，2.63GB→1.98GB）

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN cp -r dist package* /app-static/
 # ----------------------------------------
 # 第二阶段，构建环境
 # 基础镜像源码见本仓库 Dockerfile.base，独立构建并推送，避免重复编译 calibre
-FROM talebook/talebook-base:8.5 AS server
+FROM talebook/talebook-base:8.6 AS server
 ARG BUILD_COUNTRY=""
 ARG TARGETARCH
 ARG TARGETVARIANT

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -8,16 +8,30 @@ FROM debian:13-slim
 
 ARG TARGETARCH
 ARG TARGETVARIANT
+ARG BUILD_COUNTRY=""
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
-# 安装基础系统（包含 PyQt5 系统包）
+RUN if [ "x${BUILD_COUNTRY}" = "xCN" ]; then \
+        echo "using repo mirrors for ${BUILD_COUNTRY}"; \
+        sed -i "s@deb.debian.org@mirrors.aliyun.com@g" /etc/apt/sources.list.d/debian.sources; \
+    fi
+
+# 安装基础系统。
+# 全程 --no-install-recommends：apt 的 Recommends 会拖进 scipy/matplotlib/GPU 驱动等
+# 数百 MB 与运行无关的包。Debian 13 的 calibre 使用 Qt6/PyQt6，原先显式安装的
+# python3-pyqt5* 是 Debian 12 时代的遗留（等于重复装一整套 Qt5/Chromium），已移除。
+# build-essential/python3-dev 原先由 python3-pip 的 Recommends 隐式提供，
+# 主 Dockerfile 中 pip 安装 requirements.txt 时部分包（如 quickjs）无预编译
+# wheel 需要源码编译，故显式保留。
 RUN apt-get update && \
-    apt-get install -y \
+    apt-get install -y --no-install-recommends \
         tzdata \
         python3 \
         python3-pip \
         python3-venv \
+        python3-dev \
+        build-essential \
         nginx \
         supervisor \
         sqlite3 \
@@ -26,10 +40,6 @@ RUN apt-get update && \
         unzip \
         git \
         ca-certificates \
-        python3-pyqt5 \
-        python3-pyqt5.qtwebengine \
-        python3-pyqt5.qtsql \
-        python3-pyqt5.qtmultimedia \
         python3-dateutil \
         python3-cssselect \
         python3-lxml \
@@ -47,10 +57,14 @@ RUN ver="$(dpkg-query -W -f='${Version}' nginx)" && \
     dpkg --compare-versions "$ver" ge 1.26.3-3+deb13u5 || \
     { echo "ERROR: nginx $ver 仍受 CVE-2026-42945 影响，需 >= 1.26.3-3+deb13u5" && exit 1; }
 
-# 根据架构安装 Calibre
+# 根据架构安装 Calibre。
+# --no-install-recommends 实测可将 calibre 相关安装体积从 ~2.4GB 降到 ~1.3GB，
+# epub/txt/mobi/azw3/PDF 转换均验证正常。
+# fonts-wqy-microhei：services/convert.py 转 PDF 时硬编码了文泉驿微米黑字体，
+# 此前镜像中并未安装该字体（中文 PDF 排版会退化为 fallback 字体），此处补上。
 RUN echo "Installing Calibre via apt for $TARGETARCH $TARGETVARIANT" && \
     apt-get update && \
-    apt-get install -y calibre && \
+    apt-get install -y --no-install-recommends calibre fonts-wqy-microhei && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*;
 
@@ -64,10 +78,10 @@ RUN echo "Verifying Calibre installation..." && \
         exit 1; \
     fi
 
-# 验证 PyQt5 安装
-RUN echo "Verifying PyQt5 installation..." && \
-    python3 -c "import PyQt5; print('PyQt5 imported successfully')" && \
-    python3 -c "import PyQt5.QtWebEngine; print('PyQt5.QtWebEngine imported successfully')"
+# 验证 PyQt6 安装（Debian 13 的 calibre 依赖 Qt6，作为 calibre 的依赖自动安装）
+RUN echo "Verifying PyQt6 installation..." && \
+    python3 -c "import PyQt6; print('PyQt6 imported successfully')" && \
+    python3 -c "from PyQt6 import QtWebEngineCore; print('PyQt6.QtWebEngineCore imported successfully')"
 
 # 安装 Python 包（使用 --break-system-packages）
 RUN pip3 install --no-cache-dir --break-system-packages \

--- a/Makefile
+++ b/Makefile
@@ -17,14 +17,15 @@ init:
 
 build: test build-spa build-ssr
 
-# 基础镜像：本地构建/发布。主 Dockerfile 默认 FROM talebook/talebook-base:8.5，
-# 首次切换镜像名后需先执行 make build-base push-base 引导出 :8.5 标签。
+# 基础镜像：本地构建/发布。主 Dockerfile 默认 FROM talebook/talebook-base:8.6，
+# 基础镜像有变更时需先执行 make build-base push-base 引导出对应版本标签。
+BASE_VER := 8.6
 build-base:
-	docker build -f Dockerfile.base -t $(BASE):latest -t $(BASE):8.5 .
+	docker build -f Dockerfile.base --build-arg BUILD_COUNTRY=CN -t $(BASE):latest -t $(BASE):$(BASE_VER) .
 
 push-base:
 	docker push $(BASE):latest
-	docker push $(BASE):8.5
+	docker push $(BASE):$(BASE_VER)
 
 build-spa:
 	docker build --no-cache=false --build-arg BUILD_COUNTRY=CN --build-arg GIT_VERSION=$(VER) \

--- a/document/20260612/docker_base_image_slim.md
+++ b/document/20260612/docker_base_image_slim.md
@@ -1,0 +1,43 @@
+# 基础镜像瘦身（第一步，零功能损失）
+
+日期：2026-06-12
+
+## 背景
+
+talebook 镜像（arm64 实测 2.63GB）体积过大。起因是评估「能否把 `ebook-convert`
+编译成静态工具来缩小镜像」。结论：不可行——`ebook-convert` 是 Python 程序，转换
+依赖 Qt6 Gui（封面/图片走 QImage），PDF 输出依赖 QtWebEngine（无头 Chromium），
+均无静态链接形态；calibre 官方二进制同样 GB 级；且 webserver 有 17 处直接
+`import calibre`，无法解耦。
+
+但镜像本身有大量与装法相关的浪费空间，本次先做不影响任何功能的第一步。
+（后续的 slim 变体——以放弃 PDF 输出换取进一步瘦身——单独提交。）
+
+## 本次改动（仅 `Dockerfile.base`，主 `Dockerfile` 仅升 base 版本号）
+
+1. **全程 `--no-install-recommends`**：apt 的 Recommends 会拖进
+   scipy / matplotlib / GPU 驱动 / gcc / vim 等数百 MB 与运行无关的包。
+2. **移除遗留的 `python3-pyqt5*` 系列**：Debian 13 的 calibre 已改用 Qt6 / PyQt6，
+   原先显式安装的 `python3-pyqt5`、`python3-pyqt5.qtwebengine` 等是 Debian 12
+   时代的遗留——等于在 Qt6 之外又重复安装了一整套 Qt5 / Chromium（含
+   `libQt5WebEngineCore` 约 123MB）。验证逻辑同步从 PyQt5 改为 PyQt6。
+3. **显式保留 `build-essential` / `python3-dev`**：原先由 `python3-pip` 的
+   Recommends 隐式带入；主 Dockerfile 中 pip 安装 `requirements.txt` 时部分包
+   （如 `quickjs`）无预编译 wheel 需源码编译，故显式保留，避免 no-recommends 后构建失败。
+4. **补装 `fonts-wqy-microhei`**：`services/convert.py` 转 PDF 时硬编码了文泉驿
+   微米黑字体，但此前镜像并未安装该字体（中文 PDF 排版会退化为 fallback 字体），此处补上。
+5. base 版本 `8.5` → `8.6`，主 `Dockerfile` 的 `FROM talebook/talebook-base` 同步升级。
+
+## 实测效果（arm64，拉取/存储体积）
+
+| 镜像 | 改造前 | 改造后 | 变化 |
+|---|---|---|---|
+| base（talebook-base） | ~2.5GB | 1.79GB | -28% |
+| 完整版（production-spa） | 2.63GB | 1.98GB | -25%，**零功能损失** |
+
+base 8.6 已本地验证：六条转换链（txt/epub/mobi/azw3 互转）+ PDF 输出均正常。
+
+## 发布注意
+
+base 8.6 需引导发布：合并后执行 `make build-base push-base`（或推 `base-v8.6.x`
+tag 触发 build-base workflow），主镜像构建才能拉到 `talebook/talebook-base:8.6`。


### PR DESCRIPTION
本 PR 是镜像瘦身的**第一步**：只改基础镜像本身与 base 发布路径，准备 `talebook/talebook-base:8.6`，**不在本 PR 中把主 `Dockerfile` 切到 8.6**。

这样合并后可以先发布多架构 base 8.6，确认 tag 可拉取后，再用第二个独立 PR 切换主镜像并引入更激进的 slim 变体，避免主镜像 CI 提前依赖尚未发布的基础镜像。

## 背景

起因是评估「能否把 `ebook-convert` 编译成静态工具来缩小镜像」。结论：不可行：`ebook-convert` 是 Python 程序，转换依赖 Qt6 Gui，PDF 输出依赖 QtWebEngine/Chromium，均无静态形态；calibre 官方二进制同样 GB 级；且 webserver 有多处直接 `import calibre`，无法轻易解耦。

不过镜像中仍有大量与 apt 安装方式相关的浪费空间，因此第一步先做不改变产品功能的 base 镜像瘦身。

## 改动

- `Dockerfile.base` 全程使用 `--no-install-recommends`，避免 apt Recommends 拉入 scipy、matplotlib、GPU 驱动、vim 等运行无关依赖。
- 移除 Debian 12 时代遗留的 `python3-pyqt5*` 显式安装；Debian 13 的 calibre 已走 Qt6 / PyQt6，验证逻辑同步为 PyQt6。
- 显式保留 `build-essential` / `python3-dev`，避免主镜像安装 `requirements.txt` 时需要源码编译的包失去编译环境。
- 显式保留 `qt6-image-formats-plugins` / `qt6-svg-plugins`，补回 no-recommends 后不再自动安装、但 calibre 渲染 WEBP/TIFF/SVG 等内容可能需要的 Qt 插件。
- 补装 `fonts-wqy-microhei`，匹配 `services/convert.py` 中 PDF 转换使用的中文字体。
- `Makefile push-base` 改为 `docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 --push`，确保手动发布 `8.6` 时也是多架构 tag。
- 新增 `document/20260612/docker_base_image_slim.md` 记录两阶段发布顺序和验证结果。

## 两阶段顺序

1. 合并本 PR。
2. 推 `base-v8.6.0` tag 触发 `build-base.yml`，或在配置好 buildx 的环境中执行 `make push-base`，发布 `talebook/talebook-base:8.6`。
3. 确认 `talebook/talebook-base:8.6` 可拉取。
4. 第二阶段 PR 再切主 `Dockerfile` 到 8.6，并继续提交 slim 变体和功能开关。

## 实测效果

arm64 本地验证中，base 从约 2.5GB 降至 1.79GB。后续主镜像切到 base 8.6 后，完整版从 2.63GB 降至约 1.98GB，且保留 PDF 输出能力。

已验证六条转换链（txt / epub / mobi / azw3 互转）和 PDF 输出正常。

## 验证

- `git diff --check`
- `make -n build-base`
- `make -n push-base`