### PR TITLE
fix: 增加启动自检与status页，修复误判的“服务器启动中”提示

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,6 +111,7 @@ RUN mkdir -p /data/log/nginx/ && \
     mkdir -p /data/books/logo && \
     mkdir -p /data/books/ssl && \
     mkdir -p /var/www/talebook/ && \
+    mkdir -p /var/www/talebook/status && \
     chmod a+w -R /data/log /data/books /var/www
 
 COPY server.py /var/www/talebook/
@@ -119,6 +120,7 @@ COPY webserver/ /var/www/talebook/webserver/
 COPY conf/nginx/ssl.* /data/books/ssl/
 COPY conf/nginx/talebook.conf /etc/nginx/conf.d/
 COPY conf/supervisor/talebook.conf /etc/supervisor/conf.d/
+COPY docker/status_page.html /var/www/talebook/status/status_page.html
 COPY --from=builder /app-static/ /var/www/talebook/app/
 COPY --from=builder /app-static/dist/logo/ /data/books/logo/
 

--- a/app/plugins/talebook.js
+++ b/app/plugins/talebook.js
@@ -72,9 +72,18 @@ export default defineNuxtPlugin((nuxtApp) => {
       }
 
       if (rsp.status === 502) {
-        msg = '服务器正在启动中...';
-        showAlert('info', msg);
-        throw msg;
+        let status = null;
+        try {
+          const statusRsp = await fetch(server + '/status.json', { cache: 'no-store' });
+          if (statusRsp.ok) {
+            status = await statusRsp.json();
+          }
+        } catch (e) {
+          status = null;
+        }
+        const alert = resolveStatusAlert(status);
+        showAlert(alert.type, alert.msg);
+        throw alert.msg;
       }
 
       if (rsp.status !== 200) {
@@ -149,6 +158,33 @@ export default defineNuxtPlugin((nuxtApp) => {
     }
   };
 });
+
+// 502 时展示的启动状态提示：由 docker/start.sh + webserver/self_check.py 写入的
+// /status.json 提供 phase 与失败 step 的 code（枚举），文案只从下面这份固定白名单里取，
+// 不拼接 status.json 里的任何自由文本，避免把后端日志/环境变量/路径带到页面上（v-html 渲染）。
+const STATUS_CODE_HINTS = {
+  permission_denied: '检测到 /data 目录写入失败，请检查挂载卷的 PUID/PGID 与目录权限设置。',
+  nginx_config_invalid: 'Nginx 配置校验失败，请检查是否覆盖了自定义证书或配置文件。',
+  syncdb_failed: '数据库初始化失败，请检查 /data/books 目录是否可写、磁盘空间是否充足。',
+  migrate_failed: '数据库结构迁移失败，请检查 /data/books/calibre-webserver.db 是否可正常访问。',
+  update_config_failed: '服务器配置写入失败，请检查 /data/books/settings 目录权限。',
+};
+
+const STATUS_STARTING_MSG = '服务器正在启动中，请稍候...';
+const STATUS_FAILED_FALLBACK_MSG = '服务器启动失败。';
+const STATUS_PAGE_LINK = '<br/><a href="/status_page.html" target="_blank">查看详细启动状态</a>';
+
+// 根据 /status.json 的内容为 502 场景生成提示：拿不到该文件（老镜像/尚未生成）或
+// phase 还在 starting，保留原有的通用"启动中"提示；phase 为 failed 时换成具体建议，
+// 并附上跳转到 /status_page.html 的入口，用户不用进容器看日志。单独导出以便单元测试。
+export function resolveStatusAlert(status) {
+  if (!status || status.phase !== 'failed') {
+    return { type: 'info', msg: STATUS_STARTING_MSG };
+  }
+  const failedStep = (status.steps || []).find((step) => step.status === 'failed');
+  const hint = (failedStep && STATUS_CODE_HINTS[failedStep.code]) || STATUS_FAILED_FALLBACK_MSG;
+  return { type: 'error', msg: hint + STATUS_PAGE_LINK };
+}
 
 // 解析 NDJSON（换行分隔的 JSON）流：逐行 yield 已解析的对象，跳过空行与非法行，
 // 并正确拼接跨 chunk 被截断的行。单独导出以便单元测试。

