### PR TITLE
修复了书架相关的bug

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -285,12 +285,12 @@ class TestReadingState(unittest.TestCase):
         s.set_read_state(99)
         self.assertEqual(s.get_read_state(), 1)
 
-    def test_set_read_state_clears_wants(self):
+    def test_set_read_state_preserves_wants(self):
         s = self._make_state()
         s.set_wants(True)
         self.assertEqual(s.wants, 1)
         s.set_read_state(1)
-        self.assertEqual(s.wants, 0)
+        self.assertEqual(s.wants, 1)
 
     def test_set_online_read(self):
         s = self._make_state()

--- a/webserver/models.py
+++ b/webserver/models.py
@@ -512,8 +512,6 @@ class ReadingState(Base, SQLAlchemyMixin):
         if read_state in [0, 1, 2]:
             self.read_state = read_state
             self.read_date = datetime.datetime.now()
-        if read_state > READ_STATE_UNREAD:
-            self.wants = 0
 
     def get_read_state(self):
         return self.read_state


### PR DESCRIPTION
### 改动概述

本 PR 修复了 `ReadingState` 模型中 `set_read_state()` 的一个逻辑 bug，共涉及 2 个文件、4 行代码。

#### 问题（修复前）

`webserver/models.py` 的 `set_read_state()` 中存在以下逻辑：

```python
if read_state > READ_STATE_UNREAD:
    self.wants = 0   # ← 只要标记为"在读/读完"，就会清除"想读"状态
```

即：用户只要将书的阅读状态设为"在读（1）"或"读完（2）"，系统就会**自动清除**其"想读"（`wants`）标记，导致用户的想读书单数据被意外抹去。

#### 修复（修复后）

删除了上述两行代码，使 `wants`（想读）与 `read_state`（阅读进度）**彼此独立**，互不干扰：

```python
def set_read_state(self, read_state):
    if read_state in [0, 1, 2]:
        self.read_state = read_state
        self.read_date = datetime.datetime.now()
    # wants 字段不再被联动清除
```

#### 测试更新

`tests/test_models.py` 同步更新，测试名称和断言均反映新行为：

| | 修复前 | 修复后 |
|---|---|---|
| 测试方法名 | `test_set_read_state_clears_wants` | `test_set_read_state_preserves_wants` |
| 断言 | `self.assertEqual(s.wants, 0)` | `self.assertEqual(s.wants, 1)` |

---

**总结**：这是一个单一职责修复，逻辑清晰，测试同步更新，改动范围最小。"想读"与"已读/在读"状态应相互独立，此 PR 消除了两者之间不合理的联动。