### PR TITLE
fix: allow admins to access private books

### DIFF
--- a/design/webserver/20260716-admin-private-book-access.active.html
+++ b/design/webserver/20260716-admin-private-book-access.active.html
@@ -1,0 +1,212 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>管理员访问私藏图书权限统一方案</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --ink: #172033;
+      --muted: #647084;
+      --line: #dce2ea;
+      --paper: #ffffff;
+      --canvas: #f4f6f9;
+      --accent: #2457c5;
+      --accent-soft: #eaf0ff;
+      --ok: #18794e;
+      --warn: #9a6700;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      color: var(--ink);
+      background: var(--canvas);
+      font: 15px/1.7 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    main { width: min(1040px, calc(100% - 32px)); margin: 32px auto 72px; }
+    header, section {
+      margin-bottom: 20px;
+      padding: 26px 30px;
+      border: 1px solid var(--line);
+      border-radius: 14px;
+      background: var(--paper);
+    }
+    header { border-top: 5px solid var(--accent); }
+    h1 { margin: 0 0 10px; font-size: 30px; line-height: 1.25; }
+    h2 { margin: 0 0 14px; font-size: 21px; }
+    h3 { margin: 18px 0 8px; font-size: 16px; }
+    p, ul, ol { margin: 8px 0; }
+    code { padding: 2px 5px; border-radius: 5px; background: #eef1f5; }
+    a { color: var(--accent); }
+    .meta { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 16px; }
+    .tag {
+      padding: 4px 10px;
+      border-radius: 999px;
+      color: var(--muted);
+      background: #eef1f5;
+      font-size: 13px;
+    }
+    .tag.status { color: var(--ok); background: #e8f5ee; font-weight: 700; }
+    .lead { color: var(--muted); font-size: 16px; }
+    .callout {
+      margin: 14px 0;
+      padding: 13px 16px;
+      border-left: 4px solid var(--accent);
+      background: var(--accent-soft);
+    }
+    .grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 14px; }
+    .card { padding: 16px; border: 1px solid var(--line); border-radius: 10px; }
+    table { width: 100%; border-collapse: collapse; margin: 12px 0; }
+    th, td { padding: 10px 12px; border: 1px solid var(--line); text-align: left; vertical-align: top; }
+    th { background: #f7f8fa; }
+    .yes { color: var(--ok); font-weight: 700; }
+    .no { color: #b42318; font-weight: 700; }
+    .flow { display: grid; grid-template-columns: 1fr 44px 1fr 44px 1fr; align-items: center; gap: 6px; }
+    .node { min-height: 92px; padding: 14px; border: 1px solid var(--line); border-radius: 10px; background: #fafbfc; }
+    .arrow { color: var(--accent); text-align: center; font-size: 25px; }
+    .pending { color: var(--warn); font-weight: 700; }
+    footer { color: var(--muted); text-align: center; font-size: 13px; }
+    @media (max-width: 760px) {
+      main { width: min(100% - 20px, 1040px); margin-top: 10px; }
+      header, section { padding: 20px; }
+      .grid { grid-template-columns: 1fr; }
+      .flow { grid-template-columns: 1fr; }
+      .arrow { transform: rotate(90deg); }
+    }
+  </style>
+</head>
+<body>
+<main>
+  <header>
+    <h1>管理员访问私藏图书权限统一方案</h1>
+    <p class="lead">修复管理员在“图书管理”能搜到图书、在普通搜索却看不到的问题，并统一私藏图书在各入口的访问规则。</p>
+    <div class="meta">
+      <span class="tag status">状态：ACTIVE</span>
+      <span class="tag">创建日期：2026-07-16</span>
+      <span class="tag">所属模块：webserver</span>
+      <span class="tag">影响范围：网页 API、OPDS、WebDAV</span>
+      <span class="tag">需求来源：GitHub Issue #867</span>
+    </div>
+  </header>
+
+  <section>
+    <h2>原始诉求与问题定位</h2>
+    <p>需求来源：<a href="https://github.com/talebook/talebook/issues/867">talebook/talebook#867</a>。同一个关键词在后台“图书管理”中能搜索到图书，但顶部普通搜索无结果。用户进一步确认：管理员本身具有查看权限，应当能够查看其他用户的私藏图书。</p>
+    <div class="callout">
+      <strong>根因：</strong>后台列表直接使用 Calibre 搜索结果；普通搜索经过 <code>render_book_list()</code> 后，会把所有“非当前用户所有”的 <code>scope=private</code> 图书过滤掉。该过滤只按所有者判断，没有为管理员豁免。
+    </div>
+    <p>代码审计还发现，详情与元数据参考接口各自重复了同类判断，而阅读、下载和 EPUB 文件入口没有统一检查私藏所有权。结果既可能出现“搜得到但打不开”，也可能出现“列表隐藏但直接链接可访问”。</p>
+  </section>
+
+  <section>
+    <h2>目标与非目标</h2>
+    <div class="grid">
+      <div class="card">
+        <h3>目标</h3>
+        <ul>
+          <li>管理员通过普通搜索可找到其他用户的私藏图书。</li>
+          <li>管理员在首页、书库、榜单、详情、阅读、下载、OPDS 与 WebDAV 中具有一致的查看能力。</li>
+          <li>所有者仍可访问自己的私藏图书。</li>
+          <li>其他用户与游客无法通过列表或直接链接访问私藏图书。</li>
+          <li>用自动化测试固定权限矩阵，避免入口之间再次漂移。</li>
+        </ul>
+      </div>
+      <div class="card">
+        <h3>非目标</h3>
+        <ul>
+          <li>不改变私藏图书的所有者与 <code>scope</code> 数据结构。</li>
+          <li>不改变管理员和所有者现有的编辑、删除权限。</li>
+          <li>不修改 Calibre 的搜索语法、分词或索引机制。</li>
+          <li>不新增前端页面、开关或 API 字段。</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>确认后的权限矩阵</h2>
+    <table>
+      <thead>
+        <tr><th>访问者</th><th>公开图书</th><th>自己的私藏图书</th><th>他人的私藏图书</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>管理员</td><td class="yes">允许</td><td class="yes">允许</td><td class="yes">允许</td></tr>
+        <tr><td>普通登录用户</td><td class="yes">允许</td><td class="yes">允许</td><td class="no">拒绝并按不存在处理</td></tr>
+        <tr><td>游客</td><td>服从现有游客阅读/下载配置</td><td>不适用</td><td class="no">拒绝并按不存在处理</td></tr>
+      </tbody>
+    </table>
+    <p>“按不存在处理”延续现有隐私策略，不向无权用户泄露私藏图书是否存在。游客配置仅决定公开图书能否阅读或下载，不能越过私藏权限。</p>
+  </section>
+
+  <section>
+    <h2>方案</h2>
+    <h3>1. 统一网页端权限判定</h3>
+    <p>在 <code>BaseHandler</code> 中提供单本图书可见性判断，并让批量私藏过滤首先识别管理员。<code>get_books()</code> 默认移除当前访问者不可见的私藏图书；<code>get_book()</code> 先执行单本权限判断，再读取 Calibre 数据，避免为单本请求扫描全部私藏 ID。两者共同覆盖详情、阅读、下载、TXT/EPUB 内容、收藏/阅读状态列表、邮件发送和已有的书籍操作入口；无权访问时沿用不存在语义。已经预先过滤 ID 的分页列表显式跳过第二次权限查询，避免重复 SQL。</p>
+    <p>首页与热度榜单移除重复的私藏过滤分支，复用同一权限规则。元数据参考接口在读取 Calibre 元数据前执行统一判定。</p>
+
+    <h3>2. 补齐不经过 <code>get_book()</code> 的内容入口</h3>
+    <p>封面与 OPF 文件接口直接访问 Calibre 数据库，需要显式执行单本可见性判断。公开图书行为不变；默认封面不对应具体书籍，不受影响。</p>
+
+    <h3>3. OPDS 与 WebDAV 保持一致</h3>
+    <p>OPDS 已复用 <code>BaseHandler</code> 的批量过滤，管理员豁免会自然覆盖搜索、全部图书和分类结果。WebDAV 使用独立 provider，因此在计算不可见私藏 ID 时读取认证用户的管理员标记；管理员返回空的不可见集合，普通用户和游客保持原规则。列表和按文件名直接解析都继续复用这组 ID。</p>
+
+    <div class="flow" aria-label="统一权限流程图">
+      <div class="node"><strong>访问入口</strong><br>搜索、详情、阅读、下载、OPDS、WebDAV</div>
+      <div class="arrow">→</div>
+      <div class="node"><strong>统一判断</strong><br>公开？管理员？私藏所有者？</div>
+      <div class="arrow">→</div>
+      <div class="node"><strong>统一结果</strong><br>允许访问，或按不存在处理</div>
+    </div>
+  </section>
+
+  <section>
+    <h2>实现约束与风险控制</h2>
+    <ul>
+      <li>管理员判断沿用现有 <code>Reader.is_admin()</code> 与 <code>BaseHandler.is_admin()</code>，不引入第二套角色定义。</li>
+      <li>批量列表使用一次 SQL 查询取得不可见 ID，避免逐书查询。</li>
+      <li>单本判断只查询对应 <code>Item</code>；没有 <code>Item</code> 或非 private 时按公开图书处理，兼容存量数据。</li>
+      <li>游客的公开图书能力仍由 <code>ALLOW_GUEST_READ</code>、<code>ALLOW_GUEST_DOWNLOAD</code> 等现有配置控制。</li>
+      <li>无前端代码和用户界面变化，因此无需新增 i18n 文案，也不需要前端构建产物变更。</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>测试计划与验收标准</h2>
+    <table>
+      <thead><tr><th>层级</th><th>计划验证</th><th>当前结果</th></tr></thead>
+      <tbody>
+        <tr><td>问题回归</td><td>管理员普通搜索能返回其他用户的私藏图书；普通用户同词搜索不返回。</td><td class="yes">通过：旧实现上关键用例 5 项失败；修复后定向用例 6 项通过。</td></tr>
+        <tr><td>网页列表与详情</td><td>管理员在书库、首页与详情可见；所有者可见；其他用户与游客不可见。</td><td class="yes">通过：<code>TestBookDetailScope</code> 全组通过。</td></tr>
+        <tr><td>直接内容入口</td><td>管理员可阅读、下载和获取私藏内容；游客即使开启公开下载/阅读也无法访问私藏内容。</td><td class="yes">通过：覆盖管理员下载、其他用户直链阅读与下载、游客直链封面 404。</td></tr>
+        <tr><td>OPDS / WebDAV</td><td>管理员可见全部私藏书；普通用户只见自己的私藏书；直接资源解析遵守同一规则。</td><td class="yes">通过：相关测试组 43 项通过、1 项按既有条件跳过。</td></tr>
+        <tr><td>回归与质量</td><td>相关 pytest、完整后端测试、<code>make lint-py-fix</code>、<code>make lint-py</code>、<code>make check-design</code>。</td><td class="yes">通过：全量后端 582 项通过、1 项跳过；格式化、lint 与方案检查通过。</td></tr>
+      </tbody>
+    </table>
+    <h3>实际执行记录</h3>
+    <ul>
+      <li><code>docker run ... pytest -q [5 个关键回归用例]</code>：修复前 5 项失败，确认测试可复现管理员过滤和直链越权。</li>
+      <li><code>docker run ... pytest -q [6 个关键回归用例]</code>：6 项通过。</li>
+      <li><code>docker run ... pytest -q TestBookDetailScope TestFile TestBook TestOpds tests/test_webdav.py</code>：43 项通过、1 项跳过。</li>
+      <li><code>make lint-py-fix</code>：通过，96 个后端文件无需额外格式化。</li>
+      <li><code>make lint-py</code>：通过，ruff 检查与格式检查均无错误。</li>
+      <li><code>docker run ... pytest tests -q</code>：最终 582 项通过、1 项跳过、32 条既有弃用或 SQLAlchemy 警告，用时 37.30 秒。</li>
+      <li><code>make check-design</code>：通过，13 份方案文档全部合格。</li>
+    </ul>
+    <p>宿主机没有 Calibre Python 模块，无法直接执行 <code>make pytest</code>；因此使用仓库现有 <code>talebook/test:latest</code> 镜像挂载当前 worktree，执行等价的完整 <code>pytest tests -q</code>。测试使用 Calibre 8.5，与当前生产 Dockerfile 固定的基础镜像版本一致。</p>
+  </section>
+
+  <section>
+    <h2>决策记录</h2>
+    <ol>
+      <li>2026-07-16：用户确认管理员应当能够查看其他用户的私藏图书。</li>
+      <li>2026-07-16：用户确认权限规则覆盖完整入口；管理员全入口可读，所有者可读自己的，其他用户和游客拒绝。</li>
+      <li>2026-07-16：选择后端统一授权，不在前端根据角色绕过过滤，确保 API、OPDS 与 WebDAV 一致。</li>
+      <li>2026-07-16：实现阶段将默认批量权限过滤下沉到 <code>get_books()</code>，单本入口使用 <code>can_view_book()</code> 精确判断；分页列表在已过滤 ID 后跳过重复查询。</li>
+    </ol>
+  </section>
+
+  <footer>Talebook 内部开发方案 · ACTIVE · GitHub Issue #867</footer>
+</main>
+</body>
+</html>

--- a/design/webserver/20260716-private-book-access-review-fixes.active.html
+++ b/design/webserver/20260716-private-book-access-review-fixes.active.html
@@ -1,0 +1,184 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>私藏图书访问 PR Review 修复方案</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --ink: #172033;
+      --muted: #637083;
+      --line: #dce2ea;
+      --paper: #fff;
+      --canvas: #f4f6f9;
+      --blue: #2457c5;
+      --blue-soft: #eaf0ff;
+      --amber: #9a6700;
+      --green: #18794e;
+      --red: #b42318;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      color: var(--ink);
+      background: var(--canvas);
+      font: 15px/1.7 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    main { width: min(1040px, calc(100% - 32px)); margin: 32px auto 72px; }
+    header, section {
+      margin-bottom: 20px;
+      padding: 26px 30px;
+      border: 1px solid var(--line);
+      border-radius: 14px;
+      background: var(--paper);
+    }
+    header { border-top: 5px solid var(--blue); }
+    h1 { margin: 0 0 10px; font-size: 29px; line-height: 1.25; }
+    h2 { margin: 0 0 14px; font-size: 21px; }
+    h3 { margin: 18px 0 8px; font-size: 16px; }
+    p, ul, ol { margin: 8px 0; }
+    code { padding: 2px 5px; border-radius: 5px; background: #eef1f5; }
+    code.command { display: block; margin: 6px 0; padding: 8px 10px; white-space: pre-wrap; overflow-wrap: anywhere; }
+    a { color: var(--blue); }
+    .lead { color: var(--muted); font-size: 16px; }
+    .meta { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 16px; }
+    .tag { padding: 4px 10px; border-radius: 999px; color: var(--muted); background: #eef1f5; font-size: 13px; }
+    .status { color: var(--green); background: #e8f5ee; font-weight: 700; }
+    .callout { margin: 14px 0; padding: 13px 16px; border-left: 4px solid var(--blue); background: var(--blue-soft); }
+    table { width: 100%; margin: 12px 0; border-collapse: collapse; }
+    th, td { padding: 10px 12px; border: 1px solid var(--line); text-align: left; vertical-align: top; }
+    th { background: #f7f8fa; }
+    .yes { color: var(--green); font-weight: 700; }
+    .no { color: var(--red); font-weight: 700; }
+    .pending { color: var(--amber); font-weight: 700; }
+    .flow { display: grid; grid-template-columns: 1fr 42px 1fr 42px 1fr; align-items: center; gap: 6px; margin-top: 16px; }
+    .node { min-height: 92px; padding: 14px; border: 1px solid var(--line); border-radius: 10px; background: #fafbfc; }
+    .arrow { color: var(--blue); text-align: center; font-size: 24px; }
+    footer { color: var(--muted); text-align: center; font-size: 13px; }
+    @media (max-width: 760px) {
+      main { width: min(100% - 20px, 1040px); margin-top: 10px; }
+      header, section { padding: 20px; }
+      .flow { grid-template-columns: 1fr; }
+      .arrow { transform: rotate(90deg); }
+      table { display: block; overflow-x: auto; }
+    }
+  </style>
+</head>
+<body>
+<main>
+  <header>
+    <h1>私藏图书访问 PR Review 修复方案</h1>
+    <p class="lead">处理 PR #869 的评审意见，修复静态资源域名与认证 Cookie 不同源的问题，并恢复阅读入口原有的 HTTP 404 语义。</p>
+    <div class="meta">
+      <span class="tag status">状态：ACTIVE</span>
+      <span class="tag">创建日期：2026-07-16</span>
+      <span class="tag">所属模块：webserver</span>
+      <span class="tag">需求来源：GitHub PR #869 Review</span>
+      <span class="tag">影响范围：资源 URL、阅读入口、测试</span>
+    </div>
+  </header>
+
+  <section>
+    <h2>原始诉求与核对结果</h2>
+    <p>原始任务是处理 <a href="https://github.com/talebook/talebook/pull/869">PR #869</a> 中评审发现的问题。该 PR 的基础方案为 <code>design/webserver/20260716-admin-private-book-access.active.html</code> ，本方案是兼容性补充，不替代其管理员权限矩阵。</p>
+    <table>
+      <thead><tr><th>评审项</th><th>核对结论</th><th>处理决定</th></tr></thead>
+      <tbody>
+        <tr><td><code>can_view_book()</code> 与既有 <code>can_read_book()</code> 重复</td><td>当前 master、PR HEAD 与本地所有引用中都不存在 <code>can_read_book()</code>，无法复现重复。</td><td>保留唯一的 <code>can_view_book()</code>，不凭空新增第二套授权函数；在 PR 回复中说明证据。</td></tr>
+        <tr><td>阅读入口的旧检查成为死代码</td><td>当前代码没有这些旧调用；但中央 <code>get_book()</code> 会让私藏拒绝提前以 HTTP 200 JSON 结束。</td><td>非 JSON 文件与阅读入口统一调用 <code>get_book_or_404()</code>，由该助手复用中央授权并在不可见或不存在时返回 404。</td></tr>
+        <tr><td>配置 <code>static_host</code> 后私藏封面 404</td><td class="yes">成立。序列化仍把封面、缩略图和格式下载 URL 指向 CDN 域名，而认证 Cookie 属于应用域名。</td><td>私藏资源使用应用源；公开资源继续使用 CDN。</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section>
+    <h2>目标与不变量</h2>
+    <ul>
+      <li>管理员和所有者在配置 <code>static_host</code> 时仍能加载私藏封面、缩略图和下载链接。</li>
+      <li>公开图书继续使用 <code>static_host</code>，不牺牲现有 CDN 缓存能力。</li>
+      <li>无权用户访问 <code>/read/&lt;id&gt;</code> 或 <code>/get/extract/&lt;id&gt;/...</code> 时返回 HTTP 404，不泄露图书存在性。</li>
+      <li>权限矩阵保持不变：管理员可见全部，普通用户仅可见自己的私藏书，游客不可见私藏书。</li>
+      <li>只保留 <code>can_view_book()</code> 作为单本可见性判断，不引入同义函数。</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>方案</h2>
+    <h3>1. 按图书 scope 选择资源源地址</h3>
+    <p>由 <code>SimpleBookFormatter</code> 同时接收 CDN 地址与应用 API 地址。图书为 private 时，封面和缩略图使用应用地址；其他图书继续使用 CDN 地址。所有调用方，包括普通列表与管理员图书列表，都走同一选择逻辑。</p>
+    <p><code>BookFormatter.get_files()</code> 对格式下载链接应用同样规则，避免详情页封面修好但下载仍因跨域缺少 Cookie 而 404。</p>
+
+    <h3>2. 非 JSON 阅读入口保留 404</h3>
+    <p><code>BookRead</code>、<code>EpubReader</code> 与 <code>BookDownload</code> 统一调用 <code>get_book_or_404()</code>。该助手通过中央 <code>get_book()</code> 复用唯一的 <code>can_view_book()</code> 授权，拒绝或不存在时抛出 HTTP 404；JSON 接口仍保留原有的 not_found 语义。</p>
+
+    <div class="flow" aria-label="私藏资源地址选择流程">
+      <div class="node"><strong>序列化图书</strong><br>读取 scope 与请求源</div>
+      <div class="arrow">→</div>
+      <div class="node"><strong>选择资源源</strong><br>private → 应用源<br>public → CDN</div>
+      <div class="arrow">→</div>
+      <div class="node"><strong>资源请求</strong><br>私藏携带认证 Cookie<br>公开保留 CDN 缓存</div>
+    </div>
+  </section>
+
+  <section>
+    <h2>兼容性、安全与回滚</h2>
+    <ul>
+      <li>无配置 <code>static_host</code> 时，应用源与 CDN 地址都为空前缀，仍生成相对 URL，行为不变。</li>
+      <li>私藏资源不再经过独立静态域名，避免 Cookie 缺失；代价是私藏封面不使用 CDN 缓存，这是授权正确性所需。</li>
+      <li>公开图书 URL 不变，CDN 命中率不受影响。</li>
+      <li>不修改数据库、配置字段或前端代码。回滚时可单独撤销本次 follow-up 提交，不影响原权限方案。</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>测试计划</h2>
+    <table>
+      <thead><tr><th>公开 seam</th><th>预期</th><th>当前结果</th></tr></thead>
+      <tbody>
+        <tr><td><code>GET /api/book/&lt;id&gt;</code></td><td>配置 static_host 后，私藏图书 img、thumb、files 使用请求应用源；公开图书仍使用 CDN。</td><td class="yes">通过：私藏资源使用 books.example，公开资源保留 cdn.example。</td></tr>
+        <tr><td><code>GET /api/admin/book/list</code></td><td>管理员列表中的私藏封面使用应用源。</td><td class="yes">通过：私藏封面与缩略图均使用 books.example。</td></tr>
+        <tr><td><code>GET /read/&lt;id&gt;</code></td><td>其他用户访问私藏图书返回 HTTP 404。</td><td class="yes">通过：修复前为 200，修复后为 404。</td></tr>
+        <tr><td><code>GET /get/extract/&lt;id&gt;/...</code></td><td>其他用户访问私藏 EPUB 内容返回 HTTP 404。</td><td class="yes">通过：修复前为 200，修复后为 404。</td></tr>
+        <tr><td>质量门禁</td><td>相关测试、完整 pytest、<code>make lint-py-fix</code>、<code>make lint-py</code>、<code>make check-design</code> 通过。</td><td class="yes">相关测试与全量 pytest、格式化、lint、方案门禁全部通过。</td></tr>
+      </tbody>
+    </table>
+    <h3>实际执行记录</h3>
+    <ul>
+      <li>阅读 seam 红灯与绿灯：
+        <code class="command">docker run --rm -v /private/tmp/talebook-wt-867:/workspace -w /workspace talebook/test:latest pytest -q tests/test_main.py::TestBookDetailScope::test_other_user_cannot_read_private_book_by_direct_url tests/test_main.py::TestBookDetailScope::test_other_user_cannot_read_private_epub_content_by_direct_url</code>
+        修复前 2 项失败，均为期望 404、实际 200；最小修复后 2 项通过。
+      </li>
+      <li>static_host seam 红灯：私藏详情与管理员列表 2 项失败，公开 CDN 回归项通过。</li>
+      <li>自审整理后的 5 项核心 seam：
+        <code class="command">docker run --rm -v /private/tmp/talebook-wt-867:/workspace -w /workspace talebook/test:latest pytest -q tests/test_main.py::TestBookDetailScope::test_private_book_resources_use_authenticated_origin_when_static_host_is_set tests/test_main.py::TestBookDetailScope::test_public_book_resources_keep_using_static_host tests/test_admin.py::TestAdminPrivateBookResources::test_private_book_cover_uses_authenticated_origin_when_static_host_is_set tests/test_main.py::TestBookDetailScope::test_other_user_cannot_read_private_book_by_direct_url tests/test_main.py::TestBookDetailScope::test_other_user_cannot_read_private_epub_content_by_direct_url</code>
+        5 项通过，用时 2.54 秒。
+      </li>
+      <li>自审修正后的相关测试：
+        <code class="command">docker run --rm -v /private/tmp/talebook-wt-867:/workspace -w /workspace talebook/test:latest pytest -q tests/test_main.py::TestBookDetailScope tests/test_main.py::TestFile tests/test_main.py::TestBook tests/test_admin.py::TestAdminPrivateBookResources</code>
+        36 项通过。
+      </li>
+      <li><code>make lint-py-fix</code>：通过，96 个后端文件无需额外格式化。</li>
+      <li><code>make lint-py</code>：通过，ruff 检查与格式检查均无错误。</li>
+      <li>完整后端测试：
+        <code class="command">docker run --rm -v /private/tmp/talebook-wt-867:/workspace -w /workspace talebook/test:latest pytest tests -q</code>
+        586 项通过、1 项跳过、32 条既有警告，用时 43.97 秒。
+      </li>
+      <li><code>make check-design</code>：通过，14 份方案文档全部合格。</li>
+    </ul>
+    <p>宿主机缺少 Calibre Python 模块，因此完整测试继续使用仓库现有 <code>talebook/test:latest</code> 镜像挂载当前 worktree 执行；该镜像与生产 Dockerfile 当前固定的 Calibre 8.5 基础版本一致。</p>
+  </section>
+
+  <section>
+    <h2>决策记录</h2>
+    <ol>
+      <li>2026-07-16：不接受无法在 master 或 PR HEAD 复现的 <code>can_read_book()</code> 重复结论；保持一个授权函数并在 review 中提供核对结果。</li>
+      <li>2026-07-16：修复范围从封面扩展到缩略图与格式下载链接，因为它们共享同一个跨域认证根因。</li>
+      <li>2026-07-16：恢复阅读入口的 HTTP 404，而不是把 HTTP 200 JSON 行为写成新的兼容约定。</li>
+    </ol>
+  </section>
+
+  <footer>Talebook 内部开发方案 · ACTIVE · PR #869 Review Follow-up</footer>
+</main>
+</body>
+</html>

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -8,7 +8,14 @@ import tempfile
 import urllib.parse
 from unittest import mock
 
-from tests.test_main import TestWithAdminUser, TestWithUserLogin, get_db
+from tests.test_main import (
+    BID_EPUB,
+    TestWithAdminUser,
+    TestWithUserLogin,
+    get_db,
+    temporary_book_scope,
+    temporary_static_host,
+)
 from tests.test_main import setUpModule as init
 from webserver import loader
 
@@ -22,6 +29,19 @@ class TestAdmin(TestWithUserLogin):
         d = self.json("/api/admin/book/list?sort=id&num=10")
         self.assertEqual(d["err"], "ok")
         self.assertEqual(len(d["items"]), 10)
+
+
+class TestAdminPrivateBookResources(TestWithAdminUser):
+    def test_private_book_cover_uses_authenticated_origin_when_static_host_is_set(self):
+        with temporary_book_scope(BID_EPUB, "private", collector_id=2):
+            with temporary_static_host("cdn.example"):
+                d = self.json(
+                    "/api/admin/book/list?search=A&num=0",
+                    headers={"X-Forwarded-Host": "books.example"},
+                )
+            book = next(book for book in d["items"] if book["id"] == BID_EPUB)
+            self.assertEqual(urllib.parse.urlsplit(book["img"]).netloc, "books.example")
+            self.assertEqual(urllib.parse.urlsplit(book["thumb"]).netloc, "books.example")
 
 
 class TestAdminSettingsSecurity(TestWithAdminUser):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import base64
+import contextlib
 import json
 import logging
 import os
@@ -103,6 +104,43 @@ def Q(s):
     if not isinstance(s, str):
         s = str(s)
     return urllib.parse.quote(s.encode("UTF-8"))
+
+
+@contextlib.contextmanager
+def temporary_static_host(host):
+    original_static_host = main.CONF["static_host"]
+    main.CONF["static_host"] = host
+    try:
+        yield
+    finally:
+        main.CONF["static_host"] = original_static_host
+
+
+@contextlib.contextmanager
+def temporary_book_scope(book_id, scope, collector_id=1):
+    session = get_db()
+    item = session.query(models.Item).filter(models.Item.book_id == book_id).first()
+    created = item is None
+    if created:
+        item = models.Item(book_id=book_id)
+        session.add(item)
+    original_scope = item.scope
+    original_collector_id = item.collector_id
+    item.scope = scope
+    item.collector_id = collector_id
+    session.commit()
+
+    try:
+        yield
+    finally:
+        session = get_db()
+        item = session.query(models.Item).filter(models.Item.book_id == book_id).first()
+        if created:
+            session.delete(item)
+        else:
+            item.scope = original_scope
+            item.collector_id = original_collector_id
+        session.commit()
 
 
 class FakeHandler(BaseHandler):
@@ -984,151 +1022,122 @@ class TestInviteMode(TestApp):
 class TestBookDetailScope(TestApp):
     """私有书籍详情页访问权限测试"""
 
-    def _set_book_scope(self, book_id, scope, collector_id=1):
-        from webserver.models import Item
-
-        session = get_db()
-        item = session.query(Item).filter(Item.book_id == book_id).first()
-        if item is None:
-            item = Item()
-            item.book_id = book_id
-            session.add(item)
-        item.scope = scope
-        item.collector_id = collector_id
-        session.commit()
-
-    def _clear_book_scope(self, book_id):
-        from webserver.models import Item
-
-        session = get_db()
-        item = session.query(Item).filter(Item.book_id == book_id).first()
-        if item:
-            item.scope = "public"
-            session.commit()
-
     def test_guest_cannot_access_private_book(self):
-        self._set_book_scope(BID_EPUB, "private", collector_id=1)
-        try:
+        with temporary_book_scope(BID_EPUB, "private", collector_id=1):
             d = self.json("/api/book/%d" % BID_EPUB)
             self.assertEqual(d["err"], "book.not_found")
-        finally:
-            self._clear_book_scope(BID_EPUB)
 
     def test_owner_can_access_private_book(self):
-        self._set_book_scope(BID_EPUB, "private", collector_id=1)
-        try:
+        with temporary_book_scope(BID_EPUB, "private", collector_id=1):
             with mock.patch.object(BaseHandler, "user_id", return_value=1):
                 d = self.json("/api/book/%d" % BID_EPUB)
                 self.assertEqual(d["err"], "ok")
-        finally:
-            self._clear_book_scope(BID_EPUB)
 
     def test_other_user_cannot_access_private_book(self):
-        self._set_book_scope(BID_EPUB, "private", collector_id=1)
-        try:
+        with temporary_book_scope(BID_EPUB, "private", collector_id=1):
             with mock.patch.object(BaseHandler, "user_id", return_value=2):
                 d = self.json("/api/book/%d" % BID_EPUB)
                 self.assertEqual(d["err"], "book.not_found")
-        finally:
-            self._clear_book_scope(BID_EPUB)
 
     def test_admin_can_access_private_book_owned_by_other_user(self):
-        self._set_book_scope(BID_EPUB, "private", collector_id=2)
-        try:
+        with temporary_book_scope(BID_EPUB, "private", collector_id=2):
             with mock.patch.object(BaseHandler, "user_id", return_value=1):
                 d = self.json("/api/book/%d" % BID_EPUB)
                 self.assertEqual(d["err"], "ok")
-        finally:
-            self._clear_book_scope(BID_EPUB)
+
+    def test_private_book_resources_use_authenticated_origin_when_static_host_is_set(self):
+        with temporary_book_scope(BID_EPUB, "private", collector_id=2):
+            with temporary_static_host("cdn.example"):
+                with mock.patch.object(BaseHandler, "user_id", return_value=1):
+                    d = self.json(
+                        "/api/book/%d" % BID_EPUB,
+                        headers={"X-Forwarded-Host": "books.example"},
+                    )
+            self.assertEqual(urllib.parse.urlsplit(d["book"]["img"]).netloc, "books.example")
+            self.assertEqual(urllib.parse.urlsplit(d["book"]["thumb"]).netloc, "books.example")
+            self.assertTrue(d["book"]["files"])
+            for item in d["book"]["files"]:
+                self.assertEqual(urllib.parse.urlsplit(item["href"]).netloc, "books.example")
+
+    def test_public_book_resources_keep_using_static_host(self):
+        with temporary_book_scope(BID_EPUB, "public", collector_id=1):
+            with temporary_static_host("cdn.example"):
+                d = self.json(
+                    "/api/book/%d" % BID_EPUB,
+                    headers={"X-Forwarded-Host": "books.example"},
+                )
+            self.assertEqual(urllib.parse.urlsplit(d["book"]["img"]).netloc, "cdn.example")
+            self.assertEqual(urllib.parse.urlsplit(d["book"]["thumb"]).netloc, "cdn.example")
+            self.assertTrue(d["book"]["files"])
+            for item in d["book"]["files"]:
+                self.assertEqual(urllib.parse.urlsplit(item["href"]).netloc, "cdn.example")
 
     def test_guest_can_access_public_book(self):
-        self._set_book_scope(BID_EPUB, "public", collector_id=1)
-        try:
+        with temporary_book_scope(BID_EPUB, "public", collector_id=1):
             d = self.json("/api/book/%d" % BID_EPUB)
             self.assertEqual(d["err"], "ok")
-        finally:
-            self._clear_book_scope(BID_EPUB)
 
     def test_library_hides_private_book_from_guest(self):
-        self._set_book_scope(BID_EPUB, "private", collector_id=1)
-        try:
+        with temporary_book_scope(BID_EPUB, "private", collector_id=1):
             d = self.json("/api/library")
             self.assertEqual(d["err"], "ok")
             ids = [b["id"] for b in d["books"]]
             self.assertNotIn(BID_EPUB, ids)
-        finally:
-            self._clear_book_scope(BID_EPUB)
 
     def test_library_shows_private_book_to_owner(self):
-        self._set_book_scope(BID_EPUB, "private", collector_id=1)
-        try:
+        with temporary_book_scope(BID_EPUB, "private", collector_id=1):
             with mock.patch.object(BaseHandler, "user_id", return_value=1):
                 d = self.json("/api/library")
                 self.assertEqual(d["err"], "ok")
                 ids = [b["id"] for b in d["books"]]
                 self.assertIn(BID_EPUB, ids)
-        finally:
-            self._clear_book_scope(BID_EPUB)
 
     def test_library_hides_private_book_from_other_user(self):
-        self._set_book_scope(BID_EPUB, "private", collector_id=1)
-        try:
+        with temporary_book_scope(BID_EPUB, "private", collector_id=1):
             with mock.patch.object(BaseHandler, "user_id", return_value=2):
                 d = self.json("/api/library")
                 self.assertEqual(d["err"], "ok")
                 ids = [b["id"] for b in d["books"]]
                 self.assertNotIn(BID_EPUB, ids)
-        finally:
-            self._clear_book_scope(BID_EPUB)
 
     def test_admin_search_shows_private_book_owned_by_other_user(self):
-        self._set_book_scope(BID_EPUB, "private", collector_id=2)
-        try:
+        with temporary_book_scope(BID_EPUB, "private", collector_id=2):
             with mock.patch.object(BaseHandler, "user_id", return_value=1):
                 d = self.json("/api/search?name=A")
                 self.assertEqual(d["err"], "ok")
                 ids = [book["id"] for book in d["books"]]
                 self.assertIn(BID_EPUB, ids)
-        finally:
-            self._clear_book_scope(BID_EPUB)
 
     def test_other_user_cannot_download_private_book_by_direct_url(self):
-        self._set_book_scope(BID_EPUB, "private", collector_id=1)
-        try:
+        with temporary_book_scope(BID_EPUB, "private", collector_id=1):
             with mock.patch.object(BaseHandler, "user_id", return_value=2):
                 rsp = self.fetch("/api/book/%d.epub" % BID_EPUB)
                 self.assertEqual(rsp.code, 404)
-        finally:
-            self._clear_book_scope(BID_EPUB)
 
     def test_admin_can_download_private_book_owned_by_other_user(self):
-        self._set_book_scope(BID_EPUB, "private", collector_id=2)
-        try:
+        with temporary_book_scope(BID_EPUB, "private", collector_id=2):
             with mock.patch.object(BaseHandler, "user_id", return_value=1):
                 rsp = self.fetch("/api/book/%d.epub" % BID_EPUB)
                 self.assertEqual(rsp.code, 200)
                 self.assertGreater(len(rsp.body), 0)
                 self.assertNotEqual(rsp.headers.get("Content-Type"), "application/json; charset=UTF-8")
-        finally:
-            self._clear_book_scope(BID_EPUB)
 
     def test_other_user_cannot_read_private_book_by_direct_url(self):
-        self._set_book_scope(BID_EPUB, "private", collector_id=1)
-        try:
+        with temporary_book_scope(BID_EPUB, "private", collector_id=1):
             with mock.patch.object(BaseHandler, "user_id", return_value=2):
                 rsp = self.fetch("/read/%d" % BID_EPUB)
-                self.assertEqual(rsp.code, 200)
-                self.assertEqual(json.loads(rsp.body)["err"], "not_found")
-        finally:
-            self._clear_book_scope(BID_EPUB)
+                self.assertEqual(rsp.code, 404)
+
+    def test_other_user_cannot_read_private_epub_content_by_direct_url(self):
+        with temporary_book_scope(BID_EPUB, "private", collector_id=1):
+            with mock.patch.object(BaseHandler, "user_id", return_value=2):
+                rsp = self.fetch("/get/extract/%d/content.opf" % BID_EPUB)
+                self.assertEqual(rsp.code, 404)
 
     def test_guest_cannot_get_private_book_cover_by_direct_url(self):
-        self._set_book_scope(BID_EPUB, "private", collector_id=1)
-        try:
+        with temporary_book_scope(BID_EPUB, "private", collector_id=1):
             rsp = self.fetch("/get/cover/%d.jpg" % BID_EPUB)
             self.assertEqual(rsp.code, 404)
-        finally:
-            self._clear_book_scope(BID_EPUB)
 
 
 def setUpModule():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1010,7 +1010,7 @@ class TestBookDetailScope(TestApp):
         self._set_book_scope(BID_EPUB, "private", collector_id=1)
         try:
             d = self.json("/api/book/%d" % BID_EPUB)
-            self.assertNotEqual(d["err"], "ok")
+            self.assertEqual(d["err"], "book.not_found")
         finally:
             self._clear_book_scope(BID_EPUB)
 
@@ -1028,7 +1028,16 @@ class TestBookDetailScope(TestApp):
         try:
             with mock.patch.object(BaseHandler, "user_id", return_value=2):
                 d = self.json("/api/book/%d" % BID_EPUB)
-                self.assertNotEqual(d["err"], "ok")
+                self.assertEqual(d["err"], "book.not_found")
+        finally:
+            self._clear_book_scope(BID_EPUB)
+
+    def test_admin_can_access_private_book_owned_by_other_user(self):
+        self._set_book_scope(BID_EPUB, "private", collector_id=2)
+        try:
+            with mock.patch.object(BaseHandler, "user_id", return_value=1):
+                d = self.json("/api/book/%d" % BID_EPUB)
+                self.assertEqual(d["err"], "ok")
         finally:
             self._clear_book_scope(BID_EPUB)
 
@@ -1069,6 +1078,55 @@ class TestBookDetailScope(TestApp):
                 self.assertEqual(d["err"], "ok")
                 ids = [b["id"] for b in d["books"]]
                 self.assertNotIn(BID_EPUB, ids)
+        finally:
+            self._clear_book_scope(BID_EPUB)
+
+    def test_admin_search_shows_private_book_owned_by_other_user(self):
+        self._set_book_scope(BID_EPUB, "private", collector_id=2)
+        try:
+            with mock.patch.object(BaseHandler, "user_id", return_value=1):
+                d = self.json("/api/search?name=A")
+                self.assertEqual(d["err"], "ok")
+                ids = [book["id"] for book in d["books"]]
+                self.assertIn(BID_EPUB, ids)
+        finally:
+            self._clear_book_scope(BID_EPUB)
+
+    def test_other_user_cannot_download_private_book_by_direct_url(self):
+        self._set_book_scope(BID_EPUB, "private", collector_id=1)
+        try:
+            with mock.patch.object(BaseHandler, "user_id", return_value=2):
+                rsp = self.fetch("/api/book/%d.epub" % BID_EPUB)
+                self.assertEqual(rsp.code, 404)
+        finally:
+            self._clear_book_scope(BID_EPUB)
+
+    def test_admin_can_download_private_book_owned_by_other_user(self):
+        self._set_book_scope(BID_EPUB, "private", collector_id=2)
+        try:
+            with mock.patch.object(BaseHandler, "user_id", return_value=1):
+                rsp = self.fetch("/api/book/%d.epub" % BID_EPUB)
+                self.assertEqual(rsp.code, 200)
+                self.assertGreater(len(rsp.body), 0)
+                self.assertNotEqual(rsp.headers.get("Content-Type"), "application/json; charset=UTF-8")
+        finally:
+            self._clear_book_scope(BID_EPUB)
+
+    def test_other_user_cannot_read_private_book_by_direct_url(self):
+        self._set_book_scope(BID_EPUB, "private", collector_id=1)
+        try:
+            with mock.patch.object(BaseHandler, "user_id", return_value=2):
+                rsp = self.fetch("/read/%d" % BID_EPUB)
+                self.assertEqual(rsp.code, 200)
+                self.assertEqual(json.loads(rsp.body)["err"], "not_found")
+        finally:
+            self._clear_book_scope(BID_EPUB)
+
+    def test_guest_cannot_get_private_book_cover_by_direct_url(self):
+        self._set_book_scope(BID_EPUB, "private", collector_id=1)
+        try:
+            rsp = self.fetch("/get/cover/%d.jpg" % BID_EPUB)
+            self.assertEqual(rsp.code, 404)
         finally:
             self._clear_book_scope(BID_EPUB)
 

--- a/tests/test_webdav.py
+++ b/tests/test_webdav.py
@@ -10,6 +10,7 @@ Run with the dependency installed: ``pip install -r requirements.txt``.
 """
 
 import logging
+from unittest import mock
 
 import pytest
 
@@ -31,16 +32,18 @@ def setUpModule():
     from webserver.models import Reader
 
     session = get_db()
-    if not session.query(Reader).filter(Reader.username == "admin").first():
+    user = session.query(Reader).filter(Reader.username == "admin").first()
+    if not user:
         user = Reader()
         user.username = "admin"
         user.name = "Admin"
         user.email = "admin@talebook.local"
-        user.permission = "admin"
+        user.permission = ""
         user.create_time = datetime.now()
         user.set_secure_password("admin")
         session.add(user)
-        session.commit()
+    user.admin = True
+    session.commit()
 
 
 class TestWebDav(TestApp):
@@ -88,6 +91,30 @@ class TestWebDav(TestApp):
         )
         # 207 Multi-Status is the WebDAV success code for PROPFIND.
         self.assertEqual(rsp.code, 207)
+
+    def test_admin_has_no_invisible_private_books(self):
+        """WebDAV 管理员应能看到其他用户的私藏书。"""
+        from webserver.models import Item, Reader
+        from webserver.webdav.dav_provider import MyBooksDavProvider
+
+        session = get_db()
+        admin = session.query(Reader).filter(Reader.username == "admin").first()
+        item = session.query(Item).filter(Item.book_id == 1).first()
+        original_scope = item.scope
+        original_collector_id = item.collector_id
+        item.scope = "private"
+        item.collector_id = 2
+        session.commit()
+
+        try:
+            provider = MyBooksDavProvider(mock.Mock(), get_session_func=get_db)
+            self.assertNotIn(1, provider._get_other_private_book_ids(admin.id))
+        finally:
+            session = get_db()
+            item = session.query(Item).filter(Item.book_id == 1).first()
+            item.scope = original_scope
+            item.collector_id = original_collector_id
+            session.commit()
 
 
 if __name__ == "__main__":

--- a/webserver/handlers/admin.py
+++ b/webserver/handlers/admin.py
@@ -905,7 +905,7 @@ class AdminBookList(BaseHandler):
             end = start + num
             page_ids = all_ids[start:end]
         if page_ids:
-            books = [utils.SimpleBookFormatter(b, self.cdn_url).format() for b in self.get_books(ids=page_ids)]
+            books = [utils.SimpleBookFormatter(b, self.cdn_url, self.api_url).format() for b in self.get_books(ids=page_ids)]
 
         return {"err": "ok", "items": books, "total": total}
 

--- a/webserver/handlers/base.py
+++ b/webserver/handlers/base.py
@@ -419,6 +419,13 @@ class BaseHandler(web.RequestHandler):
                 return None
         return books[0]
 
+    def get_book_or_404(self, book_id):
+        """获取当前访问者可见的图书，否则返回适用于文件和阅读入口的 HTTP 404。"""
+        book = self.get_book(book_id, raise_exception=False)
+        if not book:
+            raise web.HTTPError(404, reason=_("书籍不存在"))
+        return book
+
     def can_view_book(self, book_id):
         """返回当前访问者是否有权查看指定图书。"""
         if self.is_admin():

--- a/webserver/handlers/base.py
+++ b/webserver/handlers/base.py
@@ -408,7 +408,8 @@ class BaseHandler(web.RequestHandler):
         self.write(self.render_string(template, **vals))
 
     def get_book(self, book_id, raise_exception=True):
-        books = self.get_books(ids=[int(book_id)])
+        book_id = int(book_id)
+        books = self.get_books(ids=[book_id], check_permission=False) if self.can_view_book(book_id) else []
         if not books:
             if raise_exception:
                 self.write({"err": "not_found", "msg": _("抱歉，这本书不存在")})
@@ -418,8 +419,23 @@ class BaseHandler(web.RequestHandler):
                 return None
         return books[0]
 
+    def can_view_book(self, book_id):
+        """返回当前访问者是否有权查看指定图书。"""
+        if self.is_admin():
+            return True
+
+        item = self.session.get(Item, int(book_id))
+        if not item or item.scope != "private":
+            return True
+
+        user_id = self.user_id()
+        return bool(user_id and item.collector_id == user_id)
+
     def _get_private_book_ids(self):
         """返回当前用户无权查看的 scope=private 书籍 ID 集合"""
+        if self.is_admin():
+            return set()
+
         user_id = self.user_id()
         if user_id:
             return set(
@@ -509,6 +525,7 @@ class BaseHandler(web.RequestHandler):
             return {"err": "internal", "msg": _("同步元数据时发生错误: %s") % str(e)}
 
     def get_books(self, *args, **kwargs):
+        check_permission = kwargs.pop("check_permission", True)
         _ts = time.time()
         books = self.db.get_data_as_dict(*args, **kwargs)
         logging.debug("[%5d ms] select books from library  (count = %d)" % (int(1000 * (time.time() - _ts)), len(books)))
@@ -526,6 +543,9 @@ class BaseHandler(web.RequestHandler):
             maps[b.book_id] = d
         for book in books:
             book.update(maps.get(book["id"], empty_item))
+        if check_permission:
+            private_book_ids = self._get_private_book_ids()
+            books = [book for book in books if book["id"] not in private_book_ids]
         logging.debug("[%5d ms] select books from database (count = %d)" % (int(1000 * (time.time() - _ts)), len(books)))
         return books
 
@@ -633,7 +653,7 @@ class ListHandler(BaseHandler):
         if ids:
             ids = [book_id for book_id in ids if book_id not in private_book_ids]
             count = len(ids)
-            books = self.get_books(ids=ids[start : start + delta])
+            books = self.get_books(ids=ids[start : start + delta], check_permission=False)
             if sort_by_id:
                 # 归一化，按照 id 从大到小排列。
                 self.do_sort(books, "id", False)
@@ -658,7 +678,7 @@ class ListHandler(BaseHandler):
         if ids:
             ids = [book_id for book_id in ids if book_id not in private_book_ids]
             count = len(ids)
-            books = self.get_books(ids=ids[start : start + delta])
+            books = self.get_books(ids=ids[start : start + delta], check_permission=False)
             if sort_by_id:
                 self.do_sort(books, "id", False)
         else:

--- a/webserver/handlers/book.py
+++ b/webserver/handlers/book.py
@@ -952,9 +952,7 @@ class BookDownload(BaseHandler, web.StaticFileHandler):
         bid, fmt = filename.split(".")
         fmt = fmt.lower()
         logging.error("download %s bid=%s, fmt=%s" % (filename, bid, fmt))
-        book = self.get_book(bid, raise_exception=False)
-        if not book:
-            raise web.HTTPError(404, reason=_("书籍不存在"))
+        book = self.get_book_or_404(bid)
         book_id = book["id"]
         self.user_history("download_history", book)
         self.count_increase(book_id, count_download=1)
@@ -1502,7 +1500,7 @@ class BookRead(BaseHandler):
             else:
                 raise web.HTTPError(403, reason=_("无权在线阅读"))
 
-        book = self.get_book(id)
+        book = self.get_book_or_404(id)
         book_id = book["id"]
         self.user_history("read_history", book)
         self.count_increase(book_id, count_download=1)

--- a/webserver/handlers/book.py
+++ b/webserver/handlers/book.py
@@ -68,31 +68,22 @@ class Index(BaseHandler):
         random_books = []
         new_books = []
 
-        # 过滤掉其他用户标记为 scope=private 的书籍
-        user_id = self.user_id()
         if ids:
-            if user_id:
-                private_book_ids = set(
-                    item.book_id
-                    for item in self.session.query(Item).filter(Item.scope == "private", Item.collector_id != user_id).all()
-                )
-                ids = [book_id for book_id in ids if book_id not in private_book_ids]
-            else:
-                private_book_ids = set(item.book_id for item in self.session.query(Item).filter(Item.scope == "private").all())
-                ids = [book_id for book_id in ids if book_id not in private_book_ids]
+            private_book_ids = self._get_private_book_ids()
+            ids = [book_id for book_id in ids if book_id not in private_book_ids]
 
         if ids:
             # 如果配置为 0，则不显示随机推荐
             if cnt_random > 0:
                 random_ids = random.sample(ids, min(cnt_random, len(ids)))
-                random_books = [b for b in self.get_books(ids=random_ids)]
+                random_books = [b for b in self.get_books(ids=random_ids, check_permission=False)]
                 random_books.sort(key=lambda x: x["id"], reverse=True)
 
             ids.sort(reverse=True)
             # 确保不会尝试从空列表中取样
             sample_ids = ids[0:100] if len(ids) > 100 else ids
             new_ids = random.sample(sample_ids, min(cnt_recent, len(sample_ids)))
-            new_books = [b for b in self.get_books(ids=new_ids)]
+            new_books = [b for b in self.get_books(ids=new_ids, check_permission=False)]
             new_books.sort(key=lambda x: x["id"], reverse=True)
 
         return {
@@ -106,12 +97,10 @@ class Index(BaseHandler):
 class BookDetail(BaseHandler):
     @js
     def get(self, id):
-        book = self.get_book(id)
-        item = self.session.query(Item).filter(Item.book_id == int(id)).first()
-        if item and item.scope == "private":
-            user_id = self.user_id()
-            if not user_id or item.collector_id != user_id:
-                return {"err": "book.not_found", "msg": _("书籍不存在")}
+        book_id = int(id)
+        if not self.can_view_book(book_id):
+            return {"err": "book.not_found", "msg": _("书籍不存在")}
+        book = self.get_book(book_id)
         book_info = utils.BookFormatter(self, book).format(with_files=True, with_perms=True)
         reading_state = None
         user_id = self.user_id()
@@ -578,10 +567,8 @@ class BookRefer(BaseHandler):
     @auth
     async def get(self, id):
         book_id = int(id)
-        item = self.session.query(Item).filter(Item.book_id == book_id).first()
-        if item and item.scope == "private":
-            if item.collector_id != self.user_id():
-                return {"err": "book.not_found", "msg": _("书籍不存在")}
+        if not self.can_view_book(book_id):
+            return {"err": "book.not_found", "msg": _("书籍不存在")}
         mi = self.db.get_metadata(book_id, index_is_id=True)
 
         stream = self.get_argument("stream", None)
@@ -965,7 +952,9 @@ class BookDownload(BaseHandler, web.StaticFileHandler):
         bid, fmt = filename.split(".")
         fmt = fmt.lower()
         logging.error("download %s bid=%s, fmt=%s" % (filename, bid, fmt))
-        book = self.get_book(bid)
+        book = self.get_book(bid, raise_exception=False)
+        if not book:
+            raise web.HTTPError(404, reason=_("书籍不存在"))
         book_id = book["id"]
         self.user_history("download_history", book)
         self.count_increase(book_id, count_download=1)
@@ -1084,8 +1073,10 @@ class HotBook(ListHandler):
         title = _("热度榜单")
         user_id = self.user_id()
 
-        # 过滤掉其他用户标记为 scope=private 的书籍
-        if user_id:
+        # 管理员可查看全部私藏图书，普通用户只可查看自己的私藏图书。
+        if self.is_admin():
+            db_items = self.session.query(Item).filter(Item.count_visit > 1).order_by(Item.count_download.desc())
+        elif user_id:
             db_items = (
                 self.session.query(Item)
                 .filter(Item.count_visit > 1, (Item.scope != "private") | (Item.collector_id == user_id))

--- a/webserver/handlers/files.py
+++ b/webserver/handlers/files.py
@@ -167,7 +167,7 @@ class EpubReader(BaseHandler):
             else:
                 raise web.HTTPError(403, reason=_("无权在线阅读"))
 
-        book = self.get_book(bid)
+        book = self.get_book_or_404(bid)
         fpath = book.get("fmt_epub", None)
         if not fpath:
             raise web.HTTPError(404)

--- a/webserver/handlers/files.py
+++ b/webserver/handlers/files.py
@@ -46,6 +46,8 @@ class ImageHandler(BaseHandler):
             id = int(match.group())
         if not self.db.has_id(id):
             raise web.HTTPError(404, "id:%d does not exist in database" % id)
+        if not self.can_view_book(id):
+            raise web.HTTPError(404, "id:%d does not exist in database" % id)
         if fmt == "thumb" or fmt.startswith("thumb_"):
             try:
                 width, height = map(int, fmt.split("_")[1:])

--- a/webserver/utils.py
+++ b/webserver/utils.py
@@ -56,12 +56,17 @@ def get_title_sort(title):
         return title
 
 
+def _book_resource_url(book, cdn_url, api_url):
+    """私藏资源需要携带应用域名的认证 Cookie，公开资源可继续使用 CDN。"""
+    return api_url if book.get("scope") == "private" else cdn_url
+
+
 class SimpleBookFormatter:
     """格式化calibre book的字段"""
 
-    def __init__(self, calibre_book_item, cdn_url):
-        self.cdn_url = cdn_url
+    def __init__(self, calibre_book_item, cdn_url, api_url):
         self.book = calibre_book_item
+        self.resource_url = _book_resource_url(calibre_book_item, cdn_url, api_url)
 
     def get_collector(self):
         collector = self.book.get("collector", None)
@@ -98,8 +103,8 @@ class SimpleBookFormatter:
             "series": self.val("series", None),
             "language": self.val("language", None),
             "isbn": self.val("isbn", None),
-            "img": self.cdn_url + "/get/cover/%(id)s.jpg?t=%(ts)s" % b,
-            "thumb": self.cdn_url + "/get/thumb_60x80/%(id)s.jpg?t=%(ts)s" % b,
+            "img": self.resource_url + "/get/cover/%(id)s.jpg?t=%(ts)s" % b,
+            "thumb": self.resource_url + "/get/thumb_60x80/%(id)s.jpg?t=%(ts)s" % b,
             # 额外填充的字段
             "collector": self.get_collector(),
             "count_visit": self.val("count_visit", 0),
@@ -118,6 +123,7 @@ class BookFormatter:
     def get_files(self):
         files = []
         book_id = self.book["id"]
+        resource_url = _book_resource_url(self.book, self.cdn_url, self.api_url)
         for fmt in self.book.get("available_formats", []):
             try:
                 filesize = self.db.sizeof_format(book_id, fmt, index_is_id=True)
@@ -126,7 +132,7 @@ class BookFormatter:
             item = {
                 "format": fmt,
                 "size": filesize,
-                "href": self.cdn_url + "/api/book/%s.%s" % (book_id, fmt),
+                "href": resource_url + "/api/book/%s.%s" % (book_id, fmt),
             }
             files.append(item)
         return files
@@ -141,7 +147,7 @@ class BookFormatter:
         }
 
     def format(self, with_files=False, with_perms=False):
-        f = SimpleBookFormatter(self.book, self.cdn_url)
+        f = SimpleBookFormatter(self.book, self.cdn_url, self.api_url)
         data = f.format()
         data.update(
             {

--- a/webserver/webdav/dav_provider.py
+++ b/webserver/webdav/dav_provider.py
@@ -543,14 +543,17 @@ class MyBooksDavProvider(DAVProvider):
             return None
 
     def _get_other_private_book_ids(self, user_id):
-        """Return set of book_ids that are private and owned by other users."""
+        """Return private book ids invisible to the current WebDAV user."""
         if not self.get_session_func:
             return set()
-        from webserver.models import Item
+        from webserver.models import Item, Reader
 
         session = self.get_session_func()
         try:
             if user_id:
+                user = session.get(Reader, user_id)
+                if user and user.is_admin():
+                    return set()
                 items = session.query(Item).filter(Item.scope == "private", Item.collector_id != user_id).all()
             else:
                 items = session.query(Item).filter(Item.scope == "private").all()


### PR DESCRIPTION
## Summary
- allow administrators to access private books across search, lists, details, reading, downloads, OPDS, and WebDAV
- enforce the same private-book policy on direct download, reading, and cover URLs
- add regression coverage and an ACTIVE design document

## Testing
- Docker full backend suite: 582 passed, 1 skipped
- make lint-py
- make check-design

Closes #867