### PR TITLE
ci: 多平台构建拆为 matrix 修复 calibre 锁冲突 (#816)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,33 +18,16 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  docker:
+  # ----------------------------------------
+  # 计算构建矩阵与公共构建参数。
+  # PR 只构 linux/amd64；push/tag 构建全部架构，每个架构一个独立 job。
+  prepare:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+      build_args: ${{ steps.prep.outputs.build_args }}
+      safe_ref_name: ${{ steps.prep.outputs.safe_ref_name }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-        id: buildx
-
-      - name: Log in to Docker Hub
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
       - name: Prepare build args and safe ref name
         id: prep
         run: |
@@ -57,61 +40,186 @@ jobs:
           echo "build_args=GIT_VERSION=$VERSION" >> $GITHUB_OUTPUT
           echo "safe_ref_name=$SAFE_REF_NAME" >> $GITHUB_OUTPUT
 
-      - name: Extract metadata (for SPA tags)
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
-            type=raw,value=master,enable=${{ github.ref == 'refs/heads/master' }}
-            type=raw,value=${{ github.ref_name }},enable=${{ startsWith(github.ref, 'refs/tags/') }}
-            type=raw,value=${{ steps.prep.outputs.safe_ref_name }},enable=${{ startsWith(github.ref, 'refs/heads/dev/') || startsWith(github.ref, 'refs/heads/claude/') || startsWith(github.ref, 'refs/heads/codex/') }}
-
-      - name: Set build platforms
-        id: platforms
+      - name: Set build matrix
+        id: matrix
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "platforms=linux/amd64" >> $GITHUB_OUTPUT
+            echo 'matrix={"platform":["linux/amd64"]}' >> $GITHUB_OUTPUT
           else
-            echo "platforms=linux/amd64,linux/arm64,linux/arm/v7" >> $GITHUB_OUTPUT
+            echo 'matrix={"platform":["linux/amd64","linux/arm64","linux/arm/v7"]}' >> $GITHUB_OUTPUT
           fi
 
-      # ----------------------------------------
-      # SPA 镜像：talebook/talebook:latest / <ver> / calibre-webserver:latest
-      - name: Build and push SPA
+  # ----------------------------------------
+  # 每个平台单独一个 job 构建，按 digest 推送（不打 tag）。
+  # 单平台构建保证同一 BuildKit 内不会并发跑多个 calibredb（见 issue #816）。
+  build:
+    needs: prepare
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Platform safe name
+        id: pname
+        run: echo "name=${platform//\//-}" >> $GITHUB_OUTPUT
+        env:
+          platform: ${{ matrix.platform }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set build outputs
+        id: out
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "value=type=image,push=false" >> $GITHUB_OUTPUT
+          else
+            echo "value=type=image,name=${REGISTRY}/${IMAGE_NAME},push-by-digest=true,name-canonical=true,push=true" >> $GITHUB_OUTPUT
+          fi
+        env:
+          REGISTRY: ${{ env.REGISTRY }}
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+
+      - name: Build SPA
+        id: spa
         uses: docker/build-push-action@v5
         with:
           context: .
           target: production-spa
-          platforms: ${{ steps.platforms.outputs.platforms }}
-          labels: ${{ steps.meta.outputs.labels }}
-          push: ${{ github.event_name != 'pull_request' }}
+          platforms: ${{ matrix.platform }}
           provenance: false
-          tags: |
-            ${{ steps.meta.outputs.tags }}
-            ${{ github.repository == 'talebook/talebook' && startsWith(github.ref, 'refs/tags/') && format('{0}/talebook/calibre-webserver:latest', env.REGISTRY) || '' }}
-            ${{ github.repository == 'talebook/talebook' && github.ref == 'refs/heads/master' && format('{0}/talebook/calibre-webserver:master', env.REGISTRY) || '' }}
-          build-args: ${{ steps.prep.outputs.build_args }}
-          cache-from: type=gha,scope=spa
-          cache-to: type=gha,scope=spa,mode=max
+          outputs: ${{ steps.out.outputs.value }}
+          build-args: ${{ needs.prepare.outputs.build_args }}
+          cache-from: type=gha,scope=spa-${{ steps.pname.outputs.name }}
+          cache-to: type=gha,scope=spa-${{ steps.pname.outputs.name }},mode=max
 
-      # ----------------------------------------
-      # SSR 镜像：talebook/talebook:server-side-render / server-side-render-<ver>
-      - name: Build and push SSR
+      - name: Build SSR
+        id: ssr
         uses: docker/build-push-action@v5
         with:
           context: .
           target: production-ssr
-          platforms: ${{ steps.platforms.outputs.platforms }}
-          labels: ${{ steps.meta.outputs.labels }}
-          push: ${{ github.event_name != 'pull_request' }}
+          platforms: ${{ matrix.platform }}
           provenance: false
-          tags: |
-            ${{ startsWith(github.ref, 'refs/tags/') && format('{0}/{1}:server-side-render', env.REGISTRY, env.IMAGE_NAME) || '' }}
-            ${{ startsWith(github.ref, 'refs/tags/') && format('{0}/{1}:server-side-render-{2}', env.REGISTRY, env.IMAGE_NAME, github.ref_name) || '' }}
-            ${{ github.ref == 'refs/heads/master' && format('{0}/{1}:server-side-render', env.REGISTRY, env.IMAGE_NAME) || '' }}
-            ${{ (startsWith(github.ref, 'refs/heads/dev/') || startsWith(github.ref, 'refs/heads/claude/') || startsWith(github.ref, 'refs/heads/codex/')) && format('{0}/{1}:server-side-render-{2}', env.REGISTRY, env.IMAGE_NAME, steps.prep.outputs.safe_ref_name) || '' }}
-          build-args: ${{ steps.prep.outputs.build_args }}
-          cache-from: type=gha,scope=ssr
-          cache-to: type=gha,scope=ssr,mode=max
+          outputs: ${{ steps.out.outputs.value }}
+          build-args: ${{ needs.prepare.outputs.build_args }}
+          cache-from: type=gha,scope=ssr-${{ steps.pname.outputs.name }}
+          cache-to: type=gha,scope=ssr-${{ steps.pname.outputs.name }},mode=max
+
+      - name: Export digests
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p /tmp/digests/spa /tmp/digests/ssr
+          echo "${{ steps.spa.outputs.digest }}" > "/tmp/digests/spa/${{ steps.pname.outputs.name }}"
+          echo "${{ steps.ssr.outputs.digest }}" > "/tmp/digests/ssr/${{ steps.pname.outputs.name }}"
+
+      - name: Upload digests
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ steps.pname.outputs.name }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # ----------------------------------------
+  # 把各平台 digest 合并成 multi-arch manifest，并打上最终 tag。
+  # PR 不推送，跳过本 job。
+  merge:
+    needs: [prepare, build]
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      # SPA 镜像：talebook/talebook:latest / <ver> / master / <branch>，
+      # 以及 calibre-webserver:latest / master（仅 talebook/talebook 仓库）
+      - name: Create SPA manifest
+        run: |
+          IMAGE="${REGISTRY}/${IMAGE_NAME}"
+          TAGS=()
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            TAGS+=("-t" "${IMAGE}:latest" "-t" "${IMAGE}:${GITHUB_REF_NAME}")
+          fi
+          if [[ "$GITHUB_REF" == "refs/heads/master" ]]; then
+            TAGS+=("-t" "${IMAGE}:master")
+          fi
+          if [[ "$GITHUB_REF" == refs/heads/dev/* || "$GITHUB_REF" == refs/heads/claude/* || "$GITHUB_REF" == refs/heads/codex/* ]]; then
+            TAGS+=("-t" "${IMAGE}:${SAFE_REF_NAME}")
+          fi
+          if [[ "$GITHUB_REPOSITORY" == "talebook/talebook" ]]; then
+            if [[ $GITHUB_REF == refs/tags/* ]]; then
+              TAGS+=("-t" "${REGISTRY}/talebook/calibre-webserver:latest")
+            fi
+            if [[ "$GITHUB_REF" == "refs/heads/master" ]]; then
+              TAGS+=("-t" "${REGISTRY}/talebook/calibre-webserver:master")
+            fi
+          fi
+          if [[ ${#TAGS[@]} -eq 0 ]]; then echo "No SPA tags for this ref, skip."; exit 0; fi
+          SRCS=()
+          for f in /tmp/digests/spa/*; do SRCS+=("${IMAGE}@$(cat "$f")"); done
+          docker buildx imagetools create "${TAGS[@]}" "${SRCS[@]}"
+        env:
+          REGISTRY: ${{ env.REGISTRY }}
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          SAFE_REF_NAME: ${{ needs.prepare.outputs.safe_ref_name }}
+
+      # SSR 镜像：talebook/talebook:server-side-render / server-side-render-<ver|branch>
+      - name: Create SSR manifest
+        run: |
+          IMAGE="${REGISTRY}/${IMAGE_NAME}"
+          TAGS=()
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            TAGS+=("-t" "${IMAGE}:server-side-render" "-t" "${IMAGE}:server-side-render-${GITHUB_REF_NAME}")
+          fi
+          if [[ "$GITHUB_REF" == "refs/heads/master" ]]; then
+            TAGS+=("-t" "${IMAGE}:server-side-render")
+          fi
+          if [[ "$GITHUB_REF" == refs/heads/dev/* || "$GITHUB_REF" == refs/heads/claude/* || "$GITHUB_REF" == refs/heads/codex/* ]]; then
+            TAGS+=("-t" "${IMAGE}:server-side-render-${SAFE_REF_NAME}")
+          fi
+          if [[ ${#TAGS[@]} -eq 0 ]]; then echo "No SSR tags for this ref, skip."; exit 0; fi
+          SRCS=()
+          for f in /tmp/digests/ssr/*; do SRCS+=("${IMAGE}@$(cat "$f")"); done
+          docker buildx imagetools create "${TAGS[@]}" "${SRCS[@]}"
+        env:
+          REGISTRY: ${{ env.REGISTRY }}
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          SAFE_REF_NAME: ${{ needs.prepare.outputs.safe_ref_name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,9 @@ env:
   REGISTRY: docker.io
   IMAGE_NAME: ${{ github.repository }}
 
+permissions:
+  contents: read
+
 jobs:
   # ----------------------------------------
   # 计算构建矩阵与公共构建参数。


### PR DESCRIPTION
## 背景

issue #816：多架构构建（amd64/arm64/armv7）时 `calibredb add` 偶发报错 "Another calibre program ... is running"。

根因（见 #816 讨论）：calibre 的 single-instance 锁是 abstract Unix socket，名字按 `calibre-singleinstance-<euid>-db` 生成，**只按 euid 区分、不按库路径区分**。当前 `build.yml` 用一次 buildx 同时构建三个平台，BuildKit 会并发跑各平台的 `RUN`，三个 root（同一 euid）的 `calibredb add` 互相误判成"另一个 calibre 在运行"。

## 改动

把单次 buildx 多平台改为标准的 **matrix 分平台构建 + 合并 manifest**：

- `prepare`：计算构建矩阵与公共构建参数（PR 只 amd64，push/tag 构全部架构）。
- `build`：matrix 按平台展开，每个平台独立 job/runner，单平台构建 SPA + SSR，`push-by-digest` 推送，上传 digest。
- `merge`：合并各平台 digest 成 multi-arch manifest 并打 tag（PR 跳过）。

每个平台单独 buildx → 同一 BuildKit 内不再并发跑多个 calibredb → euid 锁冲突消失。

## 保留 / 变更

- tag 逻辑 1:1 保留（含 SSR `server-side-render*` 与 calibre-webserver 额外 tag）。
- 缓存按平台拆 scope；`fail-fast: false`；PR 行为不变（amd64、不推送）。
- 去掉了 metadata-action 的 OCI labels（换取 merge 逻辑可读性）。

## 验证

本分支为 `claude/*`，push 会触发完整三架构构建。合并前请确认构建通过，并用 `docker buildx imagetools inspect talebook/talebook:claude-fix-816-matrix-build` 确认 manifest 含三个架构。

Fix #816

🤖 Generated with [Claude Code](https://claude.com/claude-code)