### PR TITLE
feat: add @talebook/theme-builder CLI tool (Phase 4)

### DIFF
--- a/packages/theme-builder/bin/cli.js
+++ b/packages/theme-builder/bin/cli.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+import { createProgram } from '../src/index.js';
+
+const program = createProgram();
+program.parse(process.argv);

--- a/packages/theme-builder/package.json
+++ b/packages/theme-builder/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@talebook/theme-builder",
+  "version": "1.0.0",
+  "description": "CLI tool for building Talebook themes with Vuetify support",
+  "type": "module",
+  "bin": {
+    "theme-builder": "./bin/cli.js"
+  },
+  "files": [
+    "bin",
+    "src",
+    "templates"
+  ],
+  "scripts": {
+    "test": "node --test test/validate.test.js"
+  },
+  "dependencies": {
+    "commander": "^12.1.0"
+  },
+  "peerDependencies": {
+    "vite": "^5.0.0",
+    "@vitejs/plugin-vue": "^5.0.0",
+    "vue": "^3.0.0",
+    "vuetify": "^3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "vite": { "optional": false },
+    "@vitejs/plugin-vue": { "optional": false }
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "keywords": [
+    "talebook",
+    "theme",
+    "vuetify",
+    "vue"
+  ],
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/theme-builder/src/commands/build.js
+++ b/packages/theme-builder/src/commands/build.js
@@ -1,0 +1,35 @@
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+export async function buildCommand(options) {
+    const configPath = resolve(options.config || 'vite.config.js');
+    const outDir = options.outDir || 'dist';
+
+    if (!existsSync(configPath)) {
+        console.error(`ERROR: Vite config not found: ${configPath}`);
+        console.error('Run "theme-builder init <name>" first, or ensure you are inside a theme project directory.');
+        process.exit(1);
+    }
+
+    if (!existsSync(resolve('theme.json'))) {
+        console.error('ERROR: theme.json not found. Ensure you are inside a theme project directory.');
+        process.exit(1);
+    }
+
+    console.log(`Building theme with Vite (outDir: ${outDir}) ...`);
+
+    const result = spawnSync(
+        'npx',
+        ['vite', 'build', '--config', configPath, '--outDir', outDir],
+        { stdio: 'inherit', shell: true }
+    );
+
+    if (result.status !== 0) {
+        console.error('\nBuild FAILED');
+        process.exit(result.status ?? 1);
+    }
+
+    console.log(`\n✓ Build complete. Output: ${outDir}/`);
+    console.log('Run "theme-builder validate" to verify the built theme.');
+}

--- a/packages/theme-builder/src/commands/init.js
+++ b/packages/theme-builder/src/commands/init.js
@@ -1,0 +1,69 @@
+import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
+import { resolve, join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const TEMPLATES_DIR = resolve(__dirname, '../../templates');
+
+function renderTemplate(content, vars) {
+    return content.replace(/\{\{(\w+)\}\}/g, (_, key) => vars[key] ?? `{{${key}}}`);
+}
+
+function copyTemplate(srcPath, destPath, vars) {
+    const content = readFileSync(srcPath, 'utf-8');
+    writeFileSync(destPath, renderTemplate(content, vars));
+}
+
+export async function initCommand(themeName, options) {
+    const NAME_PATTERN = /^[a-z][a-z0-9-]*$/;
+    if (!NAME_PATTERN.test(themeName)) {
+        console.error(`ERROR: Theme name "${themeName}" is invalid. Use lowercase letters, digits, and hyphens only.`);
+        process.exit(1);
+    }
+
+    const outputDir = resolve(options.output || themeName);
+
+    if (existsSync(outputDir)) {
+        console.error(`ERROR: Directory "${outputDir}" already exists. Choose a different name or use --output.`);
+        process.exit(1);
+    }
+
+    const vars = {
+        THEME_NAME: themeName,
+        THEME_AUTHOR: options.author || 'unknown',
+        THEME_DESCRIPTION: options.description || 'A custom Talebook theme',
+        THEME_VERSION: '1.0.0',
+    };
+
+    console.log(`Creating theme "${themeName}" in ${outputDir} ...`);
+
+    mkdirSync(join(outputDir, 'src'), { recursive: true });
+
+    const files = [
+        ['package.json.tpl', 'package.json'],
+        ['vite.config.js.tpl', 'vite.config.js'],
+        ['theme.json.tpl', 'theme.json'],
+        [join('src', 'AppHeader.vue.tpl'), join('src', 'AppHeader.vue')],
+        [join('src', 'AppFooter.vue.tpl'), join('src', 'AppFooter.vue')],
+        [join('src', 'index.js.tpl'), join('src', 'index.js')],
+    ];
+
+    for (const [tplRelPath, destRelPath] of files) {
+        const srcPath = join(TEMPLATES_DIR, tplRelPath);
+        const destPath = join(outputDir, destRelPath);
+        copyTemplate(srcPath, destPath, vars);
+    }
+
+    console.log(`
+✓ Theme scaffolded successfully!
+
+Next steps:
+  cd ${themeName}
+  npm install
+  npm run dev          # start Vite in watch mode
+  npm run build        # build components to dist/
+  theme-builder validate  # check theme.json
+
+Customize src/AppHeader.vue and src/AppFooter.vue to create your theme.
+`);
+}

--- a/packages/theme-builder/src/commands/validate.js
+++ b/packages/theme-builder/src/commands/validate.js
@@ -1,0 +1,94 @@
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+
+const REQUIRED_FIELDS = ['name', 'version', 'author', 'description', 'components'];
+const NAME_PATTERN = /^[a-z][a-z0-9-]*$/;
+const VERSION_PATTERN = /^\d+\.\d+\.\d+$/;
+const REQUIRES_PATTERN = /^(>=|<=|>|<|=|~|\^)?\d+\.\d+\.\d+$/;
+
+export function validateThemeJson(themeJson, themeDir = '.') {
+    const errors = [];
+    const warnings = [];
+
+    for (const field of REQUIRED_FIELDS) {
+        if (!themeJson[field]) {
+            errors.push(`Missing required field: "${field}"`);
+        }
+    }
+
+    if (errors.length > 0) {
+        return { valid: false, errors, warnings };
+    }
+
+    if (!NAME_PATTERN.test(themeJson.name)) {
+        errors.push(`"name" must be lowercase letters, digits and hyphens only (got: "${themeJson.name}")`);
+    }
+
+    if (!VERSION_PATTERN.test(themeJson.version)) {
+        errors.push(`"version" must be a valid semver like "1.0.0" (got: "${themeJson.version}")`);
+    }
+
+    if (themeJson.requires && !REQUIRES_PATTERN.test(themeJson.requires)) {
+        warnings.push(`"requires" format is unusual (got: "${themeJson.requires}"), expected e.g. ">=0.9.0"`);
+    }
+
+    if (typeof themeJson.components !== 'object' || Array.isArray(themeJson.components)) {
+        errors.push('"components" must be an object mapping component names to file paths');
+    } else if (Object.keys(themeJson.components).length === 0) {
+        errors.push('"components" must have at least one entry');
+    } else {
+        for (const [componentName, componentPath] of Object.entries(themeJson.components)) {
+            if (!componentPath || typeof componentPath !== 'string') {
+                errors.push(`Component "${componentName}" has invalid path`);
+                continue;
+            }
+            const absolutePath = resolve(themeDir, componentPath.replace(/^\/static\/themes\/[^/]+\//, ''));
+            if (!existsSync(absolutePath)) {
+                warnings.push(`Component "${componentName}" file not found: ${componentPath} (expected at ${absolutePath})`);
+            }
+        }
+    }
+
+    return { valid: errors.length === 0, errors, warnings };
+}
+
+export async function validateCommand(options) {
+    const themeDir = resolve(options.dir || '.');
+    const themeJsonPath = join(themeDir, 'theme.json');
+
+    console.log(`Validating theme at: ${themeDir}`);
+
+    if (!existsSync(themeJsonPath)) {
+        console.error('ERROR: theme.json not found');
+        process.exit(1);
+    }
+
+    let themeJson;
+    try {
+        themeJson = JSON.parse(readFileSync(themeJsonPath, 'utf-8'));
+    } catch (err) {
+        console.error(`ERROR: Failed to parse theme.json: ${err.message}`);
+        process.exit(1);
+    }
+
+    const distDir = join(themeDir, 'dist');
+    const { valid, errors, warnings } = validateThemeJson(themeJson, distDir);
+
+    if (warnings.length > 0) {
+        console.warn('\nWarnings:');
+        for (const w of warnings) {
+            console.warn(`  ⚠  ${w}`);
+        }
+    }
+
+    if (!valid) {
+        console.error('\nErrors:');
+        for (const e of errors) {
+            console.error(`  ✗  ${e}`);
+        }
+        console.error('\nValidation FAILED');
+        process.exit(1);
+    }
+
+    console.log('\n✓ theme.json is valid');
+}

--- a/packages/theme-builder/src/index.js
+++ b/packages/theme-builder/src/index.js
@@ -1,0 +1,36 @@
+import { Command } from 'commander';
+import { initCommand } from './commands/init.js';
+import { buildCommand } from './commands/build.js';
+import { validateCommand } from './commands/validate.js';
+
+export function createProgram() {
+    const program = new Command();
+
+    program
+        .name('theme-builder')
+        .description('CLI tool for building Talebook themes')
+        .version('1.0.0');
+
+    program
+        .command('init <theme-name>')
+        .description('Scaffold a new Talebook theme project')
+        .option('-o, --output <dir>', 'Output directory (defaults to theme name)')
+        .option('--author <author>', 'Theme author name', 'unknown')
+        .option('--description <desc>', 'Theme description', 'A custom Talebook theme')
+        .action(initCommand);
+
+    program
+        .command('build')
+        .description('Build theme components using Vite (run inside a theme project)')
+        .option('--outDir <dir>', 'Output directory', 'dist')
+        .option('--config <file>', 'Path to vite.config.js', 'vite.config.js')
+        .action(buildCommand);
+
+    program
+        .command('validate')
+        .description('Validate theme.json and component files')
+        .option('--dir <dir>', 'Theme project directory', '.')
+        .action(validateCommand);
+
+    return program;
+}

--- a/packages/theme-builder/templates/package.json.tpl
+++ b/packages/theme-builder/templates/package.json.tpl
@@ -1,0 +1,16 @@
+{
+  "name": "{{THEME_NAME}}",
+  "version": "{{THEME_VERSION}}",
+  "description": "{{THEME_DESCRIPTION}}",
+  "type": "module",
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite build --watch"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.0.0",
+    "vite": "^5.0.0",
+    "vue": "^3.5.0",
+    "vuetify": "^3.0.0"
+  }
+}

--- a/packages/theme-builder/templates/src/AppFooter.vue.tpl
+++ b/packages/theme-builder/templates/src/AppFooter.vue.tpl
@@ -1,0 +1,26 @@
+<template>
+    <v-row class="mt-6">
+        <v-col
+            cols="12"
+            class="text-center"
+        >
+            <v-divider class="mb-3" />
+            <p class="text-caption text-medium-emphasis">
+                Powered by
+                <v-btn
+                    variant="text"
+                    size="small"
+                    href="https://github.com/talebook/talebook"
+                    target="_blank"
+                >
+                    Talebook
+                </v-btn>
+                &bull; Theme: {{THEME_NAME}}
+            </p>
+        </v-col>
+    </v-row>
+</template>
+
+<script setup>
+// vue and vuetify components are provided by the Talebook host app.
+</script>

--- a/packages/theme-builder/templates/src/AppHeader.vue.tpl
+++ b/packages/theme-builder/templates/src/AppHeader.vue.tpl
@@ -1,0 +1,32 @@
+<template>
+    <v-app-bar
+        color="primary"
+        density="compact"
+    >
+        <v-toolbar-title>{{ title }}</v-toolbar-title>
+
+        <template #append>
+            <v-btn
+                icon="mdi-magnify"
+                @click="$router.push('/search')"
+            />
+            <v-btn
+                icon="mdi-home"
+                @click="$router.push('/')"
+            />
+        </template>
+    </v-app-bar>
+</template>
+
+<script setup>
+// This component is provided by the Talebook host app at runtime.
+// Do not import vue or vuetify here — they are already available globally.
+import { computed } from 'vue';
+
+// Access Vue Router (provided by host)
+import { useRouter } from 'vue-router';
+
+const router = useRouter();
+
+const title = computed(() => '{{THEME_NAME}}');
+</script>

--- a/packages/theme-builder/templates/src/index.js.tpl
+++ b/packages/theme-builder/templates/src/index.js.tpl
@@ -1,0 +1,7 @@
+// Theme entry point — re-exports all components.
+// The vite.config.js compiles each component individually, so this file
+// is mainly used for documentation purposes. Vite uses the named entries
+// in the "lib.entry" config directly.
+
+export { default as AppHeader } from './AppHeader.vue';
+export { default as AppFooter } from './AppFooter.vue';

--- a/packages/theme-builder/templates/theme.json.tpl
+++ b/packages/theme-builder/templates/theme.json.tpl
@@ -1,0 +1,11 @@
+{
+  "name": "{{THEME_NAME}}",
+  "version": "{{THEME_VERSION}}",
+  "author": "{{THEME_AUTHOR}}",
+  "description": "{{THEME_DESCRIPTION}}",
+  "requires": ">=0.9.0",
+  "components": {
+    "AppHeader": "/static/themes/{{THEME_NAME}}/components/AppHeader.js",
+    "AppFooter": "/static/themes/{{THEME_NAME}}/components/AppFooter.js"
+  }
+}

--- a/packages/theme-builder/templates/vite.config.js.tpl
+++ b/packages/theme-builder/templates/vite.config.js.tpl
@@ -1,0 +1,38 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+import { resolve } from 'node:path';
+
+// Pre-configured Vite config for Talebook themes.
+// vue, vuetify, pinia, and vue-router are marked as external so the theme
+// reuses the host app's instances — keeping bundle size small and avoiding
+// duplicate Vue reactivity systems.
+export default defineConfig({
+    plugins: [vue()],
+    build: {
+        lib: {
+            // Each component is compiled to its own ESM file.
+            // Add or remove entries to match the components in theme.json.
+            entry: {
+                AppHeader: resolve('src/AppHeader.vue'),
+                AppFooter: resolve('src/AppFooter.vue'),
+            },
+            formats: ['es'],
+            fileName: (format, entryName) => `components/${entryName}.js`,
+        },
+        rollupOptions: {
+            // These packages are provided by Talebook at runtime.
+            // Do NOT include them in the theme bundle.
+            external: ['vue', 'vuetify', 'vuetify/components', 'vuetify/directives', 'pinia', 'vue-router'],
+            output: {
+                globals: {
+                    vue: 'Vue',
+                    vuetify: 'Vuetify',
+                    pinia: 'Pinia',
+                    'vue-router': 'VueRouter',
+                },
+            },
+        },
+        outDir: 'dist',
+        emptyOutDir: true,
+    },
+});

--- a/packages/theme-builder/test/validate.test.js
+++ b/packages/theme-builder/test/validate.test.js
@@ -1,0 +1,97 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { validateThemeJson } from '../src/commands/validate.js';
+
+describe('validateThemeJson', () => {
+    const validTheme = {
+        name: 'dark-elegant',
+        version: '1.0.0',
+        author: 'talebook',
+        description: 'A dark elegant theme',
+        requires: '>=0.9.0',
+        components: {
+            AppHeader: '/static/themes/dark-elegant/components/AppHeader.js',
+            AppFooter: '/static/themes/dark-elegant/components/AppFooter.js',
+        },
+    };
+
+    it('accepts a valid theme.json', () => {
+        const { valid, errors } = validateThemeJson(validTheme, '/nonexistent');
+        assert.equal(errors.length, 0, `Expected no errors, got: ${errors.join(', ')}`);
+        assert.equal(valid, true);
+    });
+
+    it('rejects theme with missing required fields', () => {
+        const theme = { name: 'my-theme' };
+        const { valid, errors } = validateThemeJson(theme, '/nonexistent');
+        assert.equal(valid, false);
+        assert.ok(errors.some(e => e.includes('version')));
+        assert.ok(errors.some(e => e.includes('author')));
+        assert.ok(errors.some(e => e.includes('description')));
+        assert.ok(errors.some(e => e.includes('components')));
+    });
+
+    it('rejects name with uppercase letters', () => {
+        const theme = { ...validTheme, name: 'DarkElegant' };
+        const { valid, errors } = validateThemeJson(theme, '/nonexistent');
+        assert.equal(valid, false);
+        assert.ok(errors.some(e => e.includes('"name"')));
+    });
+
+    it('rejects name with spaces', () => {
+        const theme = { ...validTheme, name: 'dark elegant' };
+        const { valid, errors } = validateThemeJson(theme, '/nonexistent');
+        assert.equal(valid, false);
+        assert.ok(errors.some(e => e.includes('"name"')));
+    });
+
+    it('rejects invalid semver version', () => {
+        const theme = { ...validTheme, version: 'v1.0' };
+        const { valid, errors } = validateThemeJson(theme, '/nonexistent');
+        assert.equal(valid, false);
+        assert.ok(errors.some(e => e.includes('"version"')));
+    });
+
+    it('rejects empty components object', () => {
+        const theme = { ...validTheme, components: {} };
+        const { valid, errors } = validateThemeJson(theme, '/nonexistent');
+        assert.equal(valid, false);
+        assert.ok(errors.some(e => e.includes('"components"')));
+    });
+
+    it('rejects components as an array', () => {
+        const theme = { ...validTheme, components: ['AppHeader'] };
+        const { valid, errors } = validateThemeJson(theme, '/nonexistent');
+        assert.equal(valid, false);
+        assert.ok(errors.some(e => e.includes('"components"')));
+    });
+
+    it('warns about unusual requires format', () => {
+        const theme = { ...validTheme, requires: 'latest' };
+        const { valid, warnings } = validateThemeJson(theme, '/nonexistent');
+        // Still valid (requires is optional), but should have a warning
+        assert.equal(valid, true);
+        assert.ok(warnings.some(w => w.includes('"requires"')));
+    });
+
+    it('accepts valid requires patterns', () => {
+        for (const req of ['>=0.9.0', '0.9.0', '>1.0.0', '<=2.0.0']) {
+            const theme = { ...validTheme, requires: req };
+            const { warnings } = validateThemeJson(theme, '/nonexistent');
+            assert.ok(!warnings.some(w => w.includes('"requires"')), `Unexpected warning for requires="${req}"`);
+        }
+    });
+
+    it('warns about missing component files', () => {
+        const theme = {
+            ...validTheme,
+            components: {
+                AppHeader: '/static/themes/dark-elegant/components/AppHeader.js',
+            },
+        };
+        const { valid, warnings } = validateThemeJson(theme, '/nonexistent/dist');
+        // Valid structure, but files don't exist on disk
+        assert.equal(valid, true);
+        assert.ok(warnings.some(w => w.includes('AppHeader') && w.includes('not found')));
+    });
+});


### PR DESCRIPTION
feat: 添加 @talebook/theme-builder CLI 工具

实施 #820 提案中的 Phase 4：主题开发者 CLI 工具。

- `theme-builder init <name>` — 脚手架新主题工程，含预配置 Vite（vue/vuetify/pinia/vue-router 均为 external）
- `theme-builder build` — 封装 vite build，将 Vue 组件编译为独立 ESM 文件
- `theme-builder validate` — 校验 theme.json 字段完整性、版本格式、组件文件存在性

Generated with [Claude Code](https://claude.ai/code)