### PR TITLE
feat: add API to sync per-book reading progress across devices

### DIFF
--- a/tests/test_reading_state.py
+++ b/tests/test_reading_state.py
@@ -168,6 +168,74 @@ class TestBookShelf(TestWithUserLogin):
         self.assertEqual(d["err"], "params.book.invalid")
 
 
+class TestBookReadingProgress(TestWithUserLogin):
+    def _clear_reading_state(self, book_id, reader_id=1):
+        from webserver.models import ReadingState
+
+        session = get_db()
+        state = (
+            session.query(ReadingState)
+            .filter(ReadingState.book_id == book_id, ReadingState.reader_id == reader_id)
+            .first()
+        )
+        if state:
+            session.delete(state)
+            session.commit()
+
+    def test_progress_get_no_state(self):
+        self._clear_reading_state(BID_EPUB)
+        d = self.json("/api/book/%d/progress" % BID_EPUB)
+        self.assertEqual(d["err"], "ok")
+        self.assertEqual(d["progress"], {})
+        self.assertIsNone(d["update_time"])
+
+    def test_progress_post_and_get(self):
+        self._clear_reading_state(BID_EPUB)
+        try:
+            progress = {"cfi": "epubcfi(/6/4!/4/2/2)", "percentage": 12.5, "device": "iPhone"}
+            body = json.dumps({"progress": progress})
+            d = self.json("/api/book/%d/progress" % BID_EPUB, method="POST", body=body)
+            self.assertEqual(d["err"], "ok")
+            self.assertEqual(d["progress"], progress)
+
+            d = self.json("/api/book/%d/progress" % BID_EPUB)
+            self.assertEqual(d["err"], "ok")
+            self.assertEqual(d["progress"], progress)
+            self.assertIsNotNone(d["update_time"])
+        finally:
+            self._clear_reading_state(BID_EPUB)
+
+    def test_progress_post_overwrites_previous(self):
+        self._clear_reading_state(BID_EPUB)
+        try:
+            body = json.dumps({"progress": {"percentage": 10}})
+            self.json("/api/book/%d/progress" % BID_EPUB, method="POST", body=body)
+
+            body = json.dumps({"progress": {"percentage": 50}})
+            d = self.json("/api/book/%d/progress" % BID_EPUB, method="POST", body=body)
+            self.assertEqual(d["err"], "ok")
+
+            d = self.json("/api/book/%d/progress" % BID_EPUB)
+            self.assertEqual(d["progress"]["percentage"], 50)
+        finally:
+            self._clear_reading_state(BID_EPUB)
+
+    def test_progress_post_invalid_payload(self):
+        body = json.dumps({"progress": "not-a-dict"})
+        d = self.json("/api/book/%d/progress" % BID_EPUB, method="POST", body=body)
+        self.assertEqual(d["err"], "params.invalid")
+
+    def test_progress_post_too_large(self):
+        body = json.dumps({"progress": {"blob": "x" * 9000}})
+        d = self.json("/api/book/%d/progress" % BID_EPUB, method="POST", body=body)
+        self.assertEqual(d["err"], "params.invalid")
+
+    def test_progress_post_nonexistent_book(self):
+        body = json.dumps({"progress": {"percentage": 1}})
+        d = self.json("/api/book/99999/progress", method="POST", body=body)
+        self.assertEqual(d["err"], "params.book.invalid")
+
+
 class TestReadingLists(TestWithUserLogin):
     def test_reading_list(self):
         d = self.json("/api/reading")

--- a/webserver/handlers/book.py
+++ b/webserver/handlers/book.py
@@ -2067,6 +2067,49 @@ class BookReadingState(BaseHandler):
         return utils.ReadingStateFormatter.format_reading_state_with_api_format(reading_state)
 
 
