### PR TITLE
Potential fix for code scanning alert no. 1: Full server-side request forgery

### DIFF
--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -5,7 +5,7 @@ import json
 import unittest
 import warnings
 from unittest import mock
-from tests.test_main import TestWithUserLogin, setUpModule as init, testdir, get_db
+from tests.test_main import TestApp, TestWithUserLogin, setUpModule as init, testdir, get_db
 
 
 def setUpModule():

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -257,6 +257,69 @@ class TestCoverUploadSecurity(TestWithUserLogin):
         self.assertNotEqual(d["err"], "params.cover.type")
 
 
+class TestProxyImageHandlerSSRF(TestApp):
+    """ProxyImageHandler SSRF 防护集成测试"""
+
+    @mock.patch("requests.get")
+    def test_valid_url_proxied_with_safe_options(self, mock_get):
+        """合法白名单 URL 应以 allow_redirects=False 和 timeout=10 调用 requests.get"""
+        fake_response = mock.MagicMock()
+        fake_response.headers = {"Content-Type": "image/jpeg"}
+        fake_response.content = b"FAKEIMG"
+        mock_get.return_value = fake_response
+
+        rsp = self.fetch("/get/pcover?url=http://img1.bcebos.com/test.jpg")
+        self.assertEqual(rsp.code, 200)
+        self.assertEqual(rsp.body, b"FAKEIMG")
+        mock_get.assert_called_once()
+        _, kwargs = mock_get.call_args
+        self.assertFalse(kwargs.get("allow_redirects", True))
+        self.assertEqual(kwargs.get("timeout"), 10)
+
+    def test_file_scheme_rejected(self):
+        """file:// scheme 必须被拒绝，返回 yoho"""
+        rsp = self.fetch("/get/pcover?url=file:///etc/passwd")
+        self.assertEqual(rsp.code, 200)
+        self.assertEqual(rsp.body, b"yoho")
+
+    def test_ftp_scheme_rejected(self):
+        """ftp:// scheme 必须被拒绝，返回 yoho"""
+        rsp = self.fetch("/get/pcover?url=ftp://bcebos.com/file.jpg")
+        self.assertEqual(rsp.code, 200)
+        self.assertEqual(rsp.body, b"yoho")
+
+    def test_credentials_in_url_rejected(self):
+        """包含用户名的 URL（user@host 混淆攻击）必须被拒绝，返回 yoho"""
+        rsp = self.fetch("/get/pcover?url=http://evil.com@img1.bcebos.com/img.jpg")
+        self.assertEqual(rsp.code, 200)
+        self.assertEqual(rsp.body, b"yoho")
+
+    def test_non_standard_port_rejected(self):
+        """非标准端口（不是 80/443）必须被拒绝，返回 yoho"""
+        rsp = self.fetch("/get/pcover?url=http://img1.bcebos.com:8080/img.jpg")
+        self.assertEqual(rsp.code, 200)
+        self.assertEqual(rsp.body, b"yoho")
+
+    def test_non_whitelist_domain_rejected(self):
+        """非白名单域名必须被拒绝，返回 yoho"""
+        rsp = self.fetch("/get/pcover?url=http://evil.com/img.jpg")
+        self.assertEqual(rsp.code, 200)
+        self.assertEqual(rsp.body, b"yoho")
+
+    @mock.patch("requests.get")
+    def test_safe_url_rebuilt_without_fragment(self, mock_get):
+        """传给 requests.get 的 URL 不应包含 fragment"""
+        fake_response = mock.MagicMock()
+        fake_response.headers = {}
+        fake_response.content = b""
+        mock_get.return_value = fake_response
+
+        self.fetch("/get/pcover?url=http://img1.bcebos.com/img.jpg%23evil")
+        mock_get.assert_called_once()
+        called_url = mock_get.call_args[0][0]
+        self.assertNotIn("#", called_url)
+
+
 class TestProxyImageWhitelist(unittest.TestCase):
     """ProxyImageHandler.is_whitelist 修复验证（直接测试 files.py 中的实现）"""
 

--- a/webserver/handlers/files.py
+++ b/webserver/handlers/files.py
@@ -109,13 +109,29 @@ class ProxyImageHandler(BaseHandler):
         import requests
 
         p = urllib.parse.urlparse(url)
-        if not self.is_whitelist(p.netloc):
+        if p.scheme not in ("http", "https"):
             self.write("yoho")
             return
 
+        if p.username or p.password:
+            self.write("yoho")
+            return
+
+        host = (p.hostname or "").lower()
+        if not host or not self.is_whitelist(host):
+            self.write("yoho")
+            return
+
+        if p.port is not None and p.port not in (80, 443):
+            self.write("yoho")
+            return
+
+        safe_netloc = host if p.port is None else f"{host}:{p.port}"
+        safe_url = urllib.parse.urlunparse((p.scheme, safe_netloc, p.path, p.params, p.query, ""))
+
         headers = dict(constants.CHROME_HEADERS)
-        headers["Referer"] = url
-        r = requests.get(url, headers=headers)
+        headers["Referer"] = safe_url
+        r = requests.get(safe_url, headers=headers)
         for k, v in r.headers.items():
             self.set_header(k, v)
         self.write(r.content)

--- a/webserver/handlers/files.py
+++ b/webserver/handlers/files.py
@@ -131,7 +131,7 @@ class ProxyImageHandler(BaseHandler):
 
         headers = dict(constants.CHROME_HEADERS)
         headers["Referer"] = safe_url
-        r = requests.get(safe_url, headers=headers)
+        r = requests.get(safe_url, headers=headers, allow_redirects=False, timeout=10)
         for k, v in r.headers.items():
             self.set_header(k, v)
         self.write(r.content)


### PR DESCRIPTION
Potential fix for [https://github.com/talebook/talebook/security/code-scanning/1](https://github.com/talebook/talebook/security/code-scanning/1)

General fix: do not send requests to arbitrary user-provided URLs. Parse and validate URL components strictly (scheme, hostname, optional port), enforce an allowlist against canonical hostname only, and rebuild a sanitized URL from validated parts before calling `requests.get`.

Best fix here (without changing intended functionality): in `webserver/handlers/files.py` inside `ProxyImageHandler.get`:
- Parse with `urllib.parse.urlparse`.
- Require scheme to be only `http` or `https`.
- Use `p.hostname` (not `p.netloc`) for allowlist checks.
- Reject URLs containing username/password (`p.username`/`p.password`) to avoid `user@host` confusion.
- Restrict ports to default web ports (80/443) or no explicit port.
- Reconstruct a safe URL using validated components and pass that to `requests.get`.
- Set `Referer` to the sanitized URL (not raw user input).

No changes are required in `webserver/handlers/base.py`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
