### PR TITLE
fix(docker): 基础镜像补回 python3-setuptools

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -21,14 +21,15 @@ RUN if [ "x${BUILD_COUNTRY}" = "xCN" ]; then \
 # 全程 --no-install-recommends：apt 的 Recommends 会拖进 scipy/matplotlib/GPU 驱动等
 # 数百 MB 与运行无关的包。Debian 13 的 calibre 使用 Qt6/PyQt6，原先显式安装的
 # python3-pyqt5* 是 Debian 12 时代的遗留（等于重复装一整套 Qt5/Chromium），已移除。
-# build-essential/python3-dev 原先由 python3-pip 的 Recommends 隐式提供，
+# build-essential/python3-dev/python3-setuptools 原先由 python3-pip 的 Recommends 隐式提供，
 # 主 Dockerfile 中 pip 安装 requirements.txt 时部分包（如 quickjs）无预编译
-# wheel 需要源码编译，故显式保留。
+# wheel 需要源码编译（依赖 setuptools.setup），故显式保留。
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         tzdata \
         python3 \
         python3-pip \
+        python3-setuptools \
         python3-venv \
         python3-dev \
         build-essential \


### PR DESCRIPTION
## 背景

PR #818（基础镜像瘦身）全程使用 `--no-install-recommends`，连带丢掉了原本由 `python3-pip` 的 Recommends 隐式带入的 **`python3-setuptools`**。镜像中仅残留一个空的命名空间目录 `/usr/lib/python3/dist-packages/setuptools`，导致：

```
from setuptools import setup
ImportError: cannot import name 'setup' from 'setuptools' (unknown location)
```

## 影响

`requirements.txt` 中无预编译 wheel、需源码编译的包（如 `quickjs`）在 `make init` 阶段构建失败，**CI 的 `test-server` job 全部挂掉**（master 及所有 PR）。例如 #812 即被此问题阻塞。

## 修复

在 `Dockerfile.base` 的 apt 安装列表中显式补回 `python3-setuptools`（与已显式保留的 `build-essential`/`python3-dev` 同理）。

## 验证

在 `debian:13-slim` 中复现并验证：补回该包后 `from setuptools import setup` 正常，`quickjs` 可源码编译，`requirements.txt` 完整安装成功。

合并后 `build-base.yml` 会重新发布 `talebook/talebook-base:latest`，届时重跑 #812 等 PR 的 CI 即可转绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)