### PR TITLE
[codex] ci: acknowledge Codex requests with a reaction

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -74,12 +74,15 @@ jobs:
             let issueNumber = "";
             let pr = null;
             let requestKind = eventName;
+            let triggerIssueCommentId = "";
+            let triggerReviewCommentId = "";
 
             if (eventName === "issue_comment") {
               body = payload.comment.body || "";
               actor = payload.comment.user.login;
               issueNumber = String(payload.issue.number);
               requestKind = payload.issue.pull_request ? "pull_request_comment" : "issue_comment";
+              triggerIssueCommentId = String(payload.comment.id);
 
               if (payload.issue.pull_request) {
                 const result = await github.rest.pulls.get({
@@ -92,6 +95,7 @@ jobs:
             } else if (eventName === "pull_request_review_comment") {
               body = payload.comment.body || "";
               actor = payload.comment.user.login;
+              triggerReviewCommentId = String(payload.comment.id);
               const result = await github.rest.pulls.get({
                 owner,
                 repo,
@@ -129,6 +133,34 @@ jobs:
 
             if (!authorized) {
               core.warning(`Skipping Codex request from ${actor}; repository permission is ${permission}.`);
+            }
+
+            if (authorized) {
+              try {
+                if (triggerIssueCommentId) {
+                  await github.rest.reactions.createForIssueComment({
+                    owner,
+                    repo,
+                    comment_id: Number(triggerIssueCommentId),
+                    content: "rocket",
+                  });
+                } else if (triggerReviewCommentId) {
+                  await github.rest.reactions.createForPullRequestReviewComment({
+                    owner,
+                    repo,
+                    comment_id: Number(triggerReviewCommentId),
+                    content: "rocket",
+                  });
+                } else {
+                  core.info("No trigger comment ID is available for an acknowledgement reaction.");
+                }
+              } catch (error) {
+                if (error.status === 422) {
+                  core.info("Acknowledgement reaction already exists or cannot be added to this comment.");
+                } else {
+                  core.warning(`Could not add acknowledgement reaction: ${error.message}`);
+                }
+              }
             }
 
             if (authorized && pr) {


### PR DESCRIPTION
## What changed

- Add a `rocket` reaction to the GitHub comment that triggered the Codex workflow.
- Apply the reaction immediately after the requester passes repository permission checks and before Codex fetches PR files/diff or starts longer work.
- Support both top-level issue/PR comments and inline pull request review comments.
- Treat reaction failures as non-blocking warnings so Codex can still run.

## Why

When a maintainer comments `@codex`, the workflow can take time before posting a final response. Adding an immediate reaction gives visible feedback that the request was accepted and is working.

## Validation

- Confirmed the diff only changes `.github/workflows/codex.yml`.
- Parsed the workflow file with Ruby YAML loader: `yaml ok`.
- Ran `git diff --check`.

No backend or frontend tests were run because this is a GitHub Actions workflow-only change.