### PR TITLE
feat: add option to keep existing cover during auto-fill metadata

### DIFF
--- a/app/i18n/locales/en-US.json
+++ b/app/i18n/locales/en-US.json
@@ -681,6 +681,7 @@
         "name": "Name",
         "link": "Link",
         "autoFillMeta": "Auto fill book info",
+        "autoFillKeepCover": "Keep existing cover when auto filling book info",
         "metaSelectedSource": "Select enabled metadata sources",
         "doubanBaseurl": "Douban API URL",
         "doubanApiKey": "Douban API Key",

--- a/app/i18n/locales/en-US.json
+++ b/app/i18n/locales/en-US.json
@@ -681,7 +681,7 @@
         "name": "Name",
         "link": "Link",
         "autoFillMeta": "Auto fill book info",
-        "autoFillKeepCover": "Keep existing cover when auto filling book info",
+        "autoFillKeepCover": "Only update book info when auto-filling",
         "metaSelectedSource": "Select enabled metadata sources",
         "doubanBaseurl": "Douban API URL",
         "doubanApiKey": "Douban API Key",

--- a/app/i18n/locales/zh-CN.json
+++ b/app/i18n/locales/zh-CN.json
@@ -711,7 +711,7 @@
         "name": "名称",
         "link": "链接",
         "autoFillMeta": "自动从互联网拉取新书的书籍信息",
-        "autoFillKeepCover": "自动拉取书籍信息时，保留原有封面不被覆盖",
+        "autoFillKeepCover": "自动拉取书籍信息时，仅修改书籍信息",
         "metaSelectedSource": "选择启用的元数据源",
         "doubanBaseurl": "豆瓣插件 API 地址 (例如 http://10.0.0.1:8080 )",
         "doubanApiKey": "豆瓣 API Key",

--- a/app/i18n/locales/zh-CN.json
+++ b/app/i18n/locales/zh-CN.json
@@ -711,6 +711,7 @@
         "name": "名称",
         "link": "链接",
         "autoFillMeta": "自动从互联网拉取新书的书籍信息",
+        "autoFillKeepCover": "自动拉取书籍信息时，保留原有封面不被覆盖",
         "metaSelectedSource": "选择启用的元数据源",
         "doubanBaseurl": "豆瓣插件 API 地址 (例如 http://10.0.0.1:8080 )",
         "doubanApiKey": "豆瓣 API Key",

