### PR TITLE
[codex] Fix builtin theme overlay dialogs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,26 @@ make dev     # 挂载 webserver/ 进容器，用于后端开发调试
 - 后端改动在 `tests/` 中添加用例，前端改动在 `app/test/` 中添加用例。
 - 具体写法见各子目录的 CLAUDE.md。
 
+### 前端验收
+
+- 修改前端交互、样式、主题、页面布局或弹窗时，除单元/组件测试外，必须使用 Chrome DevTools MCP 在浏览器中做实际渲染验证，并在回复中说明验证过的页面、主题或关键状态。
+- 前端改动完成后，如果需要 dev server 才能体验，必须启动本地 dev server，并在最终回复中提供可访问地址（例如 `http://127.0.0.1:3000/`）。
+- 前端本地体验默认启动方式：
+  ```bash
+  cd app
+  npx nuxt dev --port 3000 --host 127.0.0.1
+  ```
+- 如需使用本仓库 mock API，可用两个终端启动 mock 与 Nuxt：
+  ```bash
+  # 终端 1
+  cd app
+  PORT=18180 node test/mock-server.js
+
+  # 终端 2
+  cd app
+  API_URL=http://127.0.0.1:18180 npx nuxt dev --port 3000 --host 127.0.0.1
+  ```
+
 ### 提交前检查
 
 ```bash

--- a/app/components/themes/BuiltinThemeHeader.vue
+++ b/app/components/themes/BuiltinThemeHeader.vue
@@ -278,6 +278,7 @@
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
 import { useDisplay } from 'vuetify';
 import { useMainStore } from '@/stores/main';
+import { buildBuiltinThemeOverlayCss } from '@/utils/builtin-theme-overlay';
 import { useI18n } from '#i18n';
 
 const props = defineProps({
@@ -413,7 +414,7 @@ function injectThemeStyles() {
     injectedStyle?.remove();
     const style = document.createElement('style');
     style.setAttribute('data-talebook-theme', props.variant);
-    style.textContent = themeCss[props.variant];
+    style.textContent = `${themeCss[props.variant]}\n${buildBuiltinThemeOverlayCss(props.variant)}`;
     document.head.appendChild(style);
     injectedStyle = style;
 }

--- a/app/test/utils/builtin-themes.spec.ts
+++ b/app/test/utils/builtin-themes.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { buildBuiltinThemeOverlayCss, builtinThemeNames } from '~/utils/builtin-theme-overlay';
 import { builtinThemeLoaders, isBuiltinTheme, loadBuiltinThemeComponent } from '~/utils/builtin-themes';
 
 describe('builtin-themes', () => {
@@ -20,5 +21,25 @@ describe('builtin-themes', () => {
             expect(builtinThemeLoaders[themeName].AppFooter).toEqual(expect.any(Function));
         }
         expect(await loadBuiltinThemeComponent('custom-theme', 'AppHeader')).toBeNull();
+    });
+
+    it('generates overlay styles for teleported dialogs and menus', () => {
+        for (const themeName of builtinThemeNames) {
+            const css = buildBuiltinThemeOverlayCss(themeName);
+
+            expect(css).toContain(`body.tb-current-builtin-theme-${themeName}.tb-current-builtin-theme-mode-light .v-overlay-container`);
+            expect(css).toContain(`body.tb-current-builtin-theme-${themeName}.tb-current-builtin-theme-mode-dark .v-overlay-container`);
+            expect(css).toContain('.v-overlay__content .v-toolbar.bg-primary');
+            expect(css).toContain('.v-overlay__content .v-card');
+        }
+    });
+
+    it('uses the minimal theme primary color for overlay toolbars', () => {
+        const css = buildBuiltinThemeOverlayCss('minimal');
+
+        expect(css).toContain('body.tb-current-builtin-theme-minimal.tb-current-builtin-theme-mode-light .v-overlay-container');
+        expect(css).toContain('background: #ff6600 !important;');
+        expect(css).toContain('body.tb-current-builtin-theme-minimal.tb-current-builtin-theme-mode-dark .v-overlay-container');
+        expect(css).toContain('background: #d35400 !important;');
     });
 });

--- a/app/utils/builtin-theme-overlay.ts
+++ b/app/utils/builtin-theme-overlay.ts
@@ -1,0 +1,442 @@
+export const builtinThemeNames = ['light-gray', 'minimal', 'graphite', 'brass', 'warm-red'] as const;
+
+export type BuiltinThemeName = typeof builtinThemeNames[number];
+type BuiltinThemeMode = 'light' | 'dark';
+
+interface OverlayThemePalette {
+    background: string
+    text: string
+    title: string
+    muted: string
+    border: string
+    shadow: string
+    radius: string
+    buttonRadius: string
+    primary: string
+    primaryText: string
+    primaryTextColor: string
+    tonalBackground: string
+    tonalText: string
+    outlinedBorder: string
+    fieldRadius: string
+    fieldBackground: string
+    fieldText: string
+    fontFamily: string
+    fontSize: string
+    titleFontFamily?: string
+    titleFontSize: string
+    cardPadding: string
+    chipRadius: string
+    chipHeight: string
+    chipPadding: string
+}
+
+const systemFont = 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans SC", sans-serif';
+const sansFont = 'Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans SC", sans-serif';
+const serifFont = 'Georgia, "Songti SC", "Noto Serif SC", serif';
+const minimalFont = 'Verdana, Geneva, sans-serif';
+
+const overlayThemePalettes: Record<BuiltinThemeName, Record<BuiltinThemeMode, OverlayThemePalette>> = {
+    'light-gray': {
+        dark: {
+            background: '#1b1d20',
+            text: '#e8eaed',
+            title: '#e8eaed',
+            muted: '#a1a7ae',
+            border: '#34383d',
+            shadow: '0 12px 30px rgba(0,0,0,.28)',
+            radius: '8px',
+            buttonRadius: '7px',
+            primary: '#747b84',
+            primaryText: '#fff',
+            primaryTextColor: '#c4c8ce',
+            tonalBackground: '#2f3338',
+            tonalText: '#eceff1',
+            outlinedBorder: '#555b63',
+            fieldRadius: '7px',
+            fieldBackground: '#2b2f33',
+            fieldText: '#f3f4f6',
+            fontFamily: `Poppins, Roboto, "Noto Sans SC", ${systemFont}`,
+            fontSize: '13px',
+            titleFontSize: '16px',
+            cardPadding: '12px 18px 18px',
+            chipRadius: '999px',
+            chipHeight: '24px',
+            chipPadding: '0 10px',
+        },
+        light: {
+            background: '#ffffff',
+            text: '#2b2f33',
+            title: '#24282d',
+            muted: '#697079',
+            border: '#d7dadd',
+            shadow: '0 8px 22px rgba(39,43,48,.08)',
+            radius: '8px',
+            buttonRadius: '7px',
+            primary: '#555c64',
+            primaryText: '#fff',
+            primaryTextColor: '#41474e',
+            tonalBackground: '#e6e8ea',
+            tonalText: '#34383d',
+            outlinedBorder: '#b9bec4',
+            fieldRadius: '7px',
+            fieldBackground: '#ffffff',
+            fieldText: '#2b2f33',
+            fontFamily: `Poppins, Roboto, "Noto Sans SC", ${systemFont}`,
+            fontSize: '13px',
+            titleFontSize: '16px',
+            cardPadding: '12px 18px 18px',
+            chipRadius: '999px',
+            chipHeight: '24px',
+            chipPadding: '0 10px',
+        },
+    },
+    minimal: {
+        dark: {
+            background: '#1f2118',
+            text: '#d8d2b8',
+            title: '#d8d2b8',
+            muted: '#9c967d',
+            border: '#3b382a',
+            shadow: 'none',
+            radius: '0',
+            buttonRadius: '0',
+            primary: '#d35400',
+            primaryText: '#111',
+            primaryTextColor: '#ff8a2a',
+            tonalBackground: '#3a2a18',
+            tonalText: '#ffd0a3',
+            outlinedBorder: '#ff8a2a',
+            fieldRadius: '0',
+            fieldBackground: '#2b2d22',
+            fieldText: '#f4ecd1',
+            fontFamily: minimalFont,
+            fontSize: '12px',
+            titleFontSize: '13px',
+            cardPadding: '4px 6px',
+            chipRadius: '0',
+            chipHeight: '18px',
+            chipPadding: '0 4px',
+        },
+        light: {
+            background: '#f6f6ef',
+            text: '#000',
+            title: '#000',
+            muted: '#828282',
+            border: '#e6e1c8',
+            shadow: 'none',
+            radius: '0',
+            buttonRadius: '0',
+            primary: '#ff6600',
+            primaryText: '#000',
+            primaryTextColor: '#ff6600',
+            tonalBackground: '#fff3df',
+            tonalText: '#000',
+            outlinedBorder: '#ff6600',
+            fieldRadius: '0',
+            fieldBackground: '#fff',
+            fieldText: '#000',
+            fontFamily: minimalFont,
+            fontSize: '12px',
+            titleFontSize: '13px',
+            cardPadding: '4px 6px',
+            chipRadius: '0',
+            chipHeight: '18px',
+            chipPadding: '0 4px',
+        },
+    },
+    graphite: {
+        dark: {
+            background: '#1c2024',
+            text: '#e7eaed',
+            title: '#eef1f4',
+            muted: '#97a0aa',
+            border: '#2b3238',
+            shadow: '0 1px 2px rgba(0,0,0,.4)',
+            radius: '8px',
+            buttonRadius: '7px',
+            primary: '#6f9dd6',
+            primaryText: '#0d1013',
+            primaryTextColor: '#8fb4de',
+            tonalBackground: '#23303d',
+            tonalText: '#bcd4ee',
+            outlinedBorder: '#3f5a75',
+            fieldRadius: '7px',
+            fieldBackground: '#1f242a',
+            fieldText: '#e7eaed',
+            fontFamily: sansFont,
+            fontSize: '13px',
+            titleFontSize: '16px',
+            cardPadding: '12px 18px 18px',
+            chipRadius: '999px',
+            chipHeight: '24px',
+            chipPadding: '0 10px',
+        },
+        light: {
+            background: '#ffffff',
+            text: '#1b1f24',
+            title: '#14181d',
+            muted: '#5f6771',
+            border: '#d9dee4',
+            shadow: '0 1px 2px rgba(15,23,42,.06)',
+            radius: '8px',
+            buttonRadius: '7px',
+            primary: '#3f6da3',
+            primaryText: '#fff',
+            primaryTextColor: '#235489',
+            tonalBackground: '#e3edf7',
+            tonalText: '#235489',
+            outlinedBorder: '#9dbfe0',
+            fieldRadius: '7px',
+            fieldBackground: '#eef1f4',
+            fieldText: '#1b1f24',
+            fontFamily: sansFont,
+            fontSize: '13px',
+            titleFontSize: '16px',
+            cardPadding: '12px 18px 18px',
+            chipRadius: '999px',
+            chipHeight: '24px',
+            chipPadding: '0 10px',
+        },
+    },
+    brass: {
+        dark: {
+            background: '#232019',
+            text: '#ece7dd',
+            title: '#f4ead6',
+            muted: '#a89f90',
+            border: '#34302a',
+            shadow: '0 12px 30px rgba(0,0,0,.3)',
+            radius: '6px',
+            buttonRadius: '6px',
+            primary: '#c99a5b',
+            primaryText: '#1f1a10',
+            primaryTextColor: '#d8b47a',
+            tonalBackground: '#3d3020',
+            tonalText: '#f0c98b',
+            outlinedBorder: '#6b5638',
+            fieldRadius: '6px',
+            fieldBackground: '#2b261d',
+            fieldText: '#ece7dd',
+            fontFamily: systemFont,
+            fontSize: '13px',
+            titleFontFamily: serifFont,
+            titleFontSize: '17px',
+            cardPadding: '12px 18px 18px',
+            chipRadius: '999px',
+            chipHeight: '24px',
+            chipPadding: '0 10px',
+        },
+        light: {
+            background: '#fbf9f4',
+            text: '#2a251d',
+            title: '#2a251d',
+            muted: '#7a7263',
+            border: '#e2dccc',
+            shadow: '0 1px 2px rgba(60,50,30,.07)',
+            radius: '6px',
+            buttonRadius: '6px',
+            primary: '#a9773a',
+            primaryText: '#fff',
+            primaryTextColor: '#8a5a1f',
+            tonalBackground: '#efe4cf',
+            tonalText: '#7a5320',
+            outlinedBorder: '#cbb384',
+            fieldRadius: '6px',
+            fieldBackground: '#f2efe8',
+            fieldText: '#2a251d',
+            fontFamily: systemFont,
+            fontSize: '13px',
+            titleFontFamily: serifFont,
+            titleFontSize: '17px',
+            cardPadding: '12px 18px 18px',
+            chipRadius: '999px',
+            chipHeight: '24px',
+            chipPadding: '0 10px',
+        },
+    },
+    'warm-red': {
+        dark: {
+            background: '#2a251f',
+            text: '#ece7dd',
+            title: '#ece7dd',
+            muted: '#a49c8b',
+            border: '#3a342b',
+            shadow: '0 8px 22px rgba(0,0,0,.34)',
+            radius: '3px',
+            buttonRadius: '3px',
+            primary: '#b5524a',
+            primaryText: '#201d18',
+            primaryTextColor: '#e0938c',
+            tonalBackground: '#3a2624',
+            tonalText: '#e9b6b1',
+            outlinedBorder: '#7a463f',
+            fieldRadius: '3px',
+            fieldBackground: '#2a251f',
+            fieldText: '#ece7dd',
+            fontFamily: systemFont,
+            fontSize: '13px',
+            titleFontFamily: serifFont,
+            titleFontSize: '17px',
+            cardPadding: '12px 18px 18px',
+            chipRadius: '3px',
+            chipHeight: '24px',
+            chipPadding: '0 10px',
+        },
+        light: {
+            background: '#fbfaf6',
+            text: '#2a2622',
+            title: '#2a2622',
+            muted: '#857e70',
+            border: '#ddd8cc',
+            shadow: '0 1px 2px rgba(60,50,40,.06)',
+            radius: '3px',
+            buttonRadius: '3px',
+            primary: '#8f3a34',
+            primaryText: '#fbfaf6',
+            primaryTextColor: '#8f3a34',
+            tonalBackground: '#f0e2e0',
+            tonalText: '#8f3a34',
+            outlinedBorder: '#d3a9a4',
+            fieldRadius: '3px',
+            fieldBackground: '#f0eee6',
+            fieldText: '#2a2622',
+            fontFamily: systemFont,
+            fontSize: '13px',
+            titleFontFamily: serifFont,
+            titleFontSize: '17px',
+            cardPadding: '12px 18px 18px',
+            chipRadius: '3px',
+            chipHeight: '24px',
+            chipPadding: '0 10px',
+        },
+    },
+};
+
+function overlaySelector(themeName: BuiltinThemeName, mode: BuiltinThemeMode, suffix = '') {
+    return `body.tb-current-builtin-theme-${themeName}.tb-current-builtin-theme-mode-${mode} .v-overlay-container${suffix}`;
+}
+
+function buildModeOverlayCss(themeName: BuiltinThemeName, mode: BuiltinThemeMode, palette: OverlayThemePalette) {
+    const base = overlaySelector(themeName, mode);
+    const titleFontFamily = palette.titleFontFamily || palette.fontFamily;
+
+    return `
+        ${base} { color: ${palette.text}; font-family: ${palette.fontFamily}; font-size: ${palette.fontSize}; }
+        ${base} .v-overlay__content .v-card {
+            background: ${palette.background} !important;
+            border: 1px solid ${palette.border} !important;
+            border-radius: ${palette.radius} !important;
+            box-shadow: ${palette.shadow} !important;
+            color: ${palette.text} !important;
+            font-family: ${palette.fontFamily} !important;
+        }
+        ${base} .v-overlay__content .v-toolbar {
+            background: ${palette.background} !important;
+            border-bottom: 1px solid ${palette.border} !important;
+            color: ${palette.title} !important;
+            font-family: ${titleFontFamily} !important;
+        }
+        ${base} .v-overlay__content .v-toolbar.bg-primary,
+        ${base} .v-overlay__content .bg-primary {
+            background: ${palette.primary} !important;
+            color: ${palette.primaryText} !important;
+        }
+        ${base} .v-overlay__content .v-card-title,
+        ${base} .v-overlay__content .v-toolbar-title {
+            color: ${palette.title} !important;
+            font-family: ${titleFontFamily} !important;
+            font-size: ${palette.titleFontSize} !important;
+            font-weight: 600;
+        }
+        ${base} .v-overlay__content .v-toolbar.bg-primary .v-toolbar-title,
+        ${base} .v-overlay__content .v-toolbar.bg-primary .v-btn {
+            color: ${palette.primaryText} !important;
+        }
+        ${base} .v-overlay__content .v-toolbar.bg-primary .v-btn.v-btn--variant-outlined {
+            border-color: ${palette.primaryText} !important;
+        }
+        ${base} .v-overlay__content .v-card-text {
+            color: ${palette.text} !important;
+            font-size: ${palette.fontSize} !important;
+            padding: ${palette.cardPadding} !important;
+        }
+        ${base} .v-overlay__content .text-medium-emphasis,
+        ${base} .v-overlay__content .v-card-subtitle {
+            color: ${palette.muted} !important;
+        }
+        ${base} .v-overlay__content .v-btn {
+            border-radius: ${palette.buttonRadius} !important;
+            font-family: ${palette.fontFamily} !important;
+            font-size: ${palette.fontSize} !important;
+            text-transform: none !important;
+        }
+        ${base} .v-overlay__content .v-btn.bg-primary {
+            background: ${palette.primary} !important;
+            color: ${palette.primaryText} !important;
+        }
+        ${base} .v-overlay__content .v-btn.v-btn--variant-tonal {
+            background: ${palette.tonalBackground} !important;
+            color: ${palette.tonalText} !important;
+        }
+        ${base} .v-overlay__content .v-btn.v-btn--variant-outlined {
+            border-color: ${palette.outlinedBorder} !important;
+            color: ${palette.primaryTextColor} !important;
+        }
+        ${base} .v-overlay__content .v-btn.v-btn--variant-text,
+        ${base} .v-overlay__content .text-primary,
+        ${base} .v-overlay__content a {
+            color: ${palette.primaryTextColor} !important;
+        }
+        ${base} .v-overlay__content .v-avatar.bg-primary {
+            background: ${palette.primary} !important;
+            color: ${palette.primaryText} !important;
+        }
+        ${base} .v-overlay__content .v-chip {
+            border-radius: ${palette.chipRadius} !important;
+            font-family: ${palette.fontFamily} !important;
+            font-size: ${palette.fontSize} !important;
+            height: ${palette.chipHeight} !important;
+            padding: ${palette.chipPadding} !important;
+        }
+        ${base} .v-overlay__content .v-chip.text-primary,
+        ${base} .v-overlay__content .v-chip.v-chip--variant-tonal {
+            background: ${palette.tonalBackground} !important;
+            color: ${palette.tonalText} !important;
+        }
+        ${base} .v-overlay__content .v-field {
+            background: ${palette.fieldBackground} !important;
+            border-radius: ${palette.fieldRadius} !important;
+            color: ${palette.fieldText} !important;
+        }
+        ${base} .v-overlay__content .v-field__input,
+        ${base} .v-overlay__content .v-label,
+        ${base} .v-overlay__content .v-select__selection {
+            color: ${palette.fieldText} !important;
+        }
+        ${base} .v-overlay__content .v-list {
+            background: ${palette.background} !important;
+            color: ${palette.text} !important;
+        }
+        ${base} .v-overlay__content .v-list-item-title {
+            color: ${palette.text} !important;
+            font-family: ${palette.fontFamily} !important;
+            font-size: ${palette.fontSize} !important;
+        }
+        ${base} .v-overlay__content .v-divider {
+            border-color: ${palette.border} !important;
+        }
+        ${base} .v-overlay__content .v-progress-circular {
+            color: ${palette.primaryTextColor} !important;
+        }
+    `;
+}
+
+export function buildBuiltinThemeOverlayCss(themeName: BuiltinThemeName) {
+    const palettes = overlayThemePalettes[themeName];
+
+    return `
+        ${buildModeOverlayCss(themeName, 'dark', palettes.dark)}
+        ${buildModeOverlayCss(themeName, 'light', palettes.light)}
+    `;
+}


### PR DESCRIPTION
## Summary

- Apply builtin theme styling to Vuetify teleported overlays, including dialogs, menus, cards, toolbars, buttons, chips, lists, fields, and progress indicators.
- Fix dialogs such as `从互联网同步书籍信息` so builtin themes no longer fall back to the default blue primary toolbar or default fonts.
- Add coverage for overlay CSS generation across all builtin themes and minimal theme primary colors.
- Document frontend validation expectations in `AGENTS.md`, including Chrome DevTools MCP verification and dev server startup commands.

## Browser validation

- Verified `从互联网同步书籍信息` on `/book/1` in minimal dark mode with Chrome DevTools MCP: toolbar became `rgb(211, 84, 0)`, title/button text used theme color, and font was Verdana.
- Checked all five builtin themes (`light-gray`, `minimal`, `graphite`, `brass`, `warm-red`) in light and dark mode: dialog toolbar colors matched each theme and did not fall back to default `rgb(25, 118, 210)`.
- Also checked the `发送到设备` dialog in minimal dark mode: card, title, primary button, and fields inherited the theme styling.

## Validation

- `cd app && npm run lint -- --quiet`
- `cd app && npx vitest run test/components/ test/utils/builtin-themes.spec.ts`
- `git diff --check`