### PR TITLE
fix(build): 非 tag 构建使用 git describe 版本号

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,13 +31,18 @@ jobs:
       build_args: ${{ steps.prep.outputs.build_args }}
       safe_ref_name: ${{ steps.prep.outputs.safe_ref_name }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Prepare build args and safe ref name
         id: prep
         run: |
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/}
           else
-            VERSION=${GITHUB_SHA::8}
+            VERSION=$(git describe --tags --always --match 'v[0-9]*')
           fi
           SAFE_REF_NAME=${GITHUB_REF_NAME//\//-}
           echo "build_args=GIT_VERSION=$VERSION" >> $GITHUB_OUTPUT

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: all build push test build-base push-base check-design
 
 VER := $(shell git branch --show-current | tr '/' '-')
+GIT_VER := $(shell git describe --tags --always --match 'v[0-9]*' 2>/dev/null || git rev-parse --short HEAD)
 IMAGE := talebook/talebook:$(VER)
 REPO1 := talebook/talebook:latest
 REPO2 := talebook/calibre-webserver:latest
@@ -29,11 +30,11 @@ push-base:
 	docker buildx build -f Dockerfile.base --build-arg BUILD_COUNTRY=CN --platform $(BASE_PLATFORMS) -t $(BASE):latest -t $(BASE):$(BASE_VER) --push .
 
 build-spa:
-	docker build --no-cache=false --build-arg BUILD_COUNTRY=CN --build-arg GIT_VERSION=$(VER) \
+	docker build --no-cache=false --build-arg BUILD_COUNTRY=CN --build-arg GIT_VERSION=$(GIT_VER) \
 		-f Dockerfile -t $(IMAGE) -t $(REPO1) --target production -t $(REPO2) .
 
 build-ssr:
-	docker build --no-cache=false --build-arg BUILD_COUNTRY=CN --build-arg GIT_VERSION=$(VER) \
+	docker build --no-cache=false --build-arg BUILD_COUNTRY=CN --build-arg GIT_VERSION=$(GIT_VER) \
 		-f Dockerfile -t $(TAG1) -t $(TAG2) --target production-ssr .
 
 build-dev:

--- a/design/project/20260714-build-version-scheme.active.html
+++ b/design/project/20260714-build-version-scheme.active.html
@@ -1,0 +1,253 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>非 tag 构建版本号方案（git describe）· ACTIVE</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --ink: #1f2420;
+        --muted: #626a64;
+        --line: #d8ddd9;
+        --surface: #ffffff;
+        --surface-soft: #f5f7f5;
+        --green: #276749;
+        --green-soft: #e8f4ed;
+        --blue: #285e8e;
+        --blue-soft: #eaf2f8;
+        --gold: #8a5a12;
+        --gold-soft: #fbf3df;
+        --red: #9b3c35;
+        --red-soft: #faecea;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0 auto;
+        max-width: 880px;
+        padding: 2rem 1.25rem 4rem;
+        color: var(--ink);
+        background: var(--surface);
+        font-family: "PingFang SC", "Microsoft YaHei", system-ui, sans-serif;
+        font-size: 16px;
+        line-height: 1.75;
+      }
+      h1 { font-size: 1.6rem; margin: 0 0 0.5rem; }
+      h2 {
+        font-size: 1.2rem;
+        margin: 2.2rem 0 0.8rem;
+        padding-bottom: 0.3rem;
+        border-bottom: 2px solid var(--line);
+      }
+      h3 { font-size: 1.02rem; margin: 1.4rem 0 0.5rem; }
+      a { color: var(--blue); }
+      code {
+        padding: 0.1rem 0.35rem;
+        border: 1px solid var(--line);
+        border-radius: 4px;
+        background: var(--surface-soft);
+        font-family: "SFMono-Regular", Consolas, monospace;
+        font-size: 0.9em;
+        overflow-wrap: anywhere;
+      }
+      pre {
+        margin: 0.6rem 0;
+        padding: 0.9rem 1rem;
+        border: 1px solid var(--line);
+        border-radius: 6px;
+        background: var(--surface-soft);
+        overflow-x: auto;
+      }
+      pre code { border: 0; padding: 0; background: none; }
+      table { border-collapse: collapse; width: 100%; margin: 0.8rem 0; font-size: 0.95rem; }
+      th, td { border: 1px solid var(--line); padding: 0.5rem 0.7rem; text-align: left; vertical-align: top; }
+      th { background: var(--surface-soft); }
+      .meta {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem 1.2rem;
+        margin: 0.5rem 0 1.5rem;
+        padding: 0.8rem 1rem;
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: var(--surface-soft);
+        color: var(--muted);
+        font-size: 0.92rem;
+      }
+      .meta b { color: var(--ink); }
+      .badge {
+        display: inline-block;
+        padding: 0.1rem 0.55rem;
+        border-radius: 999px;
+        background: var(--gold-soft);
+        color: var(--gold);
+        font-weight: 600;
+        font-size: 0.85rem;
+      }
+      .bad { color: var(--red); font-weight: 600; }
+      .good { color: var(--green); font-weight: 600; }
+      .callout {
+        margin: 1rem 0;
+        padding: 0.8rem 1rem;
+        border-left: 4px solid var(--blue);
+        background: var(--blue-soft);
+        border-radius: 0 6px 6px 0;
+      }
+      .callout.warn { border-left-color: var(--gold); background: var(--gold-soft); }
+      ul { padding-left: 1.3rem; }
+    </style>
+  </head>
+  <body>
+    <h1>非 tag 构建版本号方案（git describe）</h1>
+    <div class="meta">
+      <span><b>创建日期：</b>2026-07-14</span>
+      <span><b>所属模块：</b>project（发布流程；影响 <code>.github/workflows/build.yml</code> 、 <code>Makefile</code> ）</span>
+      <span><b>状态：</b><span class="badge">ACTIVE</span></span>
+      <span><b>需求来源：</b>线上容器 update_checker 误报“已是最新”，排查发现 <code>VERSION=52957175</code> 为 commit 短 hash。</span>
+    </div>
+
+    <h2>1. 原始诉求</h2>
+    <p>
+      用户运行的容器日志出现 <code>update_checker:142 Already up to date: version=52957175</code> 。
+      <code>52957175</code> 并非用户所打的 tag，而是 commit <code>5295717539…</code> 的前 8 位短 hash。用户要求：
+    </p>
+    <blockquote>
+      “优化一下，non-tag 的应该使用 <code>v26.07.13-xxx</code> 这种版本号格式。”
+    </blockquote>
+
+    <h2>2. 背景与根因</h2>
+    <p>
+      镜像内 <code>webserver/version.py</code> 的 <code>VERSION</code> 由构建时 build-arg <code>GIT_VERSION</code> 写入
+      （ <code>Dockerfile</code> 第 143 / 265 行）。CI 中 <code>GIT_VERSION</code> 的取值逻辑为：
+    </p>
+    <pre><code># .github/workflows/build.yml prepare 阶段（现状）
+if [[ $GITHUB_REF == refs/tags/* ]]; then
+  VERSION=${GITHUB_REF#refs/tags/}     # tag 推送 → v26.07.13
+else
+  VERSION=${GITHUB_SHA::8}             # 分支推送 → 52957175（纯 hash）
+fi</code></pre>
+    <p>
+      分支（<code>master</code> / <code>dev/*</code> 等）推送产出的镜像 <code>VERSION</code> 是纯 hash。
+      <code>update_checker._version_parts()</code> 用 <code>re.findall(r"\d+")</code> 抽数字，把
+      <code>52957175</code> 当成首段版本号，远大于 release tag <code>v26.07.13</code> 的首段 <code>26</code> ，
+      于是判定“当前更新” → <span class="bad">误报“已是最新”</span>。
+    </p>
+    <div class="callout warn">
+      注：用户确实为 <code>5295717</code> 打了 tag <code>v26.07.13</code> 。tag 推送会另出一份
+      <code>VERSION=v26.07.13</code> 的 <code>:latest</code> / <code>:v26.07.13</code> 镜像；
+      问题在于运行的容器用的是分支构建镜像。本方案只修“非 tag 构建的版本号格式”，让分支镜像也带上有意义、可比较的版本号。
+    </div>
+
+    <h2>3. 目标</h2>
+    <ul>
+      <li>非 tag 构建的 <code>VERSION</code> 使用 <code>git describe</code> 语义化格式：最近 tag + 距离 + 短 hash，例如 <code>v26.07.13-5-g5295717</code> 。</li>
+      <li>该格式与现有 <code>update_checker</code> 比较逻辑天然兼容，不再误报“已是最新”，且开发版领先于 release 时不误报“有更新”。</li>
+      <li>本地 <code>make build</code> 与 CI 保持一致。</li>
+      <li>改动最小：不改 <code>update_checker</code> 比较算法，不改 Dockerfile 写入方式。</li>
+    </ul>
+
+    <h2>4. 方案</h2>
+
+    <h3>4.1 CI：build.yml prepare 阶段</h3>
+    <p>
+      当前 <code>prepare</code> job 无 checkout，仅凭环境变量算版本，因此无法调用 <code>git describe</code> 。
+      新增一次全历史 checkout（<code>fetch-depth: 0</code> ，含 tags），并把非 tag 分支改用 <code>git describe</code> ：
+    </p>
+    <pre><code>- name: Checkout
+  uses: actions/checkout@v4
+  with:
+    fetch-depth: 0
+
+- name: Prepare build args and safe ref name
+  id: prep
+  run: |
+    if [[ $GITHUB_REF == refs/tags/* ]]; then
+      VERSION=${GITHUB_REF#refs/tags/}
+    else
+      VERSION=$(git describe --tags --always --match 'v[0-9]*')
+    fi
+    ...</code></pre>
+    <ul>
+      <li><code>--match 'v[0-9]*'</code> 只匹配 <code>v26.*</code> / <code>v3.*</code> 等版本 tag，排除 <code>base-v8.5.0</code> 之类。</li>
+      <li><code>--always</code> 兜底：仓库无匹配 tag 时退回短 hash（极端情况，不引入新分支逻辑）。</li>
+      <li>tag 推送分支保持不变，仍用 tag 名。</li>
+    </ul>
+
+    <h3>4.2 本地：Makefile</h3>
+    <p>
+      当前 <code>VER</code> 既作镜像 tag 又作 <code>GIT_VERSION</code> 。拆出独立的 <code>GIT_VER</code> 供 build-arg 使用，镜像 tag 仍用分支名：
+    </p>
+    <pre><code>GIT_VER := $(shell git describe --tags --always --match 'v[0-9]*' 2>/dev/null || git rev-parse --short HEAD)
+# build-spa / build-ssr: --build-arg GIT_VERSION=$(GIT_VER)</code></pre>
+
+    <h3>4.3 为什么无需改 update_checker</h3>
+    <p><code>git describe</code> 格式与现有比较器行为验证：</p>
+    <table>
+      <thead>
+        <tr><th>当前版本（容器内）</th><th>latest release</th><th>抽取数字对比</th><th>结果</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>v26.07.13-5-g5295717</code></td>
+          <td><code>v26.07.20</code></td>
+          <td>[26,7,13,…] vs [26,7,20]，第三段 13&lt;20</td>
+          <td class="good">有更新 ✅</td>
+        </tr>
+        <tr>
+          <td><code>v26.07.13-5-g5295717</code></td>
+          <td><code>v26.07.13</code></td>
+          <td>[26,7,13,5,…] vs [26,7,13]，开发版领先</td>
+          <td class="good">无更新 ✅（不骚扰）</td>
+        </tr>
+        <tr>
+          <td><span class="bad">52957175</span>（旧）</td>
+          <td><code>v26.07.13</code></td>
+          <td>[52957175] vs [26,…]，首段巨大</td>
+          <td class="bad">误报无更新 ❌</td>
+        </tr>
+      </tbody>
+    </table>
+    <p>新格式首段恒为年份 <code>26</code> ，彻底避开“纯 hash 被当巨型版本号”的陷阱。</p>
+
+    <h3>4.4 取舍</h3>
+    <ul>
+      <li><b>不额外加固 update_checker 拦截纯 hash：</b>仅当仓库完全无 tag 时才会退回纯 hash（<code>--always</code> 兜底），属极端场景；按最小改动原则不引入额外分支。此为已知残留边界，非本次目标。</li>
+      <li><b>不改 Dockerfile 版本写入方式：</b>仅调整传入的 <code>GIT_VERSION</code> 取值。</li>
+    </ul>
+
+    <h2>5. 测试结果</h2>
+    <p>验证日期：2026-07-14。</p>
+    <table>
+      <thead>
+        <tr><th>验证项</th><th>方式 / 命令</th><th>结果</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>git describe</code> 输出格式</td>
+          <td><code>git describe --tags --always --match 'v[0-9]*'</code></td>
+          <td class="good">通过：HEAD（即 tag）输出 <code>v26.07.13</code> ；后续 commit 会输出 <code>v26.07.13-N-g&lt;hash&gt;</code></td>
+        </tr>
+        <tr>
+          <td>Makefile <code>GIT_VER</code> 展开</td>
+          <td><code>make -p | grep 'GIT_VER :='</code></td>
+          <td class="good">通过：<code>GIT_VER := v26.07.13</code></td>
+        </tr>
+        <tr>
+          <td>describe 格式在 update_checker 下的比较正确性</td>
+          <td><code>pytest tests/test_update_checker.py</code>（新增 <code>test_compare_versions_handles_git_describe_dev_version</code> ）</td>
+          <td class="good">通过：5 passed</td>
+        </tr>
+        <tr>
+          <td>方案文档合规</td>
+          <td><code>make check-design</code></td>
+          <td class="good">通过（回写时执行）</td>
+        </tr>
+        <tr>
+          <td>CI 实际产出版本号</td>
+          <td>GitHub Actions（需真实 push，本地不可复现）</td>
+          <td class="good">受限：本地不可运行 GH Actions；<code>prepare</code> 阶段的 <code>git describe</code> 已用本地等价命令验证，checkout <code>fetch-depth: 0</code> 保证 tag 历史可用</td>
+        </tr>
+      </tbody>
+    </table>
+  </body>
+</html>

--- a/tests/test_update_checker.py
+++ b/tests/test_update_checker.py
@@ -33,6 +33,14 @@ class TestUpdateCheckerVersionCompare(unittest.TestCase):
         self.assertFalse(update_checker._compare_versions("26.06.29", "v26.06.28"))
         self.assertFalse(update_checker._compare_versions("26.06.29", "26.06.29"))
 
+    def test_compare_versions_handles_git_describe_dev_version(self):
+        # 非 tag 构建使用 git describe 格式：最近 tag + 距离 + 短 hash。
+        dev = "v26.07.13-5-g5295717"
+        # 更新的 release 应被识别为“有更新”。
+        self.assertTrue(update_checker._compare_versions(dev, "v26.07.20"))
+        # 领先于 release 的开发版不应误报“有更新”。
+        self.assertFalse(update_checker._compare_versions(dev, "v26.07.13"))
+
 
 class TestUpdateChecker(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## 背景

线上容器 update_checker 日志误报 `Already up to date: version=52957175`。`52957175` 并非 tag，而是 commit `5295717` 的前 8 位短 hash——分支构建把 `GIT_VERSION` 设为 `${GITHUB_SHA::8}`（build.yml），写进 `webserver/version.py`。

`update_checker._version_parts()` 用正则抽数字，把 `52957175` 当成首段版本号，远大于 release tag `v26.07.13` 的首段 `26`，于是判定「当前更新」→ 误报「已是最新」。

## 改动

非 tag 构建改用 `git describe` 语义化格式（如 `v26.07.13-5-g5295717`），首段恒为年份，与现有比较器天然兼容，**无需改动比较算法**（最小改动）。

| 文件 | 改动 |
|---|---|
| `.github/workflows/build.yml` | `prepare` 加 `checkout(fetch-depth: 0)`；非 tag 分支 `VERSION` 改用 `git describe --tags --always --match 'v[0-9]*'` |
| `Makefile` | 新增 `GIT_VER`，`build-spa`/`build-ssr` 的 `--build-arg GIT_VERSION` 改用它，本地与 CI 对齐 |
| `tests/test_update_checker.py` | 新增 describe 格式比较用例 |

## 验证

- `git describe --tags --always --match 'v[0-9]*'` → HEAD 输出 `v26.07.13`，后续 commit 为 `v26.07.13-N-g<hash>`
- `make -p` → `GIT_VER := v26.07.13`
- `pytest tests/test_update_checker.py` → 5 passed
- `make check-design` → passed
- `ruff check ./webserver` → passed
- CI 实际产物受限：本地不可运行 GH Actions，`git describe` 逻辑已用本地等价命令验证

## 方案文档

`design/project/20260714-build-version-scheme.active.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)