--- a/app/test/plugins/talebook.nuxt.spec.ts
+++ b/app/test/plugins/talebook.nuxt.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseNdjson } from '~/plugins/talebook';
+import { parseNdjson, resolveStatusAlert } from '~/plugins/talebook';
 
 // 构造一个最小 Response：body.getReader() 按给定的 chunk 序列依次吐出数据。
 // 用于验证 parseNdjson 的逐行解析与跨 chunk 拼接逻辑。
@@ -42,5 +42,43 @@ describe('parseNdjson', () => {
     it('跳过空行与非法 JSON', async () => {
         const res = fakeResponse(['{"id":1}\n\nnot-json\n{"id":2}\n']);
         expect(await collect(parseNdjson(res))).toEqual([{ id: 1 }, { id: 2 }]);
+    });
+});
+
+describe('resolveStatusAlert', () => {
+    it('拿不到 status.json 时，回退到通用的"启动中"提示', () => {
+        const alert = resolveStatusAlert(null);
+        expect(alert.type).toBe('info');
+        expect(alert.msg).toContain('启动中');
+    });
+
+    it('phase 仍为 starting 时，保持通用提示', () => {
+        const alert = resolveStatusAlert({ schema: 1, phase: 'starting', steps: [] });
+        expect(alert.type).toBe('info');
+        expect(alert.msg).toContain('启动中');
+    });
+
+    it('phase 为 failed 且命中已知 code 时，展示具体建议并附带诊断页链接', () => {
+        const alert = resolveStatusAlert({
+            schema: 1,
+            phase: 'failed',
+            steps: [
+                { name: 'permission', status: 'failed', code: 'permission_denied' },
+                { name: 'nginx_config', status: 'pending', code: null },
+            ],
+        });
+        expect(alert.type).toBe('error');
+        expect(alert.msg).toContain('PUID/PGID');
+        expect(alert.msg).toContain('/status_page.html');
+    });
+
+    it('phase 为 failed 但 code 未知时，展示兜底文案', () => {
+        const alert = resolveStatusAlert({
+            schema: 1,
+            phase: 'failed',
+            steps: [{ name: 'syncdb', status: 'failed', code: 'unknown_future_code' }],
+        });
+        expect(alert.type).toBe('error');
+        expect(alert.msg).toContain('服务器启动失败');
     });
 });

--- a/conf/nginx/server-side-render.conf
+++ b/conf/nginx/server-side-render.conf
@@ -48,6 +48,18 @@ server {
         proxy_set_header X-Scheme $req_scheme;
     }
 
