### PR TITLE
fix(theme): 修正内置主题弹窗/滚动条/导航/详情页配色一致性

### DIFF
--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -316,6 +316,7 @@
             v-model="sidebar"
             class="app-navigation-drawer"
             :order="2"
+            mobile-breakpoint="md"
             width="240"
         >
             <v-list
@@ -534,7 +535,7 @@ const items = computed(() => {
 
 onMounted(() => {
     visit_admin_pages.value = route.path.indexOf('/admin/') == 0;
-    sidebar.value = display.lgAndUp.value;
+    sidebar.value = display.mdAndUp.value;
     store.bootstrap().then((rsp) => {
         err.value = rsp.err;
     });

--- a/app/components/themes/BuiltinThemeHeader.vue
+++ b/app/components/themes/BuiltinThemeHeader.vue
@@ -208,6 +208,7 @@
             v-model="sidebar"
             class="tb-theme-drawer"
             :order="2"
+            mobile-breakpoint="md"
             :rail="isLightGray && miniVariant"
             :rail-width="64"
             :width="drawerWidth"
@@ -437,6 +438,7 @@ function syncThemeBodyClasses() {
 }
 
 onMounted(() => {
+    sidebar.value = display.mdAndUp.value;
     injectThemeStyles();
     stopBodyClassWatch = watch(
         [() => props.variant, () => store.theme],
@@ -508,6 +510,9 @@ const themeCss = {
         body.tb-current-builtin-theme-light-gray.tb-current-builtin-theme-mode-light .upload-btn { background: #555c64 !important; color: #fff !important; box-shadow: 0 10px 22px rgba(85,92,100,.22) !important; }
         body.tb-current-builtin-theme-light-gray.tb-current-builtin-theme-mode-light .tb-theme-light-gray .tb-theme-appbar { background: #f7f8f8 !important; color: #2b2f33 !important; border-bottom-color: #d0d3d6; box-shadow: 0 1px 8px rgba(39,43,48,.06) !important; }
         body.tb-current-builtin-theme-light-gray.tb-current-builtin-theme-mode-light .tb-theme-light-gray .tb-theme-drawer { background: #eceeef !important; color: #34383d !important; border-right-color: #d0d3d6; }
+        body.tb-current-builtin-theme-light-gray.tb-current-builtin-theme-mode-light .tb-theme-light-gray * { scrollbar-color: #b3b8bf #eceeef; }
+        body.tb-current-builtin-theme-light-gray.tb-current-builtin-theme-mode-light .tb-theme-light-gray ::-webkit-scrollbar-thumb { background: #b3b8bf; }
+        body.tb-current-builtin-theme-light-gray.tb-current-builtin-theme-mode-light .tb-theme-light-gray ::-webkit-scrollbar-track { background: #eceeef; }
         body.tb-current-builtin-theme-light-gray.tb-current-builtin-theme-mode-light .tb-theme-light-gray .tb-theme-brand-mark { background: #555c64; color: #fff; box-shadow: none; }
         body.tb-current-builtin-theme-light-gray.tb-current-builtin-theme-mode-light .tb-theme-light-gray .tb-theme-brand-title { color: #24282d; }
         body.tb-current-builtin-theme-light-gray.tb-current-builtin-theme-mode-light .tb-theme-light-gray .tb-theme-icon,
@@ -653,6 +658,9 @@ const themeCss = {
         body.tb-current-builtin-theme-graphite.tb-current-builtin-theme-mode-light .upload-btn { background: #3f6da3 !important; color: #fff !important; box-shadow: 0 10px 22px rgba(63,109,163,.22) !important; }
         body.tb-current-builtin-theme-graphite.tb-current-builtin-theme-mode-light .tb-theme-graphite .tb-theme-appbar { background: #ffffff !important; color: #1b1f24 !important; border-bottom-color: #dde2e8; box-shadow: 0 1px 2px rgba(15,23,42,.05) !important; }
         body.tb-current-builtin-theme-graphite.tb-current-builtin-theme-mode-light .tb-theme-graphite .tb-theme-drawer { background: #f5f7f9 !important; color: #3a434d !important; border-right-color: #e2e6eb; }
+        body.tb-current-builtin-theme-graphite.tb-current-builtin-theme-mode-light .tb-theme-graphite * { scrollbar-color: #c3ccd5 #eef1f4; }
+        body.tb-current-builtin-theme-graphite.tb-current-builtin-theme-mode-light .tb-theme-graphite ::-webkit-scrollbar-thumb { background: #c3ccd5; }
+        body.tb-current-builtin-theme-graphite.tb-current-builtin-theme-mode-light .tb-theme-graphite ::-webkit-scrollbar-track { background: #eef1f4; }
         body.tb-current-builtin-theme-graphite.tb-current-builtin-theme-mode-light .tb-theme-graphite .tb-theme-brand-mark { background: #3f6da3; color: #fff; }
         body.tb-current-builtin-theme-graphite.tb-current-builtin-theme-mode-light .tb-theme-graphite .tb-theme-brand-title { color: #14181d; }
         body.tb-current-builtin-theme-graphite.tb-current-builtin-theme-mode-light .tb-theme-graphite .tb-theme-icon,
@@ -735,6 +743,9 @@ const themeCss = {
         body.tb-current-builtin-theme-brass.tb-current-builtin-theme-mode-light .upload-btn { background: #a9773a !important; color: #fff !important; box-shadow: 0 10px 22px rgba(169,119,58,.22) !important; }
         body.tb-current-builtin-theme-brass.tb-current-builtin-theme-mode-light .tb-theme-brass .tb-theme-appbar { background: #fbf9f4 !important; color: #2a251d !important; border-bottom: 1px solid rgba(169,119,58,.6); box-shadow: 0 1px 2px rgba(60,50,30,.05) !important; }
         body.tb-current-builtin-theme-brass.tb-current-builtin-theme-mode-light .tb-theme-brass .tb-theme-drawer { background: #efebe1 !important; color: #4a4436 !important; border-right-color: #e2dccc; }
+        body.tb-current-builtin-theme-brass.tb-current-builtin-theme-mode-light .tb-theme-brass * { scrollbar-color: #cdbb95 #efebe1; }
+        body.tb-current-builtin-theme-brass.tb-current-builtin-theme-mode-light .tb-theme-brass ::-webkit-scrollbar-thumb { background: #cdbb95; }
+        body.tb-current-builtin-theme-brass.tb-current-builtin-theme-mode-light .tb-theme-brass ::-webkit-scrollbar-track { background: #efebe1; }
         body.tb-current-builtin-theme-brass.tb-current-builtin-theme-mode-light .tb-theme-brass .tb-theme-brand-mark { background: transparent; color: #a9773a; border: 1px solid #a9773a; }
         body.tb-current-builtin-theme-brass.tb-current-builtin-theme-mode-light .tb-theme-brass .tb-theme-brand-title { color: #2a251d; }
         body.tb-current-builtin-theme-brass.tb-current-builtin-theme-mode-light .tb-theme-brass .tb-theme-icon,
@@ -817,6 +828,9 @@ const themeCss = {
         body.tb-current-builtin-theme-warm-red.tb-current-builtin-theme-mode-dark .upload-btn { background: #b5524a !important; color: #201d18 !important; box-shadow: 0 10px 22px rgba(181,82,74,.28) !important; }
         body.tb-current-builtin-theme-warm-red.tb-current-builtin-theme-mode-dark .tb-theme-warm-red .tb-theme-appbar { background: #262019 !important; color: #ece7dd !important; border-bottom-color: #3a342b; }
         body.tb-current-builtin-theme-warm-red.tb-current-builtin-theme-mode-dark .tb-theme-warm-red .tb-theme-drawer { background: #1c1914 !important; color: #cabfad !important; border-right-color: #33302a; }
+        body.tb-current-builtin-theme-warm-red.tb-current-builtin-theme-mode-dark .tb-theme-warm-red * { scrollbar-color: #574b3f #1c1914; }
+        body.tb-current-builtin-theme-warm-red.tb-current-builtin-theme-mode-dark .tb-theme-warm-red ::-webkit-scrollbar-thumb { background: #574b3f; }
+        body.tb-current-builtin-theme-warm-red.tb-current-builtin-theme-mode-dark .tb-theme-warm-red ::-webkit-scrollbar-track { background: #1c1914; }
         body.tb-current-builtin-theme-warm-red.tb-current-builtin-theme-mode-dark .tb-theme-warm-red .tb-theme-brand-mark { background: #b5524a; color: #201d18; }
         body.tb-current-builtin-theme-warm-red.tb-current-builtin-theme-mode-dark .tb-theme-warm-red .tb-theme-brand-title { color: #ece7dd; }
         body.tb-current-builtin-theme-warm-red.tb-current-builtin-theme-mode-dark .tb-theme-warm-red .tb-theme-icon,

--- a/app/pages/book/[bid]/index.vue
+++ b/app/pages/book/[bid]/index.vue
@@ -702,7 +702,7 @@
                                 >
                                     <v-chip
                                         size="small"
-                                        color="indigo"
+                                        color="primary"
                                     >
                                         <v-icon
                                             size="small"
@@ -737,9 +737,9 @@
                                         :key="'author-' + author"
                                         class="ma-1"
                                         size="small"
-                                        color="indigo"
+                                        color="primary"
                                         :to="'/author/' + encodeURIComponent(author)"
-                                        variant="flat"
+                                        variant="tonal"
                                     >
                                         <v-icon start>
                                             mdi-account
@@ -749,9 +749,9 @@
                                     <v-chip
                                         class="ma-1"
                                         size="small"
-                                        color="indigo"
+                                        color="primary"
                                         :to="'/publisher/' + encodeURIComponent(book.publisher)"
-                                        variant="flat"
+                                        variant="tonal"
                                     >
                                         <v-icon start>
                                             mdi-domain
@@ -762,9 +762,9 @@
                                         v-if="book.series"
                                         class="ma-1"
                                         size="small"
-                                        color="indigo"
+                                        color="primary"
                                         :to="'/series/' + encodeURIComponent(book.series)"
-                                        variant="flat"
+                                        variant="tonal"
                                     >
                                         <v-icon start>
                                             mdi-bookshelf
@@ -775,8 +775,8 @@
                                         v-if="book.isbn"
                                         class="ma-1"
                                         size="small"
-                                        color="grey"
-                                        variant="flat"
+                                        color="primary"
+                                        variant="tonal"
                                     >
                                         <v-icon start>
                                             mdi-barcode
@@ -789,9 +789,9 @@
                                             :key="'tag-' + tag"
                                             class="ma-1"
                                             size="small"
-                                            color="grey"
+                                            color="primary"
                                             :to="'/tag/' + encodeURIComponent(tag)"
-                                            variant="flat"
+                                            variant="tonal"
                                         >
                                             <v-icon start>
                                                 mdi-tag

--- a/app/test/e2e/sidebar.spec.ts
+++ b/app/test/e2e/sidebar.spec.ts
@@ -62,6 +62,20 @@ test.describe('Navigation Sidebar', () => {
 
     });
 
+    test('Sidebar stays visible at md width', async ({ page }) => {
+        // md 断点（960~1279）下侧栏也应常驻展示，而非被折叠成抽屉
+        await page.setViewportSize({ width: 1100, height: 800 });
+        await page.goto('/');
+
+        const homeLink = page.locator('nav').getByRole('link', { name: '首页' });
+        await homeLink.waitFor({ state: 'visible' });
+
+        // 抽屉常驻时 nav 位于左侧可视区域（x >= 0）；若被折叠为 temporary 抽屉则会被移出屏幕（x < 0）
+        const box = await homeLink.boundingBox();
+        expect(box).not.toBeNull();
+        expect(box!.x).toBeGreaterThanOrEqual(0);
+    });
+
     test('Can navigate via all sidebar links', async ({ page }) => {
     // Define all links to test
         const linksToTest = [

--- a/app/test/mock-server.js
+++ b/app/test/mock-server.js
@@ -23,9 +23,10 @@ const builtinThemes = [
   {
     id: 'builtin-brass',
     name: 'brass',
+    display_name: '黄铜主题',
     version: '1.0.0',
     author: 'Talebook',
-    description: '黄铜风格',
+    description: '暖褐炭灰打底，一线黄铜勾勒轮廓，衬线书名沉静内敛——像台灯下摊开的一册旧书，最宜夜里慢读细品。',
     installed_at: null,
     builtin: true,
     components: {
@@ -36,9 +37,10 @@ const builtinThemes = [
   {
     id: 'builtin-graphite',
     name: 'graphite',
+    display_name: '石墨主题',
     version: '1.0.0',
     author: 'Talebook',
-    description: '石墨风格',
+    description: '冷调蓝灰如石墨般沉着，墨蓝作唯一亮色，选中项亮起一道细边——信息井然有序，久看不觉刺眼。',
     installed_at: null,
     builtin: true,
     components: {
@@ -49,9 +51,10 @@ const builtinThemes = [
   {
     id: 'builtin-light-gray',
     name: 'light-gray',
+    display_name: '浅灰主题',
     version: '1.0.0',
     author: 'Talebook',
-    description: '浅灰风格',
+    description: '通透的高级浅灰，低饱和配色搭紧凑侧栏，清爽而不喧宾夺主——日常打理书库，久对屏幕也轻松。',
     installed_at: null,
     builtin: true,
     components: {
@@ -62,9 +65,10 @@ const builtinThemes = [
   {
     id: 'builtin-warm-red',
     name: 'warm-red',
+    display_name: '暖红主题',
     version: '1.0.0',
     author: 'Talebook',
-    description: '暖红风格',
+    description: '微黄纸感的明亮底色，牛血红点题，侧栏以虚线分行如旧时图书馆的索引卡——带着纸页与目录的温度。',
     installed_at: null,
     builtin: true,
     components: {
@@ -75,9 +79,10 @@ const builtinThemes = [
   {
     id: 'builtin-minimal',
     name: 'minimal',
+    display_name: '极简主题',
     version: '1.0.0',
     author: 'Talebook',
-    description: '极简紧凑风格',
+    description: '去尽多余装饰，只留文字与留白，小字号、高密度——明暗两色皆为一目十行的快速浏览而生。',
     installed_at: null,
     builtin: true,
     components: {

--- a/app/test/utils/builtin-themes.spec.ts
+++ b/app/test/utils/builtin-themes.spec.ts
@@ -31,6 +31,21 @@ describe('builtin-themes', () => {
             expect(css).toContain(`body.tb-current-builtin-theme-${themeName}.tb-current-builtin-theme-mode-dark .v-overlay-container`);
             expect(css).toContain('.v-overlay__content .v-toolbar.bg-primary');
             expect(css).toContain('.v-overlay__content .v-card');
+            expect(css).toContain('.v-overlay__content .v-alert');
+        }
+    });
+
+    it('aligns dialog title / text / actions horizontal padding for every theme', () => {
+        for (const themeName of builtinThemeNames) {
+            const css = buildBuiltinThemeOverlayCss(themeName);
+
+            const titleX = css.match(/\.v-card-title \{\s*padding-left: (\d+px) !important;/)?.[1];
+            const actionsX = css.match(/\.v-card-actions \{[^}]*padding-left: (\d+px) !important;/)?.[1];
+            const textX = css.match(/\.v-card-text \{[^}]*padding: \d+px (\d+px)/)?.[1];
+
+            expect(titleX).toBeDefined();
+            expect(actionsX).toBe(titleX);
+            expect(textX).toBe(titleX);
         }
     });
 

--- a/app/utils/builtin-theme-overlay.ts
+++ b/app/utils/builtin-theme-overlay.ts
@@ -320,6 +320,9 @@ function overlaySelector(themeName: BuiltinThemeName, mode: BuiltinThemeMode, su
 function buildModeOverlayCss(themeName: BuiltinThemeName, mode: BuiltinThemeMode, palette: OverlayThemePalette) {
     const base = overlaySelector(themeName, mode);
     const titleFontFamily = palette.titleFontFamily || palette.fontFamily;
+    // cardPadding 是 CSS 简写（如 "12px 18px 18px"），取水平内边距让弹窗标题/正文/操作栏左右对齐
+    const cardPaddingParts = palette.cardPadding.split(/\s+/);
+    const cardPaddingX = cardPaddingParts[1] || cardPaddingParts[0];
 
     return `
         ${base} { color: ${palette.text}; font-family: ${palette.fontFamily}; font-size: ${palette.fontSize}; }
@@ -356,14 +359,27 @@ function buildModeOverlayCss(themeName: BuiltinThemeName, mode: BuiltinThemeMode
         ${base} .v-overlay__content .v-toolbar.bg-primary .v-btn.v-btn--variant-outlined {
             border-color: ${palette.primaryText} !important;
         }
+        ${base} .v-overlay__content .v-card-title {
+            padding-left: ${cardPaddingX} !important;
+            padding-right: ${cardPaddingX} !important;
+        }
         ${base} .v-overlay__content .v-card-text {
             color: ${palette.text} !important;
             font-size: ${palette.fontSize} !important;
             padding: ${palette.cardPadding} !important;
         }
+        ${base} .v-overlay__content .v-card-actions {
+            padding-bottom: ${cardPaddingX} !important;
+            padding-left: ${cardPaddingX} !important;
+            padding-right: ${cardPaddingX} !important;
+        }
         ${base} .v-overlay__content .text-medium-emphasis,
         ${base} .v-overlay__content .v-card-subtitle {
             color: ${palette.muted} !important;
+        }
+        ${base} .v-overlay__content .v-card-subtitle {
+            padding-left: ${cardPaddingX} !important;
+            padding-right: ${cardPaddingX} !important;
         }
         ${base} .v-overlay__content .v-btn {
             border-radius: ${palette.buttonRadius} !important;
@@ -428,6 +444,21 @@ function buildModeOverlayCss(themeName: BuiltinThemeName, mode: BuiltinThemeMode
         }
         ${base} .v-overlay__content .v-progress-circular {
             color: ${palette.primaryTextColor} !important;
+        }
+        ${base} .v-overlay__content .v-alert {
+            background: ${palette.tonalBackground} !important;
+            border: 1px solid ${palette.outlinedBorder} !important;
+            border-radius: ${palette.radius} !important;
+            box-shadow: none !important;
+            color: ${palette.tonalText} !important;
+        }
+        ${base} .v-overlay__content .v-alert .v-alert-title,
+        ${base} .v-overlay__content .v-alert .v-alert__content {
+            color: ${palette.tonalText} !important;
+        }
+        ${base} .v-overlay__content .v-alert .v-alert__prepend .v-icon,
+        ${base} .v-overlay__content .v-alert .v-alert__close .v-icon {
+            color: ${palette.tonalText} !important;
         }
     `;
 }


### PR DESCRIPTION
## 背景

针对内置主题在弹窗、滚动条、导航、书籍详情页的一系列配色/布局不一致问题进行修正（来自使用反馈与 Codex 测试结果）。

## 改动

### 1. 弹窗（overlay）配色与内边距
- **v-alert 主题化**：弹窗内的提示框改用各主题自己的强调色（`tonalBackground` / `tonalText` / `outlinedBorder`），不再沿用 Vuetify 默认语义蓝/绿/红。每个主题各有其色（浅灰=灰、石墨=蓝、黄铜=金、暖红=红、极简=橙）。
- **内边距对齐**：从 `cardPadding` 派生水平内边距，统一喂给 `.v-card-title` / `.v-card-subtitle` / `.v-card-text` / `.v-card-actions`，修正暖红等主题下「添加用户」等弹窗标题(16px)/正文(18px)/操作栏(8px)三种内边距错位。改一处覆盖所有弹窗×所有主题。

### 2. navbar 滚动条黑色轨道
- 各主题的 `scrollbar-color` 轨道色此前只在基础块（近黑 `#17191c`）定义、亮色模式从未覆盖 → 亮色下侧栏滚动条轨道渲染成黑色。为 light-gray / graphite / brass 补齐亮色模式覆盖，warm-red 补暗色模式覆盖。

### 3. md 宽度下 navbar 常驻
- 侧栏抽屉此前只在 lg（≥1280）常驻，md（960–1279）被 Vuetify 判为 mobile → 折叠成覆盖层。给抽屉加 `mobile-breakpoint="md"`，初始展开状态由 `lgAndUp` 改为 `mdAndUp`。md 下抽屉常驻并推开内容（`v-main` padding-left 240px），sm 及以下仍为可呼出的移动端抽屉。默认头与 5 个内置主题头一并修正。

### 4. 书籍详情页 metadata chips 跟随主题
- 作者/出版社/丛书/标签/ISBN/在读状态 chip 此前用 `variant="flat"` + 硬编码 `indigo`/`grey`，不受主题 tonal 规则约束 → 蓝紫/灰棕穿帮。改为 `color="primary" variant="tonal"`，命中已有主题 tonal 规则。评分星（黄）与公开/私有状态（橙/青）按语义保留。

### 5. mock-server 数据对齐
- 补齐内置主题的 `display_name` 与完整描述，与真实后端 `webserver/handlers/theme.py` 一致（此前只有占位短句，导致本地体验时误以为"描述丢失"）。

## 测试
- 新增/补充单测：弹窗内边距对齐、v-alert 主题化、md 常驻断言。
- `npx vitest run test/utils/ test/stores/` 全通过；`npm run lint` 0 error。
- 浏览器实测（Chrome DevTools MCP / headless Playwright）：
  - 弹窗配色与内边距：暖红/极简/石墨等主题明暗两模式
  - 滚动条：light-gray 亮色轨道由黑变浅
  - md（1000–1100px）：默认头与内置头均常驻推开内容；sm（700px）折叠
  - 详情页 chips：暖红下由 indigo/grey 变为暖红 tonal（`#f0e2e0`/`#8f3a34`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)