+class BookReadingProgress(BaseHandler):
+    """跨端同步指定书籍的阅读进度（如章节、CFI、百分比等，由客户端自定义结构）。"""
+
+    MAX_PROGRESS_BYTES = 8 * 1024
+
+    @js
+    @auth
+    def post(self, id):
+        book_id = int(id)
+        book = self.get_book(book_id, raise_exception=False)
+        if not book:
+            return {"err": "params.book.invalid", "msg": _("书籍已不存在")}
+        user_id = self.user_id()
+        data = tornado.escape.json_decode(self.request.body)
+        progress = data.get("progress")
+        if not isinstance(progress, dict):
+            return {"err": "params.invalid", "msg": _("阅读进度参数错误")}
+        if len(json.dumps(progress)) > self.MAX_PROGRESS_BYTES:
+            return {"err": "params.invalid", "msg": _("阅读进度数据过大")}
+        reading_state = (
+            self.session.query(ReadingState).filter(ReadingState.book_id == book_id, ReadingState.reader_id == user_id).first()
+        )
+        if not reading_state:
+            reading_state = ReadingState(book_id, user_id)
+            self.session.add(reading_state)
+        reading_state.set_progress(progress)
+        self.session.commit()
+        return {"err": "ok", "msg": _("阅读进度已保存"), "progress": reading_state.get_progress()}
+
+    @js
+    @auth
+    def get(self, id):
+        book_id = int(id)
+        user_id = self.user_id()
+        reading_state = (
+            self.session.query(ReadingState).filter(ReadingState.book_id == book_id, ReadingState.reader_id == user_id).first()
+        )
+        if not reading_state:
+            return {"err": "ok", "progress": {}, "update_time": None}
+        update_time = reading_state.progress_update_time.isoformat() if reading_state.progress_update_time else None
+        return {"err": "ok", "progress": reading_state.get_progress(), "update_time": update_time}
+
+
 class BookReadingStats(BaseHandler):
     @js
     @auth
@@ -2191,6 +2234,7 @@ def routes():
         (r"/api/book/([0-9]+)/favorite", BookFavorite),
         (r"/api/book/([0-9]+)/shelf", BookShelf),
         (r"/api/book/([0-9]+)/readstate", BookReadingState),
+        (r"/api/book/([0-9]+)/progress", BookReadingProgress),
         (r"/api/favorites", BookFavorite),
         (r"/api/shelf", BookShelf),
         (r"/api/reading", BookReading),

--- a/webserver/models.py
+++ b/webserver/models.py
@@ -483,6 +483,8 @@ class ReadingState(Base, SQLAlchemyMixin):
     read_date = Column(DateTime)
     online_read = Column(Integer, default=0)
     download = Column(Integer, default=0)
+    progress = Column(MutableDict.as_mutable(JSONType), default={})
+    progress_update_time = Column(DateTime)
 
     reader = relationship(Reader, backref="reading_states")
 
@@ -521,6 +523,13 @@ class ReadingState(Base, SQLAlchemyMixin):
 
     def set_download(self, download_status):
         self.download = 1 if download_status else 0
+
+    def set_progress(self, progress):
+        self.progress = progress or {}
+        self.progress_update_time = datetime.datetime.now()
+
+    def get_progress(self):
+        return self.progress or {}
 
 
 class BookSourceModel(Base, SQLAlchemyMixin):


### PR DESCRIPTION
## Summary
- Add a `progress` (JSON) field to the existing `ReadingState` model (per user + book) to store an arbitrary client-defined reading position (CFI, percentage, chapter, etc.).
- Add `GET/POST /api/book/<id>/progress` so clients can save and fetch a book's reading progress, enabling cross-device sync.
- Add backend tests covering save/fetch, overwrite, invalid/oversized payload, and non-existent book.

Closes /part of #447 (implements the API piece requested in the issue comment; frontend reader integration is a separate follow-up).

## Test plan
- [ ] `make pytest` (could not be run in this sandbox, needs CI/local verification)
- [ ] `make lint-py`
- [ ] Manually call `POST/GET /api/book/<id>/progress` against a running server

Generated with [Claude Code](https://claude.ai/code)