### PR TITLE
[codex] Fix empty states and update checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,5 +101,6 @@ app_old
 
 # 本地 dev 固化的 demo 种子环境（含 db 与 secret，勿提交）
 docker/seed/
+demo-data/
 node_modules
 mod

--- a/app/components/BookCards.vue
+++ b/app/components/BookCards.vue
@@ -59,7 +59,7 @@
         
         <!-- 空状态提示 -->
         <v-row
-            v-if="render_books.length === 0"
+            v-if="showEmptyState && render_books.length === 0"
             class="empty-state"
         >
             <v-col cols="12">
@@ -90,14 +90,18 @@ const props = defineProps({
         type: Array,
         default: () => [],
     },
+    showEmptyState: {
+        type: Boolean,
+        default: false,
+    },
 });
 
 const render_books = computed(() => {
     return props.books.map( b => {
-        if ( b['href'] == undefined ) {
-            b['href'] = '/book/' + b.id;
-        }
-        return b;
+        return {
+            ...b,
+            href: b.href ?? '/book/' + b.id,
+        };
     });
 });
 </script>

--- a/app/components/BookCards_Small.vue
+++ b/app/components/BookCards_Small.vue
@@ -59,7 +59,7 @@
         
         <!-- 空状态提示 -->
         <v-row
-            v-if="render_books.length === 0"
+            v-if="showEmptyState && render_books.length === 0"
             class="empty-state"
         >
             <v-col cols="12">