--- a/app/pages/admin/settings.vue
+++ b/app/pages/admin/settings.vue
@@ -854,7 +854,8 @@ const cards = computed(() => [
         subtitle: t('admin.settings.message.bookInfoSourcesInfo'),
         fields: [
             { icon: '', key: 'auto_fill_meta', label: t('admin.settings.label.autoFillMeta'), type: 'checkbox' },
-            { 
+            { icon: '', key: 'auto_fill_keep_cover', label: t('admin.settings.label.autoFillKeepCover'), type: 'checkbox' },
+            {
                 icon: 'mdi-source-branch',
                 key: 'META_SELECTED_SOURCES',
                 label: t('admin.settings.label.metaSelectedSource'),

--- a/tests/test_autofill.py
+++ b/tests/test_autofill.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+
+from unittest import mock
+
+from tests.test_main import TestWithUserLogin
+from tests.test_main import setUpModule as init
+from webserver.services.autofill import AutoFillService
+
+
+def setUpModule():
+    init()
+
+
+class TestAutoFillKeepCover(TestWithUserLogin):
+    def setUp(self):
+        super().setUp()
+        self.service = AutoFillService()
+        self.original_db = self.service.db
+        self.service.db = mock.MagicMock()
+
+    def tearDown(self):
+        self.service.db = self.original_db
+        super().tearDown()
+
+    def _make_mi(self, title, has_cover, cover_data):
+        from calibre.ebooks.metadata.book.base import Metadata
+
+        mi = Metadata(title, ["原作者"])
+        mi.comments = "原简介"
+        mi.has_cover = has_cover
+        mi.cover_data = cover_data
+        return mi
+
+    @mock.patch.object(AutoFillService, "plugin_search_best_book_info")
+    def test_keeps_original_cover_when_option_enabled(self, mock_search):
+        mi = self._make_mi("原书名", has_cover=True, cover_data=("jpg", b"old-cover"))
+        refer_mi = self._make_mi("错误的书名", has_cover=True, cover_data=("jpg", b"wrong-cover"))
+        refer_mi.comments = "新简介"
+        refer_mi.authors = ["新作者"]
+        mock_search.return_value = refer_mi
+
+        with mock.patch.dict("webserver.services.autofill.CONF", {"auto_fill_keep_cover": True}):
+            ok = self.service.do_fill_metadata(1, mi)
+
+        self.assertTrue(ok)
+        # 封面保持原样，未被抓取到的错误封面覆盖
+        self.assertEqual(mi.cover_data, ("jpg", b"old-cover"))
+        # 其它字段仍然被更新
+        self.assertEqual(mi.comments, "新简介")
+        self.assertEqual(mi.authors, ["新作者"])
+
+    @mock.patch.object(AutoFillService, "plugin_search_best_book_info")
+    def test_overwrites_cover_when_option_disabled(self, mock_search):
+        mi = self._make_mi("原书名", has_cover=True, cover_data=("jpg", b"old-cover"))
+        refer_mi = self._make_mi("错误的书名", has_cover=True, cover_data=("jpg", b"wrong-cover"))
+        mock_search.return_value = refer_mi
+
+        with mock.patch.dict("webserver.services.autofill.CONF", {"auto_fill_keep_cover": False}):
+            ok = self.service.do_fill_metadata(1, mi)
+
+        self.assertTrue(ok)
+        self.assertEqual(mi.cover_data, ("jpg", b"wrong-cover"))
+
+    @mock.patch.object(AutoFillService, "plugin_search_best_book_info")
+    def test_skips_update_when_no_cover_found_and_option_disabled(self, mock_search):
+        mi = self._make_mi("原书名", has_cover=False, cover_data=None)
+        refer_mi = self._make_mi("错误的书名", has_cover=False, cover_data=None)
+        mock_search.return_value = refer_mi
+
+        with mock.patch.dict("webserver.services.autofill.CONF", {"auto_fill_keep_cover": False}):
+            ok = self.service.do_fill_metadata(1, mi)
+
+        self.assertFalse(ok)

--- a/webserver/handlers/admin.py
+++ b/webserver/handlers/admin.py
@@ -394,6 +394,7 @@ class AdminSettings(BaseHandler):
             "douban_baseurl",
             "douban_max_count",
             "auto_fill_meta",
+            "auto_fill_keep_cover",
             "META_SELECTED_SOURCES",
             "ai_api_url",
             "ai_api_key",

--- a/webserver/services/autofill.py
+++ b/webserver/services/autofill.py
@@ -106,7 +106,10 @@ class AutoFillService(AsyncService):
             logging.info(_("忽略更新书籍 id=%d : 无法获取信息"), book_id)
             return False
 
-        if refer_mi.cover_data is None:
+        # 若开启了保留封面选项，且书籍已有封面，则不使用抓取到的封面覆盖原封面
+        if CONF.get("auto_fill_keep_cover", False) and mi.has_cover:
+            refer_mi.cover_data = None
+        elif refer_mi.cover_data is None:
             logging.info(_("忽略更新书籍 id=%d : 无法获取封面"), book_id)
             return False
 

--- a/webserver/services/autofill.py
+++ b/webserver/services/autofill.py
@@ -106,12 +106,16 @@ class AutoFillService(AsyncService):
             logging.info(_("忽略更新书籍 id=%d : 无法获取信息"), book_id)
             return False
 
-        # 若开启了保留封面选项，且书籍已有封面，则不使用抓取到的封面覆盖原封面
-        if CONF.get("auto_fill_keep_cover", False) and mi.has_cover:
-            refer_mi.cover_data = None
-        elif refer_mi.cover_data is None:
+        # 若开启了保留封面选项，且书籍已有封面，则保留原封面，不被抓取到的封面覆盖
+        keep_cover = CONF.get("auto_fill_keep_cover", False) and mi.has_cover
+        refer_has_cover = bool(refer_mi.cover_data and refer_mi.cover_data[1])
+
+        if not keep_cover and not refer_has_cover:
             logging.info(_("忽略更新书籍 id=%d : 无法获取封面"), book_id)
             return False
+
+        if keep_cover:
+            refer_mi.cover_data = mi.cover_data
 
         # 保留书名不修改（万一出 BUG，还能抢救一下）
         title = utils.remove_zlibrary_suffix(mi.title)

--- a/webserver/settings.py
+++ b/webserver/settings.py
@@ -94,6 +94,7 @@ settings = {
     'douban_baseurl'    : "https://api.douban.com",
     'douban_max_count'  : 2,
     'auto_fill_meta'    : False,
+    'auto_fill_keep_cover': False,
     'META_SELECTED_SOURCES': ["douban", "baidu", "google", "amazon", "xinhua"],
     'ai_api_url'        : "https://api.openai.com/v1/chat/completions",
     'ai_api_key'        : "",

--- a/webserver/settings.py
+++ b/webserver/settings.py
@@ -94,7 +94,7 @@ settings = {
     'douban_baseurl'    : "https://api.douban.com",
     'douban_max_count'  : 2,
     'auto_fill_meta'    : False,
-    'auto_fill_keep_cover': False,
+    'auto_fill_keep_cover': True,
     'META_SELECTED_SOURCES': ["douban", "baidu", "google", "amazon", "xinhua"],
     'ai_api_url'        : "https://api.openai.com/v1/chat/completions",
     'ai_api_key'        : "",


### PR DESCRIPTION
## Summary
- Auto-fetched metadata (e.g. from Douban) sometimes matches the wrong book and overwrites the correct cover.
- Adds a new setting `auto_fill_keep_cover` so admins can opt to keep the existing cover when a book already has one, while other metadata fields (title/author/comments/etc) are still updated.

Fixes #497

🤖 Generated with [Claude Code](https://claude.ai/code)