+    # 启动自检状态，供前端在 502 时读取展示，必须直接由 nginx 静态返回，
+    # 不能落入下面的 @ssr fallback，否则 tornado/nodejs 没起来时这份诊断信息本身也拿不到
+    location = /status.json {
+        alias /var/www/talebook/status/status.json;
+        add_header Cache-Control "no-store";
+        default_type application/json;
+    }
+    location = /status_page.html {
+        alias /var/www/talebook/status/status_page.html;
+        add_header Cache-Control "no-store";
+    }
+
     # for ssr mode
     location @ssr {
         proxy_pass       http://nuxtjs;

--- a/conf/nginx/talebook.conf
+++ b/conf/nginx/talebook.conf
@@ -44,6 +44,18 @@ server {
         proxy_set_header X-Scheme $req_scheme;
     }
 
+    # 启动自检状态，供前端在 502 时读取展示，必须直接由 nginx 静态返回，
+    # 不能落入下面的 SPA fallback，否则 tornado 没起来时这份诊断信息本身也拿不到
+    location = /status.json {
+        alias /var/www/talebook/status/status.json;
+        add_header Cache-Control "no-store";
+        default_type application/json;
+    }
+    location = /status_page.html {
+        alias /var/www/talebook/status/status_page.html;
+        add_header Cache-Control "no-store";
+    }
+
     # for spa mode
     # use `npm run build-spa` to generate dist/ dir
     location = /index.html {

--- a/conf/supervisor/server-side-render.conf
+++ b/conf/supervisor/server-side-render.conf
@@ -7,7 +7,7 @@ autostart=true
 autorestart=unexpected
 
 ; 启动自检：权限校验、nginx 配置检查、syncdb/migrate/update-config，逐项写入
-; status.json；全部通过后才会 `supervisorctl start tornado`。失败时不重试
+; status.json；全部通过后才会 `supervisorctl start talebook:tornado`。失败时不重试
 ; （autorestart=false），nginx 与 /status.json、/status_page.html 仍然可访问。
 [program:bootstrap]
 command=python3 /var/www/talebook/webserver/self_check.py

--- a/conf/supervisor/server-side-render.conf
+++ b/conf/supervisor/server-side-render.conf
@@ -1,18 +1,33 @@
 [group:talebook]
-programs=tornado,nginx,nodejs
-
-[program:tornado]
-command=gosu talebook:talebook python3 server.py --with-library=/data/books/library --port=8000 --host=127.0.0.1 --logging=debug --log-file-prefix=/data/log/talebook.log
-directory=/var/www/talebook
-autorestart=true
-redirect_stderr=true
-stdout_logfile=/dev/fd/1
-stdout_logfile_maxbytes=0
+programs=nginx,nodejs,bootstrap,tornado
 
 [program:nginx]
 command = /usr/sbin/nginx -g 'daemon off;'
 autostart=true
 autorestart=unexpected
+
+; 启动自检：权限校验、nginx 配置检查、syncdb/migrate/update-config，逐项写入
+; status.json；全部通过后才会 `supervisorctl start tornado`。失败时不重试
+; （autorestart=false），nginx 与 /status.json、/status_page.html 仍然可访问。
+[program:bootstrap]
+command=python3 /var/www/talebook/webserver/self_check.py
+directory=/var/www/talebook
+autostart=true
+autorestart=false
+startsecs=0
+redirect_stderr=true
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+
+; 不再随 group 自动启动，由 bootstrap 自检全部通过后拉起
+[program:tornado]
+command=gosu talebook:talebook python3 server.py --with-library=/data/books/library --port=8000 --host=127.0.0.1 --logging=debug --log-file-prefix=/data/log/talebook.log
+directory=/var/www/talebook
+autostart=false
+autorestart=true
+redirect_stderr=true
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
 
 [program:nodejs]
 command=gosu talebook:talebook npm run start

--- a/conf/supervisor/talebook.conf
+++ b/conf/supervisor/talebook.conf
@@ -1,16 +1,31 @@
 [group:talebook]
-programs=tornado,nginx
-
-[program:tornado]
-command=gosu talebook:talebook python3 server.py --with-library=/data/books/library --port=8000 --host=127.0.0.1 --logging=debug --log-file-prefix=/data/log/talebook.log
-directory=/var/www/talebook
-autorestart=true
-redirect_stderr=true
-stdout_logfile=/dev/fd/1
-stdout_logfile_maxbytes=0
+programs=nginx,bootstrap,tornado
 
 [program:nginx]
 command = /usr/sbin/nginx -g 'daemon off;'
 autostart=true
 autorestart=unexpected
+
+; 启动自检：权限校验、nginx 配置检查、syncdb/migrate/update-config，逐项写入
+; status.json；全部通过后才会 `supervisorctl start tornado`。失败时不重试
+; （autorestart=false），nginx 与 /status.json、/status_page.html 仍然可访问。
+[program:bootstrap]
+command=python3 /var/www/talebook/webserver/self_check.py
+directory=/var/www/talebook
+autostart=true
+autorestart=false
+startsecs=0
+redirect_stderr=true
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+
+; 不再随 group 自动启动，由 bootstrap 自检全部通过后拉起
+[program:tornado]
+command=gosu talebook:talebook python3 server.py --with-library=/data/books/library --port=8000 --host=127.0.0.1 --logging=debug --log-file-prefix=/data/log/talebook.log
+directory=/var/www/talebook
+autostart=false
+autorestart=true
+redirect_stderr=true
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
 

--- a/conf/supervisor/talebook.conf
+++ b/conf/supervisor/talebook.conf
@@ -7,7 +7,7 @@ autostart=true
 autorestart=unexpected
 
 ; 启动自检：权限校验、nginx 配置检查、syncdb/migrate/update-config，逐项写入
-; status.json；全部通过后才会 `supervisorctl start tornado`。失败时不重试
+; status.json；全部通过后才会 `supervisorctl start talebook:tornado`。失败时不重试
 ; （autorestart=false），nginx 与 /status.json、/status_page.html 仍然可访问。
 [program:bootstrap]
 command=python3 /var/www/talebook/webserver/self_check.py

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -38,17 +38,8 @@ done
 
 mkdir -p /root/.npm
 
-# 设置PUID/GUID权限
-permission_file=/data/.permission
-touch $permission_file
-permission=`cat $permission_file`
-if [ "x$permission" != "x$PUID:$PGID" ]; then
-    echo "updating '/data/' permission to $PUID:$PGID"
-    chown -R talebook:talebook /data
-    echo "$PUID:$PGID" > $permission_file
-fi
-
-# 设置系统文件的权限（数量较少）
+# 设置系统文件的权限（数量较少，且 nginx/诊断页在自检完成前就需要可用，必须先于 supervisord 启动前就绪）
+mkdir -p /data/log/nginx /var/www/talebook/status
 chown -R talebook:talebook \
   /data/log/ \
   /var/lib/nginx \
@@ -58,37 +49,15 @@ chown -R talebook:talebook \
   /var/www/talebook/app/dist \
   /var/www/talebook/webserver \
   /var/www/talebook/server.py \
+  /var/www/talebook/status \
   /usr/lib/calibre \
   /usr/share/calibre
 
-# 检测权限
-TEST_WRITE_FILE=/data/books/library/test_writeable.txt
-date > $TEST_WRITE_FILE
-if [ $? -ne 0 ]; then
-    echo "目录权限异常，无法写入";
-    exit 1
-else
-    rm $TEST_WRITE_FILE
-fi
-
-# 启动
+# /data/books 的权限校验、nginx 配置检查、数据库初始化/迁移/配置写入这些"可能失败"的
+# 步骤，交给 supervisor 的 bootstrap program（webserver/self_check.py）在 nginx 启动
+# 之后逐项自检并写入 status.json；任一步失败都不会导致容器整体重启，nginx 与诊断页
+# 始终可访问，用户不需要进入容器查看日志即可知道卡在哪一步、该怎么处理。
 export PYTHONDONTWRITEBYTECODE=1
-echo
-echo "====== Check config ===="
-nginx -t || exit 1
-
-echo
-echo "====== Sync DB Scheme ===="
-gosu talebook:talebook /var/www/talebook/server.py --syncdb
-
-echo
-echo "====== Migrate Database Schema ===="
-echo "Checking for missing columns and adding them..."
-gosu talebook:talebook /var/www/talebook/webserver/migrate_db.py
-
-echo
-echo "====== Update Server Config ===="
-gosu talebook:talebook /var/www/talebook/server.py --update-config
 
 echo
 echo "====== Start Server ===="

--- a/docker/status_page.html
+++ b/docker/status_page.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<title>Talebook 启动状态</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+  body { font-family: -apple-system, "Microsoft YaHei", sans-serif; max-width: 640px; margin: 40px auto; padding: 0 16px; color: #222; }
+  h1 { font-size: 20px; }
+  ul { list-style: none; padding: 0; }
+  li { padding: 10px 12px; margin-bottom: 8px; border-radius: 6px; background: #f5f5f5; display: flex; align-items: center; }
+  li .icon { margin-right: 10px; font-size: 16px; }
+  li.ok { background: #eaf7ea; }
+  li.failed { background: #fdecea; }
+  li.pending { background: #f5f5f5; color: #888; }
+  .hint { margin-top: 4px; font-size: 13px; color: #a33; display: block; }
+  #summary { padding: 12px; border-radius: 6px; margin-bottom: 16px; }
+  #summary.ready { background: #eaf7ea; }
+  #summary.failed { background: #fdecea; }
+  #summary.starting { background: #eef3fb; }
+  #error { color: #a33; }
+</style>
+</head>
+<body>
+<h1>Talebook 启动状态</h1>
+<div id="summary">正在加载...</div>
+<ul id="steps"></ul>
+<p id="error" style="display:none">无法读取 /status.json，请稍后刷新，或确认容器是否正常运行（可用 <code>docker logs</code> 查看）。</p>
+
+<script>
+var STEP_NAMES = {
+  permission: '数据目录权限校验',
+  nginx_config: 'Nginx 配置检查',
+  syncdb: '数据库初始化',
+  migrate: '数据库结构迁移',
+  update_config: '服务器配置写入'
+};
+
+var CODE_HINTS = {
+  permission_denied: '检测到 /data 目录写入失败，请检查挂载卷的 PUID/PGID 与目录权限设置。',
+  nginx_config_invalid: 'Nginx 配置校验失败，请检查是否覆盖了自定义证书或配置文件。',
+  syncdb_failed: '数据库初始化失败，请检查 /data/books 目录是否可写、磁盘空间是否充足。',
+  migrate_failed: '数据库结构迁移失败，请检查 /data/books/calibre-webserver.db 是否可正常访问。',
+  update_config_failed: '服务器配置写入失败，请检查 /data/books/settings 目录权限。'
+};
+
+var SUMMARY_TEXT = {
+  starting: '服务器正在启动中，请稍候...',
+  ready: '服务器已就绪。',
+  failed: '服务器启动失败，请根据下方提示处理。'
+};
+
+function render(doc) {
+  var summary = document.getElementById('summary');
+  summary.className = doc.phase;
+  summary.textContent = SUMMARY_TEXT[doc.phase] || doc.phase;
+
+  var list = document.getElementById('steps');
+  list.innerHTML = '';
+  (doc.steps || []).forEach(function (step) {
+    var li = document.createElement('li');
+    li.className = step.status;
+    var icon = step.status === 'ok' ? '✅' : (step.status === 'failed' ? '❌' : '⏳');
+    var name = STEP_NAMES[step.name] || step.name;
+    var html = '<span class="icon">' + icon + '</span><span>' + name + '</span>';
+    li.innerHTML = html;
+    if (step.status === 'failed' && step.code && CODE_HINTS[step.code]) {
+      var hint = document.createElement('span');
+      hint.className = 'hint';
+      hint.textContent = CODE_HINTS[step.code];
+      li.appendChild(hint);
+    }
+    list.appendChild(li);
+  });
+}
+
+function poll() {
+  fetch('/status.json', { cache: 'no-store' })
+    .then(function (rsp) {
+      if (!rsp.ok) { throw new Error('status ' + rsp.status); }
+      return rsp.json();
+    })
+    .then(function (doc) {
+      document.getElementById('error').style.display = 'none';
+      render(doc);
+    })
+    .catch(function () {
+      document.getElementById('error').style.display = 'block';
+    });
+}
+
+poll();
+setInterval(poll, 3000);
+</script>
+</body>
+</html>

--- a/tests/test_self_check.py
+++ b/tests/test_self_check.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env pytest
+# -*- coding: UTF-8 -*-
+
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from unittest import mock
+
+from webserver import self_check
+
+
+class TestSelfCheckSteps(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmpdir, ignore_errors=True)
+
+        self.data_dir = os.path.join(self.tmpdir, "data")
+        self.status_dir = os.path.join(self.tmpdir, "status")
+        os.makedirs(os.path.join(self.data_dir, "books", "library"))
+
+        self._orig_data_dir = self_check.DATA_DIR
+        self._orig_status_dir = self_check.STATUS_DIR
+        self_check.DATA_DIR = self.data_dir
+        self_check.STATUS_DIR = self.status_dir
+        self.addCleanup(self._restore_dirs)
+
+        env_patch = mock.patch.dict(os.environ, {"PUID": "1000", "PGID": "1000"})
+        env_patch.start()
+        self.addCleanup(env_patch.stop)
+
+    def _restore_dirs(self):
+        self_check.DATA_DIR = self._orig_data_dir
+        self_check.STATUS_DIR = self._orig_status_dir
+
+    def test_write_status_schema(self):
+        self_check.write_status([{"name": "permission", "status": "ok", "code": None}], phase="ready")
+        with open(os.path.join(self.status_dir, "status.json")) as f:
+            doc = json.load(f)
+        self.assertEqual(doc["schema"], 1)
+        self.assertEqual(doc["phase"], "ready")
+        self.assertIn("updated_at", doc)
+        self.assertEqual(doc["steps"], [{"name": "permission", "status": "ok", "code": None}])
+
+    @mock.patch("webserver.self_check.run")
+    def test_check_permission_chowns_when_puid_changed(self, m_run):
+        m_run.return_value = True
+        ok, code = self_check.check_permission()
+        self.assertTrue(ok)
+        self.assertIsNone(code)
+        with open(os.path.join(self.data_dir, ".permission")) as f:
+            self.assertEqual(f.read().strip(), "1000:1000")
+        chown_call, write_test_call = m_run.call_args_list
+        self.assertEqual(chown_call.args[0][:2], ["chown", "-R"])
+        self.assertEqual(write_test_call.args[0][0], "gosu")
+
+    @mock.patch("webserver.self_check.run")
+    def test_check_permission_skips_chown_when_unchanged(self, m_run):
+        with open(os.path.join(self.data_dir, ".permission"), "w") as f:
+            f.write("1000:1000")
+        m_run.return_value = True
+
+        ok, code = self_check.check_permission()
+
+        self.assertTrue(ok)
+        self.assertIsNone(code)
+        self.assertEqual(m_run.call_count, 1)
+        self.assertEqual(m_run.call_args.args[0][0], "gosu")
+
+    @mock.patch("webserver.self_check.run")
+    def test_check_permission_chown_failure(self, m_run):
+        m_run.return_value = False
+        ok, code = self_check.check_permission()
+        self.assertFalse(ok)
+        self.assertEqual(code, "permission_denied")
+        self.assertFalse(os.path.exists(os.path.join(self.data_dir, ".permission")))
+
+    @mock.patch("webserver.self_check.run")
+    def test_check_permission_write_test_failure(self, m_run):
+        m_run.side_effect = [True, False]
+        ok, code = self_check.check_permission()
+        self.assertFalse(ok)
+        self.assertEqual(code, "permission_denied")
+
+    @mock.patch("webserver.self_check.run")
+    def test_check_nginx_config(self, m_run):
+        m_run.return_value = True
+        self.assertEqual(self_check.check_nginx_config(), (True, None))
+        m_run.return_value = False
+        self.assertEqual(self_check.check_nginx_config(), (False, "nginx_config_invalid"))
+
+    @mock.patch("webserver.self_check.run")
+    def test_check_syncdb(self, m_run):
+        m_run.return_value = True
+        self.assertEqual(self_check.check_syncdb(), (True, None))
+        m_run.return_value = False
+        self.assertEqual(self_check.check_syncdb(), (False, "syncdb_failed"))
+
+    @mock.patch("webserver.self_check.run")
+    def test_check_migrate(self, m_run):
+        m_run.return_value = True
+        self.assertEqual(self_check.check_migrate(), (True, None))
+        m_run.return_value = False
+        self.assertEqual(self_check.check_migrate(), (False, "migrate_failed"))
+
+    @mock.patch("webserver.self_check.run")
+    def test_check_update_config(self, m_run):
+        m_run.return_value = True
+        self.assertEqual(self_check.check_update_config(), (True, None))
+        m_run.return_value = False
+        self.assertEqual(self_check.check_update_config(), (False, "update_config_failed"))
+
+
+class TestRunBootstrap(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmpdir, ignore_errors=True)
+        self._orig_status_dir = self_check.STATUS_DIR
+        self_check.STATUS_DIR = os.path.join(self.tmpdir, "status")
+        self.addCleanup(self._restore)
+
+    def _restore(self):
+        self_check.STATUS_DIR = self._orig_status_dir
+
+    def _status(self):
+        with open(os.path.join(self_check.STATUS_DIR, "status.json")) as f:
+            return json.load(f)
+
+    def test_all_steps_ok_starts_tornado(self):
+        checks = [("a", lambda: (True, None)), ("b", lambda: (True, None))]
+        start_tornado_fn = mock.Mock()
+
+        result = self_check.run_bootstrap(checks=checks, start_tornado_fn=start_tornado_fn)
+
+        self.assertTrue(result)
+        start_tornado_fn.assert_called_once()
+        doc = self._status()
+        self.assertEqual(doc["phase"], "ready")
+        self.assertEqual([s["status"] for s in doc["steps"]], ["ok", "ok"])
+
+    def test_stops_at_first_failure_and_skips_tornado(self):
+        second_check = mock.Mock(return_value=(True, None))
+        checks = [
+            ("a", lambda: (False, "permission_denied")),
+            ("b", second_check),
+        ]
+        start_tornado_fn = mock.Mock()
+
+        result = self_check.run_bootstrap(checks=checks, start_tornado_fn=start_tornado_fn)
+
+        self.assertFalse(result)
+        start_tornado_fn.assert_not_called()
+        second_check.assert_not_called()
+        doc = self._status()
+        self.assertEqual(doc["phase"], "failed")
+        self.assertEqual(doc["steps"][0], {"name": "a", "status": "failed", "code": "permission_denied"})
+        self.assertEqual(doc["steps"][1]["status"], "pending")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_self_check.py
+++ b/tests/test_self_check.py
@@ -157,6 +157,12 @@ class TestRunBootstrap(unittest.TestCase):
         self.assertEqual(doc["steps"][0], {"name": "a", "status": "failed", "code": "permission_denied"})
         self.assertEqual(doc["steps"][1]["status"], "pending")
 
+    @mock.patch("webserver.self_check.subprocess.run")
+    def test_start_tornado_uses_group_process_name(self, m_run):
+        # tornado 在 [group:talebook] 中，supervisorctl 必须用 group:program 形式的进程名
+        self_check.start_tornado()
+        m_run.assert_called_once_with(["supervisorctl", "start", "talebook:tornado"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/webserver/self_check.py
+++ b/webserver/self_check.py
@@ -19,6 +19,7 @@ import os
 import subprocess
 import sys
 
+
 DATA_DIR = os.environ.get("TALEBOOK_DATA_DIR", "/data")
 SERVER_DIR = os.environ.get("TALEBOOK_SERVER_DIR", "/var/www/talebook")
 STATUS_DIR = os.environ.get("TALEBOOK_STATUS_DIR", "/var/www/talebook/status")
@@ -32,7 +33,7 @@ def _status_path():
 
 
 def _now():
-    return datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def write_status(steps, phase):
@@ -115,7 +116,8 @@ CHECKS = [
 
 
 def start_tornado():
-    subprocess.run(["supervisorctl", "start", "tornado"])
+    # tornado 位于 [group:talebook] 中，supervisor 的进程名是 talebook:tornado
+    subprocess.run(["supervisorctl", "start", "talebook:tornado"])
 
 
 def run_bootstrap(checks=CHECKS, start_tornado_fn=start_tornado):

--- a/webserver/self_check.py
+++ b/webserver/self_check.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+"""容器启动自检。
+
+以 root 身份作为 supervisor 的 bootstrap program 运行，在 nginx 已经起来之后
+逐项校验运行环境（数据目录权限、nginx 配置、数据库初始化/迁移/配置写入），每完成
+一步就把结果写入 status.json。任一步失败就停止后续步骤且不再拉起 tornado，但
+nginx 不受影响，用户可以直接通过 /status.json、/status_page.html 看到诊断结果，
+不需要进入容器查看日志。
+
+status.json 只提供 phase/status/code，不写入 stderr、日志内容、环境变量或宿主机
+路径；每个 code 对应的提示文案由前端（app/plugins/talebook.js）和
+docker/status_page.html 各自维护一份固定白名单。
+"""
+
+import datetime
+import json
+import os
+import subprocess
+import sys
+
+DATA_DIR = os.environ.get("TALEBOOK_DATA_DIR", "/data")
+SERVER_DIR = os.environ.get("TALEBOOK_SERVER_DIR", "/var/www/talebook")
+STATUS_DIR = os.environ.get("TALEBOOK_STATUS_DIR", "/var/www/talebook/status")
+RUN_USER = os.environ.get("TALEBOOK_RUN_USER", "talebook")
+
+SCHEMA_VERSION = 1
+
+
+def _status_path():
+    return os.path.join(STATUS_DIR, "status.json")
+
+
+def _now():
+    return datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def write_status(steps, phase):
+    os.makedirs(STATUS_DIR, exist_ok=True)
+    doc = {
+        "schema": SCHEMA_VERSION,
+        "phase": phase,
+        "updated_at": _now(),
+        "steps": steps,
+    }
+    path = _status_path()
+    tmp_path = path + ".tmp"
+    with open(tmp_path, "w") as f:
+        json.dump(doc, f)
+    os.replace(tmp_path, path)
+
+
+def run(cmd):
+    """执行命令并把输出打印到 stdout（docker logs 可见，便于管理员排查），但不回传给
+    调用方——status.json 只记录成功与否 + 错误 code，不落地 stderr/日志内容。"""
+    print("[self_check] $ %s" % " ".join(cmd))
+    result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    output = result.stdout.decode("utf-8", "replace")
+    if output.strip():
+        print(output)
+    return result.returncode == 0
+
+
+def check_permission():
+    """校验 /data/books 的属主与写入权限，仅在 PUID/PGID 变化时重新 chown（避免大型书库每次重启都全量 chown）。"""
+    permission_file = os.path.join(DATA_DIR, ".permission")
+    current = "%s:%s" % (os.environ.get("PUID", "0"), os.environ.get("PGID", "0"))
+    previous = None
+    if os.path.exists(permission_file):
+        with open(permission_file) as f:
+            previous = f.read().strip()
+
+    if previous != current:
+        books_dir = os.path.join(DATA_DIR, "books")
+        if not run(["chown", "-R", "%s:%s" % (RUN_USER, RUN_USER), books_dir]):
+            return False, "permission_denied"
+        with open(permission_file, "w") as f:
+            f.write(current)
+
+    test_file = os.path.join(DATA_DIR, "books", "library", "test_writeable.txt")
+    write_test = "date > '{0}' && rm -f '{0}'".format(test_file)
+    if not run(["gosu", "%s:%s" % (RUN_USER, RUN_USER), "sh", "-c", write_test]):
+        return False, "permission_denied"
+
+    return True, None
+
+
+def check_nginx_config():
+    return (True, None) if run(["nginx", "-t"]) else (False, "nginx_config_invalid")
+
+
+def check_syncdb():
+    cmd = ["gosu", "%s:%s" % (RUN_USER, RUN_USER), os.path.join(SERVER_DIR, "server.py"), "--syncdb"]
+    return (True, None) if run(cmd) else (False, "syncdb_failed")
+
+
+def check_migrate():
+    cmd = ["gosu", "%s:%s" % (RUN_USER, RUN_USER), os.path.join(SERVER_DIR, "webserver", "migrate_db.py")]
+    return (True, None) if run(cmd) else (False, "migrate_failed")
+
+
+def check_update_config():
+    cmd = ["gosu", "%s:%s" % (RUN_USER, RUN_USER), os.path.join(SERVER_DIR, "server.py"), "--update-config"]
+    return (True, None) if run(cmd) else (False, "update_config_failed")
+
+
+# 顺序即自检顺序，也是 status.json 里 steps 的顺序
+CHECKS = [
+    ("permission", check_permission),
+    ("nginx_config", check_nginx_config),
+    ("syncdb", check_syncdb),
+    ("migrate", check_migrate),
+    ("update_config", check_update_config),
+]
+
+
+def start_tornado():
+    subprocess.run(["supervisorctl", "start", "tornado"])
+
+
+def run_bootstrap(checks=CHECKS, start_tornado_fn=start_tornado):
+    steps = [{"name": name, "status": "pending", "code": None} for name, _ in checks]
+    write_status(steps, phase="starting")
+
+    for index, (name, check) in enumerate(checks):
+        print("[self_check] ==== %s ====" % name)
+        ok, code = check()
+        steps[index]["status"] = "ok" if ok else "failed"
+        steps[index]["code"] = code
+        if not ok:
+            print("[self_check] %s failed: %s" % (name, code))
+            write_status(steps, phase="failed")
+            return False
+        write_status(steps, phase="starting")
+
+    print("[self_check] all checks passed, starting tornado")
+    write_status(steps, phase="ready")
+    start_tornado_fn()
+    return True
+
+
+if __name__ == "__main__":
+    sys.exit(0 if run_bootstrap() else 1)


### PR DESCRIPTION
## Summary
- nginx 现在始终先于自检启动且不受其失败影响，新增 /status.json + /status_page.html 诊断页，用户不用进容器看日志就能知道卡在哪一步、该怎么处理
- 权限校验/nginx 配置检查/syncdb/migrate/update-config 改由 supervisor 的 bootstrap program（webserver/self_check.py）逐项执行，全部通过后才 supervisorctl start tornado
- 前端 502 时读取 status.json，按固定白名单展示具体建议，不再只显示通用的"启动中"

## Test plan
- [ ] `make lint-py` 通过
- [ ] `make pytest` 通过（重点看 tests/test_self_check.py）
- [ ] `cd app && npm run lint` 通过
- [ ] `npx vitest run test/plugins/talebook.nuxt.spec.ts` 通过
- [ ] 实际 `docker build` + `docker run`，模拟 PUID/PGID 权限错误场景，确认 nginx 仍然可访问且 /status_page.html 展示正确
- [ ] 确认 talebook-base:8.5 镜像中 supervisorctl RPC 可用（依赖 Debian 默认 supervisord.conf）

Closes #769

🤖 Generated with [Claude Code](https://claude.ai/code)