### PR TITLE
[codex] ci: allow Codex to comment on PRs

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -11,7 +11,7 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   codex:


### PR DESCRIPTION
## What changed

- Grant the Codex workflow `pull-requests: write` in addition to `issues: write`.

## Why

The failed Codex run `28033736485` completed the Codex execution step, then failed while posting the response back to PR #831:

```text
RequestError [HttpError]: Resource not accessible by integration
POST /repos/talebook/talebook/issues/831/comments
x-accepted-github-permissions: issues=write; pull_requests=write
```

The workflow currently limits `pull-requests` to `read`, so GitHub rejects the PR conversation comment with 403. Giving `pull-requests: write` matches the permission GitHub reports as required for this PR comment path.

## Validation

- Confirmed the diff only changes `.github/workflows/codex.yml` permissions.
- Parsed the workflow file with Ruby YAML loader: `yaml ok`.

No backend or frontend tests were run because this is a GitHub Actions permission-only change.