### PR TITLE
fix(app): 加大侧边栏管理面板二级菜单缩进

### DIFF
--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -660,7 +660,7 @@ function toggleTheme() {
 
 /* 默认侧边栏二级菜单：保留层级，但不要使用 Vuetify 默认的大幅缩进 */
 :deep(.app-navigation-drawer) .app-navigation-group .v-list-group__items .v-list-item {
-    padding-inline-start: 24px !important;
+    padding-inline-start: 40px !important;
 }
 :deep(.app-navigation-drawer) .app-navigation-group .v-list-group__items .v-list-item__prepend {
     width: auto !important;


### PR DESCRIPTION
## 改动说明

侧边栏「管理」二级菜单（系统设置、用户管理等）相对父级图标的缩进过小，视觉上难以区分层级。将 `app/components/AppHeader.vue` 中 `.app-navigation-group .v-list-group__items .v-list-item` 的 `padding-inline-start` 从 `24px` 调整为 `40px`。

Fixes #864

🤖 Generated with [Claude Code](https://claude.ai/code)