### PR TITLE
fix(network): 网络书库列表继承 ListHandler 修复 render_book_list 缺失

### DIFF
--- a/tests/test_network_library.py
+++ b/tests/test_network_library.py
@@ -9,7 +9,7 @@ from unittest import mock
 
 from tests.test_booksource_admin import CSS_SOURCE
 from tests.test_booksource_engine import FakeSession, text
-from tests.test_main import TestWithUserLogin, get_db
+from tests.test_main import BID_EPUB, TestWithUserLogin, get_db
 from tests.test_main import setUpModule as init
 from webserver import models
 
@@ -192,6 +192,26 @@ class TestNetworkLibrary(TestWithUserLogin):
     def test_explore_missing_url(self):
         d = self.json("/api/network/explore?source_id=%d&url=&page=1" % self.sid)
         self.assertEqual(d["err"], "params.error")
+
+    def test_library_online(self):
+        # /api/library/online 走 render_book_list，需 NetworkBaseHandler 继承 ListHandler
+        session = get_db()
+        session.query(models.OnlineBookMeta).delete()
+        session.commit()
+        meta = models.OnlineBookMeta(book_id=BID_EPUB, source_url="http://x.com")
+        meta.serialize_status = models.OnlineBookMeta.SERIAL
+        meta.save()
+        try:
+            d = self.json("/api/library/online")
+            self.assertEqual(d["err"], "ok")
+            self.assertEqual(d["title"], "网络书库")
+            ids = [b["id"] for b in d["books"]]
+            self.assertIn(BID_EPUB, ids)
+            book = next(b for b in d["books"] if b["id"] == BID_EPUB)
+            self.assertEqual(book["serialize_status"], "serial")
+        finally:
+            session.query(models.OnlineBookMeta).filter(models.OnlineBookMeta.book_id == BID_EPUB).delete()
+            session.commit()
 
     def test_status_get_set(self):
         session = get_db()

--- a/webserver/handlers/network_library.py
+++ b/webserver/handlers/network_library.py
@@ -7,7 +7,7 @@ import datetime
 import tornado.escape
 
 from webserver import loader
-from webserver.handlers.base import BaseHandler, auth, js
+from webserver.handlers.base import ListHandler, auth, js
 from webserver.i18n import _
 from webserver.models import BookSourceModel, OnlineBookMeta
 from webserver.services.booksource import BookSource, BookSourceEngine, JsRuleUnsupported
@@ -27,7 +27,7 @@ def engine_config():
     }
 
 
-class NetworkBaseHandler(BaseHandler):
+class NetworkBaseHandler(ListHandler):
     def get_source(self, source_id):
         if not source_id:
             return None


### PR DESCRIPTION
## 问题

打开「网络书库」页面时后端报错：

```
AttributeError: 'NetworkLibraryOnline' object has no attribute 'render_book_list'
  File ".../webserver/handlers/network_library.py", line 308, in get
    rsp = self.render_book_list([], ids=ids, title=_("网络书库"), sort_by_id=True)
```

## 根因

`render_book_list` 定义在 `ListHandler`（ `webserver/handlers/base.py` ），**不在** `BaseHandler` 上。`NetworkBaseHandler` 原继承 `BaseHandler`，因此其子类 `NetworkLibraryOnline` 调用 `self.render_book_list(...)` 找不到方法。对比 `book.py` / `meta.py` 中用到该方法的类（ `BookNav`、`RecentBook`、`MetaList` 等）均继承自 `ListHandler`。

## 修复

让 `NetworkBaseHandler` 改继承 `ListHandler`（本身是 `BaseHandler` 子类，原有能力全部保留）。一行改动。

## 为什么之前没测出来

`tests/test_network_library.py` 覆盖了 sources / search / book / toc / content / categories / explore / status，唯独没有用例打 `/api/library/online`——这是文件里唯一走 `render_book_list` 的接口，恰好落在测试盲区。本 PR 补上 `test_library_online`。

## 测试

- Docker（ `talebook/test` ）内 `pytest tests/test_network_library.py`：**17 passed**（含新用例）。
- 回归验证：临时把基类换回 `BaseHandler`，新用例如实复现 `AttributeError` 并 FAILED；换回 `ListHandler` 后通过。
- `ruff check`：通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)