### PR TITLE
fix: 标题栏站点标题点击区域收敛为文字本身

### DIFF
--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -42,12 +42,14 @@
             </template>
 
             <v-app-bar-nav-icon @click.stop="sidebar = !sidebar" />
-            <v-toolbar-title
-                class="ml-2 mr-4 align-center"
-                style="cursor: pointer"
-                @click="router.push('/')"
-            >
-                {{ store.sys.title }}
+            <v-toolbar-title class="ml-2 mr-4 align-center">
+                <span
+                    class="site-title"
+                    style="cursor: pointer"
+                    @click="router.push('/')"
+                >
+                    {{ store.sys.title }}
+                </span>
             </v-toolbar-title>
 
             <template v-if="display.smAndUp.value">

--- a/app/test/components/AppHeader.spec.ts
+++ b/app/test/components/AppHeader.spec.ts
@@ -1,0 +1,88 @@
+// @vitest-environment nuxt
+import { mount } from '@vue/test-utils';
+import { mockNuxtImport } from '@nuxt/test-utils/runtime';
+import { createVuetify } from 'vuetify';
+import * as components from 'vuetify/components';
+import * as directives from 'vuetify/directives';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('vue-i18n', () => ({
+    useI18n: () => ({
+        locale: { value: 'zh-CN' },
+        locales: { value: [{ code: 'zh-CN', name: '简体中文' }] },
+        setLocale: vi.fn(),
+        t: (key: string) => key,
+    }),
+}));
+
+const { pushMock, storeState } = vi.hoisted(() => ({
+    pushMock: vi.fn(),
+    storeState: {
+        theme: 'light',
+        sys: {
+            title: 'TaleBook',
+            allow: {},
+            friends: [],
+            show_sidebar_sys: false,
+        },
+        user: {
+            is_login: false,
+            is_admin: false,
+        },
+        messages: [],
+        bootstrap: vi.fn().mockResolvedValue({ err: 'ok' }),
+        hideMessage: vi.fn(),
+        toggleTheme: vi.fn(),
+    },
+}));
+
+vi.mock('@/stores/main', () => ({
+    useMainStore: () => storeState,
+}));
+
+mockNuxtImport('useRouter', () => {
+    return () => ({ push: pushMock });
+});
+
+mockNuxtImport('useRoute', () => {
+    return () => ({ path: '/' });
+});
+
+const vuetify = createVuetify({ components, directives });
+global.ResizeObserver = require('resize-observer-polyfill');
+
+import AppHeader from '@/components/AppHeader.vue';
+
+function mountHeader() {
+    return mount(
+        { components: { AppHeader }, template: '<v-app><AppHeader /></v-app>' },
+        { global: { plugins: [vuetify] } },
+    );
+}
+
+describe('AppHeader.vue', () => {
+    it('only wraps the site title text in the clickable/pointer area, not the whole title bar', () => {
+        const wrapper = mountHeader();
+
+        const title = wrapper.find('.v-toolbar-title');
+        expect(title.exists()).toBe(true);
+        // 整个标题容器不应带有指针样式或点击监听，避免点击命中范围扩展到搜索框左侧空白区域
+        expect(title.attributes('style') || '').not.toContain('cursor');
+
+        const siteTitle = wrapper.find('.site-title');
+        expect(siteTitle.exists()).toBe(true);
+        expect(siteTitle.text()).toBe('TaleBook');
+        expect(siteTitle.attributes('style')).toContain('cursor: pointer');
+
+        wrapper.unmount();
+    });
+
+    it('navigates home when the title text is clicked', async () => {
+        const wrapper = mountHeader();
+
+        await wrapper.find('.site-title').trigger('click');
+        expect(pushMock).toHaveBeenCalledWith('/');
+
+        wrapper.unmount();
+    });
+});


### PR DESCRIPTION
## Summary

修复 AppHeader.vue 中标题栏站点标题的点击判定范围过大的问题：
- 原因是 `v-toolbar-title` 作为 flex 容器会增长填充剩余空间，而 click 和 cursor:pointer 直接加在该容器上，导致点击判定范围扩展到了搜索框左侧的空白区域。
- 修复方式：将 @click 和 cursor:pointer 移到仅包裹文字的内层 span 上，外层容器的 flex 布局不变，保证右侧图标仍靠右对齐。

## Test plan
- [ ] `npx vitest run test/components/AppHeader.spec.ts` 通过（本地环境未能执行验证，需在 CI 中确认）
- [ ] `npm run lint` 通过
- [ ] 浏览器中确认标题文字外的空白区域不再响应点击/hover

Closes #860

🤖 Generated with [Claude Code](https://claude.ai/code)