### PR TITLE
chore(codex): 指定 codex 模型为 gpt-5.6-sol 并启用 xhigh 推理

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -324,6 +324,8 @@ jobs:
           cli_auth_credentials_store = "file"
           approval_policy = "never"
           sandbox_mode = "workspace-write"
+          model = "gpt-5.6-sol"
+          model_reasoning_effort = "xhigh"
 
           [sandbox_workspace_write]
           network_access = false

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -47,7 +47,7 @@ jobs:
       )
     runs-on: ubuntu-latest
     env:
-      CODEX_VERSION: "0.141.0"
+      CODEX_VERSION: "0.144.0"
     steps:
       - id: context
         name: Resolve request context

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -47,7 +47,7 @@ jobs:
       )
     runs-on: ubuntu-latest
     env:
-      CODEX_VERSION: "0.144.0"
+      CODEX_VERSION: "0.144.4"
     steps:
       - id: context
         name: Resolve request context


### PR DESCRIPTION
## 改动

在 `.github/workflows/codex.yml` 生成的 `config.toml` 中新增两行,固定 Codex 使用的模型与推理强度:

```toml
model = "gpt-5.6-sol"
model_reasoning_effort = "xhigh"
```

## 说明

- 此前 workflow 未指定模型,走的是 ChatGPT/codex 账号默认模型。
- ⚠️ `gpt-5.6-sol` 这个 slug 未经核实,若模型名无效 codex 运行时会报 invalid model,合并后首次触发即可验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)