### PR TITLE
Fix Codex workflow runner temp env

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -46,10 +46,6 @@ jobs:
       )
     runs-on: ubuntu-latest
     env:
-      CODEX_HOME: ${{ runner.temp }}/codex-home
-      CODEX_PR_DIFF: ${{ runner.temp }}/codex-pr.diff
-      CODEX_PR_FILES_JSON: ${{ runner.temp }}/codex-pr-files.json
-      CODEX_REQUEST_JSON: ${{ runner.temp }}/codex-request.json
       CODEX_VERSION: "0.141.0"
     steps:
       - id: context
@@ -62,6 +58,16 @@ jobs:
             const repo = context.repo.repo;
             const eventName = context.eventName;
             const payload = context.payload;
+            const runnerTemp = process.env.RUNNER_TEMP;
+            const codexHome = `${runnerTemp}/codex-home`;
+            const codexPrDiff = `${runnerTemp}/codex-pr.diff`;
+            const codexPrFilesJson = `${runnerTemp}/codex-pr-files.json`;
+            const codexRequestJson = `${runnerTemp}/codex-request.json`;
+
+            core.exportVariable("CODEX_HOME", codexHome);
+            core.exportVariable("CODEX_PR_DIFF", codexPrDiff);
+            core.exportVariable("CODEX_PR_FILES_JSON", codexPrFilesJson);
+            core.exportVariable("CODEX_REQUEST_JSON", codexRequestJson);
 
             let body = "";
             let actor = context.actor;
@@ -133,7 +139,7 @@ jobs:
                 per_page: 100,
               });
               fs.writeFileSync(
-                process.env.CODEX_PR_FILES_JSON,
+                codexPrFilesJson,
                 `${JSON.stringify(files.map((file) => ({
                   filename: file.filename,
                   status: file.status,
@@ -154,7 +160,7 @@ jobs:
                 },
               });
               fs.writeFileSync(
-                process.env.CODEX_PR_DIFF,
+                codexPrDiff,
                 typeof diff.data === "string" ? diff.data : JSON.stringify(diff.data, null, 2),
                 { mode: 0o600 },
               );
@@ -182,7 +188,7 @@ jobs:
             };
 
             fs.writeFileSync(
-              process.env.CODEX_REQUEST_JSON,
+              codexRequestJson,
               `${JSON.stringify(request, null, 2)}\n`,
               { mode: 0o600 },
             );


### PR DESCRIPTION
## Summary
- Fix Codex workflow initialization by removing job-level runner.temp expressions
- Compute RUNNER_TEMP-backed paths inside the first github-script step and export them to later steps

## Investigation
- The merged workflow appears as .github/workflows/codex.yml and has push runs with no jobs, which indicates GitHub failed during workflow initialization
- Recent issue_comment events only triggered Claude Code skipped runs, so the Codex workflow was not actually responding to @codex comments
- The native OpenAI Codex message 'To use Codex here, create an environment for this repo.' is separate from this Actions workflow and comes from the Codex GitHub integration

## Verification
- Ruby YAML parser loaded .github/workflows/codex.yml
- Embedded github-script JavaScript passed node --check
- git diff --check passed