@@ -94,6 +94,10 @@ const props = defineProps({
         type: Number,
         default: 3,
     },
+    showEmptyState: {
+        type: Boolean,
+        default: false,
+    },
 });
 
 const cols = computed(() => {
@@ -113,10 +117,10 @@ const mdCols = computed(() => {
 
 const render_books = computed(() => {
     return props.books.map( b => {
-        if ( b['href'] == undefined ) {
-            b['href'] = '/book/' + b.id;
-        }
-        return b;
+        return {
+            ...b,
+            href: b.href ?? '/book/' + b.id,
+        };
     });
 });
 </script>

--- a/app/components/BookList.vue
+++ b/app/components/BookList.vue
@@ -8,7 +8,10 @@
             </v-col>
 
             <v-col cols="12">
-                <BookCards :books="books" />
+                <BookCards
+                    :books="books"
+                    :show-empty-state="loaded && books.length === 0"
+                />
             </v-col>
 
             <v-col cols="12">
@@ -44,15 +47,18 @@ const books = ref([]);
 const total = ref(0);
 const page_size = ref(60);
 const page = ref(1);
+const loaded = ref(false);
 
 const loadData = async () => {
     const fullPath = route.fullPath;
+    loaded.value = false;
     try {
         const rsp = await $backend(fullPath);
         if (rsp.err === 'ok') {
             title.value = rsp.title;
             books.value = rsp.books || [];
             total.value = rsp.total || 0;
+            loaded.value = true;
         }
     } catch (e) {
         console.error(e);

--- a/app/components/ListBook.vue
+++ b/app/components/ListBook.vue
@@ -10,7 +10,10 @@
             </v-col>
 
             <v-col cols="12">
-                <BookCards :books="books" />
+                <BookCards
+                    :books="books"
+                    :show-empty-state="loaded && books.length === 0"
+                />
             </v-col>
 
             <v-col cols="12">
@@ -45,6 +48,7 @@ const books = ref([]);
 const total = ref(0);
 const page_size = 60;
 const page_cnt = ref(0);
+const loaded = ref(false);
 
 // Initialize page from query
 if (route.query.start != undefined) {
@@ -53,6 +57,7 @@ if (route.query.start != undefined) {
 
 // Fetch data function
 const fetchData = async () => {
+    loaded.value = false;
     try {
         const data = await $backend(route.fullPath);
         if (data.err != 'ok') {
@@ -63,6 +68,7 @@ const fetchData = async () => {
         books.value = data.books;
         total.value = data.total;
         page_cnt.value = total.value > 0 ? Math.max(1, Math.ceil(total.value / page_size)) : 0;
+        loaded.value = true;
     } catch (e) {
         console.error(e);
     }
@@ -81,6 +87,7 @@ watch(data, (newData) => {
         books.value = newData.books;
         total.value = newData.total;
         page_cnt.value = total.value > 0 ? Math.max(1, Math.ceil(total.value / page_size)) : 0;
+        loaded.value = true;
     } else if (newData && newData.err !== 'ok' && $alert) {
         $alert('error', newData.msg);
     }
@@ -88,6 +95,7 @@ watch(data, (newData) => {
 
 // Watch for route changes (e.g. search query change or pagination)
 watch(() => route.fullPath, async () => {
+    loaded.value = false;
     await refresh();  // 刷新 useAsyncData
     // fetchData()  // 或者直接调用 fetchData
 });

--- a/app/components/MetaList.vue
+++ b/app/components/MetaList.vue
@@ -46,7 +46,7 @@
         
         <!-- 空状态提示 -->
         <v-row
-            v-if="meta_items.length === 0"
+            v-if="loaded && meta_items.length === 0"
             class="empty-state"
         >
             <v-col cols="12">
@@ -93,13 +93,16 @@ const show_all = ref(false);
 const items = ref([]);
 const total = ref(0);
 const page_size = ref(20);
+const loaded = ref(false);
 
 const loadData = async () => {
     const path = '/' + meta.value + (show_all.value ? '?show=all' : '');
+    loaded.value = false;
     try {
         const rsp = await $backend(path);
         items.value = rsp.items || [];
         total.value = rsp.total || 0;
+        loaded.value = true;
     } catch (e) {
         console.error(e);
     }
@@ -109,10 +112,12 @@ const loadData = async () => {
 // 使用 useAsyncData 替代直接调用
 const { data, refresh } = useAsyncData(`meta-${meta.value}`, async () => {
     const path = '/' + meta.value + (show_all.value ? '?show=all' : '');
+    loaded.value = false;
     try {
         const rsp = await $backend(path);
         items.value = rsp.items || [];
         total.value = rsp.total || 0;
+        loaded.value = true;
         return rsp;
     } catch (e) {
         console.error(e);

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -29,7 +29,7 @@
             </v-col>
             <!-- 空状态提示 -->
             <v-col
-                v-if="get_random_books.length === 0"
+                v-if="!indexPending && get_random_books.length === 0"
                 cols="12"
             >
                 <v-card class="ma-1 pa-6 text-center">
@@ -119,7 +119,7 @@ onMounted(() => {
 });
 
 // 修复: 直接使用 useAsyncData 不添加 await
-const { data: indexData } = useAsyncData('index', () => 
+const { data: indexData, pending: indexPending } = useAsyncData('index', () =>
     $backend('/index')
 );
 

--- a/app/pages/library.vue
+++ b/app/pages/library.vue
@@ -298,7 +298,10 @@
                     color="primary"
                     class="mb-3"
                 />
-                <BookCards :books="books">
+                <BookCards
+                    :books="books"
+                    :show-empty-state="inited && !loading && books.length === 0"
+                >
                     <template #introduce="{ book }">
                         <SerializeStatusBadge
                             v-if="book.serialize_status"

--- a/app/pages/nav.vue
+++ b/app/pages/nav.vue
@@ -26,7 +26,7 @@
 
         <!-- 空状态提示 -->
         <v-row
-            v-if="!hasAnyBooks"
+            v-if="loaded && !hasAnyBooks"
             class="empty-state"
         >
             <v-col cols="12">
@@ -60,6 +60,7 @@ const { $backend } = useNuxtApp();
 const { t } = useI18n();
 
 const navs = ref([]);
+const loaded = ref(false);
 
 // 修复1: 移除 await，正确使用 useAsyncData
 const { data: navData } = useAsyncData('nav', async () => {
@@ -76,6 +77,7 @@ const { data: navData } = useAsyncData('nav', async () => {
 watch(navData, (newData) => {
     if (newData) {
         navs.value = newData.navs || [];
+        loaded.value = true;
     }
 }, { immediate: true });
 

--- a/app/pages/scopedbooks.vue
+++ b/app/pages/scopedbooks.vue
@@ -13,7 +13,10 @@
                     color="primary"
                     class="mb-3"
                 />
-                <BookCards :books="books" />
+                <BookCards
+                    :books="books"
+                    :show-empty-state="inited && !loading && books.length === 0"
+                />
             </v-col>
 
             <v-col cols="12">

--- a/app/test/components/BookCards.nuxt.spec.ts
+++ b/app/test/components/BookCards.nuxt.spec.ts
@@ -13,7 +13,7 @@ const vuetify = createVuetify({
 global.ResizeObserver = require('resize-observer-polyfill');
 
 describe('BookCards.vue', () => {
-    it('renders empty state correctly (User Experience: Empty State)', () => {
+    it('does not render empty state by default', () => {
         const wrapper = mount(BookCards, {
             global: {
                 plugins: [vuetify],
@@ -26,6 +26,27 @@ describe('BookCards.vue', () => {
             },
             props: {
                 books: []
+            }
+        });
+
+        expect(wrapper.text()).not.toContain('本书库暂无藏书');
+        expect(wrapper.find('.mdi-book-open-variant').exists()).toBe(false);
+    });
+
+    it('renders empty state when explicitly enabled (User Experience: Empty State)', () => {
+        const wrapper = mount(BookCards, {
+            global: {
+                plugins: [vuetify],
+                mocks: {
+                    $t: (key: string) => ({
+                        'messages.noBooks': '本书库暂无藏书',
+                        'messages.addBooksFirst': '请先添加书籍到书库',
+                    }[key] || key),
+                },
+            },
+            props: {
+                books: [],
+                showEmptyState: true,
             }
         });
     

--- a/tests/test_update_checker.py
+++ b/tests/test_update_checker.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env pytest
+# -*- coding: UTF-8 -*-
+
+import json
+import unittest
+from unittest import mock
+
+from webserver.services import update_checker
+from webserver.services.update_checker import UpdateChecker
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self):
+        return json.dumps(self.payload).encode("utf-8")
+
+
+class TestUpdateCheckerVersionCompare(unittest.TestCase):
+    def test_compare_versions_normalizes_v_prefix(self):
+        self.assertFalse(update_checker._compare_versions("v26.06.29", "26.06.29"))
+        self.assertFalse(update_checker._compare_versions("26.06.29", "v26.06.29"))
+
+    def test_compare_versions_only_true_for_newer_version(self):
+        self.assertTrue(update_checker._compare_versions("26.06.28", "v26.06.29"))
+        self.assertFalse(update_checker._compare_versions("26.06.29", "v26.06.28"))
+        self.assertFalse(update_checker._compare_versions("26.06.29", "26.06.29"))
+
+
+class TestUpdateChecker(unittest.TestCase):
+    def setUp(self):
+        UpdateChecker._instance = None
+        self.addCleanup(setattr, UpdateChecker, "_instance", None)
+
+    def _mock_latest_release(self, tag_name):
+        payload = {
+            "tag_name": tag_name,
+            "html_url": "https://example.test/release",
+            "name": tag_name,
+            "body": "release body",
+        }
+        return mock.patch("webserver.services.update_checker.urllib.request.urlopen", return_value=_FakeResponse(payload))
+
+    def test_check_for_updates_does_not_report_same_version_with_v_prefix(self):
+        checker = UpdateChecker()
+        checker.current_version = "v26.06.29"
+
+        with self._mock_latest_release("26.06.29"):
+            checker.check_for_updates()
+
+        self.assertFalse(checker.has_update)
+        self.assertEqual(checker.latest_version, "26.06.29")
+        self.assertIsNone(checker.check_error)
+
+    def test_check_for_updates_reports_only_newer_latest_release(self):
+        checker = UpdateChecker()
+        checker.current_version = "v26.06.28"
+
+        with self._mock_latest_release("v26.06.29"):
+            checker.check_for_updates()
+
+        self.assertTrue(checker.has_update)
+        self.assertEqual(checker.latest_version, "26.06.29")
+        self.assertIsNone(checker.check_error)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/webserver/services/update_checker.py
+++ b/webserver/services/update_checker.py
@@ -2,8 +2,10 @@
 # -*- coding: UTF-8 -*-
 
 import datetime
+import itertools
 import json
 import logging
+import re
 import ssl
 import threading
 import time
@@ -26,19 +28,45 @@ _UNVERIFIED_CONTEXT.check_hostname = False
 _UNVERIFIED_CONTEXT.verify_mode = ssl.CERT_NONE
 
 
+def _normalize_version(version):
+    """Normalize release tags for comparison and storage."""
+    return str(version or "").strip().lstrip("vV")
+
+
+def _version_parts(version):
+    return [int(part) for part in re.findall(r"\d+", _normalize_version(version))]
+
+
 def _compare_versions(v1, v2):
-    """Compare two version strings, return True if v2 > v1"""
-    try:
-        parts1 = [int(x) for x in v1.split(".")]
-        parts2 = [int(x) for x in v2.split(".")]
-        for p1, p2 in zip(parts1, parts2, strict=True):
-            if p2 > p1:
-                return True
-            if p2 < p1:
-                return False
-        return len(parts2) > len(parts1)
-    except Exception:
-        return v2 != v1
+    """Compare two version strings, return True if v2 > v1."""
+    normalized_v1 = _normalize_version(v1)
+    normalized_v2 = _normalize_version(v2)
+    if normalized_v1 == normalized_v2:
+        return False
+
+    parts1 = _version_parts(normalized_v1)
+    parts2 = _version_parts(normalized_v2)
+    if not parts1 or not parts2:
+        return normalized_v2 != normalized_v1
+
+    for p1, p2 in itertools.zip_longest(parts1, parts2, fillvalue=0):
+        if p2 > p1:
+            return True
+        if p2 < p1:
+            return False
+    return False
+
+
+def _has_newer_version(current_version, latest_version):
+    return bool(_normalize_version(latest_version)) and _compare_versions(current_version, latest_version)
+
+
+def _same_version(v1, v2):
+    return _normalize_version(v1) == _normalize_version(v2)
+
+
+def _release_version(tag_name):
+    return _normalize_version(tag_name)
 
 
 class UpdateChecker:
@@ -96,13 +124,13 @@ class UpdateChecker:
                 logging.error("Update check failed: %s", self.check_error)
                 return
 
-            self.latest_version = data.get("tag_name", "").lstrip("v")
+            self.latest_version = _release_version(data.get("tag_name", ""))
             self.latest_release_url = data.get("html_url", "")
             self.latest_release_name = data.get("name", "")
             self.latest_release_body = data.get("body", "")
             self.last_check_time = time.time()
 
-            if self.latest_version and self.latest_version != self.current_version:
+            if _has_newer_version(self.current_version, self.latest_version):
                 self.has_update = True
                 logging.info(
                     "Update available: current=%s, latest=%s",
@@ -151,7 +179,7 @@ class UpdateChecker:
 
                 if existing:
                     existing_version = existing.data.get(UPDATE_NOTIFY_VERSION_KEY, "")
-                    if existing_version == self.latest_version:
+                    if _same_version(existing_version, self.latest_version):
                         continue
                     if _compare_versions(existing_version, self.latest_version):
                         existing.data[UPDATE_NOTIFY_VERSION_KEY] = self.latest_version


### PR DESCRIPTION
## Summary

- Gate book and metadata empty states behind loaded/pending checks so first load and searches do not flash `本书库暂无藏书` before data returns.
- Add explicit `showEmptyState` handling for book card components and avoid mutating incoming book props while filling default hrefs.
- Normalize release versions in the update checker so `v26.06.29` and `26.06.29` are treated as the same version.
- Ignore generated local `demo-data/` artifacts so runtime data and secrets are not accidentally reviewed or committed.

## Validation

- `cd app && npm run lint -- --quiet`
- `cd app && npx vitest run test/components/`
- `python3 -m pytest tests/test_update_checker.py`
- `make lint-py`