### PR TITLE
fix(codex): allow conversational issue replies

### DIFF
--- a/.github/codex/prompts/comment-response.md
+++ b/.github/codex/prompts/comment-response.md
@@ -8,21 +8,34 @@
 
 根据下方 GitHub 上下文完成维护者请求：
 
-- 当前 checkout 是 workflow 选定的精确目标提交。对于 Pull Request，它是当前 PR head；对于 Issue，它是现有 Codex Issue 分支，或者首次处理时的仓库默认分支。
+- 当前 checkout 是 workflow 选定的精确目标提交。对于 Pull Request，它是当前 PR head；对于 Issue，它是唯一的活动 Codex Issue 分支，或者仓库默认分支。GitHub 上下文中的 `target.publishBlockReason` 只限制代码发布，不限制纯问答。
 - 实现和验证任务时可以访问公共网络与 localhost。不得尝试发现凭据、访问私有网络，或者使用 Docker 等 Unix socket。
 - 不得修改 `.github/workflows/` 下的任何内容。发布身份被有意限制为不能更新 workflow 文件。
 - 不得自行 commit 或 push。不得使用 `gh` 或 GitHub API 修改仓库状态。验证通过后，由受控 workflow 步骤统一完成一次 commit、push 和 Draft PR 创建。
-- 必须完成请求的实现及其必要测试。重要改动必须遵循仓库的方案文档生命周期；只要仍存在 `.wip.html`，就不得把工作标记为可发布。
+- 必须先实际检查请求和相关上下文，再决定交付类型；不得根据关键词预先判断用户是在纯问答还是要求修改代码。
+- 纯问答、解释或状态查询不需要制造仓库改动，也不需要创建无关的方案和测试。需要修改代码时，必须完成实现及其必要测试。重要改动必须遵循仓库的方案文档生命周期；只要仍存在 `.wip.html`，就不得把工作标记为代码发布。
 - 开始实现前必须先使用计划工具创建中文执行计划；每完成或调整一个步骤时及时更新计划状态，让 workflow 能把真实进展同步到 GitHub 评论。
 - 不得打印 Secret、Token 内容或认证文件。
 - 执行计划、进度说明、结构化摘要和最终答复必须使用中文。命令、路径、代码标识符、JSON 字段名、`feature` 与 Conventional Commit 消息保持其规定格式，不要为了中文化而翻译这些机器接口。
-- 最终答复保持简洁，并列出本次实际执行的命令及其结果。
+- 最终答复保持简洁。代码交付应列出本次实际执行的命令及其结果；纯问答应直接回答维护者的问题。
 
 在最终答复之前，在仓库根目录写入 `.codex-result.json`，且必须严格符合以下契约：
 
 ```json
 {
-  "ready_to_publish": true,
+  "delivery": "reply",
+  "feature": "",
+  "commit_message": "",
+  "summary": "用于 GitHub 评论的简短中文答复。",
+  "tests": []
+}
+```
+
+需要发布仓库改动时使用：
+
+```json
+{
+  "delivery": "publish",
   "feature": "short-english-kebab-case",
   "commit_message": "fix(scope): concise subject",
   "summary": "用于 GitHub 评论的简短中文摘要。",
@@ -38,9 +51,10 @@
 
 契约规则：
 
-- 仅当请求工作已经完成、相关检查通过或有符合仓库规范的未执行原因、`git diff --check` 通过，并且没有残留 WIP 方案文档时，`ready_to_publish` 才能设为 `true`；否则必须设为 `false`。
-- `feature` 必须是 3–48 个小写 ASCII 字符组成的 kebab-case。首次处理 Issue 时，选择一个稳定的英文功能名，以用于 `codex/issue-<id>-<feature>`。
-- `commit_message` 必须是单行 Conventional Commit 消息，长度不得超过 120 个字符。
+- `delivery` 只能是 `reply` 或 `publish`。请求已经完成且不需要仓库改动时使用 `reply`；需要发布真实仓库改动时使用 `publish`。
+- 使用 `reply` 时，`feature` 和 `commit_message` 必须为空字符串，`tests` 可以为空，并且工作树不能包含任何改动。`summary` 应直接回答维护者，不要附加伪造的测试或发布说明。
+- 使用 `publish` 时，必须存在真实仓库改动；`feature` 必须是 3–48 个小写 ASCII 字符组成的 kebab-case。首次处理 Issue 时，选择一个稳定的英文功能名，以用于 `codex/issue-<id>-<feature>`。
+- 使用 `publish` 时，`commit_message` 必须是单行 Conventional Commit 消息，长度不得超过 120 个字符。
 - `summary` 必须是 1–1000 个字符的中文纯文本。
-- `tests` 至少包含一条本次实际验证记录。`result` 只能是 `passed`、`failed` 或 `not_run`；使用 `not_run` 时必须在 `details` 中写明中文原因。只要相关测试为 `failed`，就不得把 `ready_to_publish` 设为 `true`。
+- `tests` 中每条记录的 `result` 只能是 `passed`、`failed` 或 `not_run`；使用 `not_run` 时必须在 `details` 中写明中文原因。使用 `publish` 时至少包含一条本次实际验证记录，且不能存在 `failed` 结果。
 - 结果文件是 workflow 元数据，不是仓库交付内容，不得将其加入 Git。

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -102,6 +102,10 @@ jobs:
             let targetSha = "";
             let existingIssueBranch = "";
             let existingIssuePrNumber = "";
+            let publishBlockReason = "";
+            let activeIssueBranches = [];
+            let issueBranches = [];
+            const historicalIssueBranches = [];
             const defaultBranch = payload.repository.default_branch;
 
             if (eventName === "issue_comment") {
@@ -214,29 +218,39 @@ jobs:
                 ref: refPrefix,
                 per_page: 100,
               });
+              issueBranches = refs.map((ref) => ref.ref.replace(/^refs\/heads\//, ""));
 
-              if (refs.length > 1) {
-                blockReason = `Issue #${issueNumber} 已存在多个 Codex 分支，请先处理冲突分支再重试。`;
-              } else if (refs.length === 1) {
-                existingIssueBranch = refs[0].ref.replace(/^refs\/heads\//, "");
+              const activeIssueTargets = [];
+              for (const ref of refs) {
+                const branchName = ref.ref.replace(/^refs\/heads\//, "");
                 const pulls = await github.paginate(github.rest.pulls.list, {
                   owner,
                   repo,
                   state: "all",
-                  head: `${owner}:${existingIssueBranch}`,
+                  head: `${owner}:${branchName}`,
                   per_page: 100,
                 });
-                const closedPull = pulls.find((pull) => pull.state !== "open");
                 const openPull = pulls.find((pull) => pull.state === "open");
 
-                if (closedPull) {
-                  blockReason = `分支 ${existingIssueBranch} 属于已关闭或已合并的 Pull Request，请删除或重命名后重试。`;
+                if (!openPull && pulls.length > 0) {
+                  historicalIssueBranches.push(branchName);
                 } else {
-                  supportedTarget = true;
-                  targetRef = existingIssueBranch;
-                  targetSha = refs[0].object.sha;
-                  existingIssuePrNumber = openPull ? String(openPull.number) : "";
+                  activeIssueTargets.push({
+                    branchName,
+                    sha: ref.object.sha,
+                    openPullNumber: openPull ? String(openPull.number) : "",
+                  });
                 }
+              }
+
+              activeIssueBranches = activeIssueTargets.map((target) => target.branchName);
+              if (activeIssueTargets.length === 1) {
+                const activeTarget = activeIssueTargets[0];
+                supportedTarget = true;
+                targetRef = activeTarget.branchName;
+                targetSha = activeTarget.sha;
+                existingIssueBranch = activeTarget.branchName;
+                existingIssuePrNumber = activeTarget.openPullNumber;
               } else {
                 const branch = await github.rest.repos.getBranch({
                   owner,
@@ -246,6 +260,9 @@ jobs:
                 supportedTarget = true;
                 targetRef = defaultBranch;
                 targetSha = branch.data.commit.sha;
+                if (activeIssueTargets.length > 1) {
+                  publishBlockReason = `Issue #${issueNumber} 已存在多个活动 Codex 分支：${activeIssueBranches.join(", ")}。纯问答可以继续，但发布改动前必须先处理冲突分支。`;
+                }
               }
             }
 
@@ -266,6 +283,10 @@ jobs:
                 sha: targetSha,
                 existingIssueBranch,
                 existingIssuePrNumber,
+                publishBlockReason,
+                activeIssueBranches,
+                historicalIssueBranches,
+                issueBranches,
               },
               pullRequest: pr ? {
                 number: pr.number,
@@ -373,6 +394,8 @@ jobs:
             core.setOutput("target_sha", targetSha);
             core.setOutput("existing_issue_branch", existingIssueBranch);
             core.setOutput("existing_issue_pr_number", existingIssuePrNumber);
+            core.setOutput("publish_block_reason", publishBlockReason);
+            core.setOutput("issue_branches_json", JSON.stringify(issueBranches));
             core.setOutput("default_branch", defaultBranch);
             core.setOutput("issue_title", issueTitle);
             core.setOutput("progress_comment_id", progressCommentId);
@@ -579,6 +602,9 @@ jobs:
           IS_PR: ${{ steps.context.outputs.is_pr }}
           ISSUE_NUMBER: ${{ steps.context.outputs.issue_number }}
           EXISTING_ISSUE_BRANCH: ${{ steps.context.outputs.existing_issue_branch }}
+          PUBLISH_BLOCK_REASON: ${{ steps.context.outputs.publish_block_reason }}
+          ISSUE_BRANCHES_JSON: ${{ steps.context.outputs.issue_branches_json }}
+          RUN_ID: ${{ github.run_id }}
           RESULT_FILE: .codex-result.json
         run: |
           set -uo pipefail
@@ -587,6 +613,7 @@ jobs:
           contract_valid=false
           no_changes=false
           reason=""
+          delivery=""
           feature=""
           commit_message=""
           publish_branch=""
@@ -603,28 +630,40 @@ jobs:
             reject "Codex 未生成 .codex-result.json。"
           elif ! jq -e '
             type == "object" and
-            (keys | sort) == ["commit_message", "feature", "ready_to_publish", "summary", "tests"] and
-            (.ready_to_publish | type == "boolean") and
+            (keys | sort) == ["commit_message", "delivery", "feature", "summary", "tests"] and
+            (.delivery == "reply" or .delivery == "publish") and
             (.feature | type == "string") and
-            (.feature | length >= 3 and length <= 48 and test("^[a-z0-9]+(-[a-z0-9]+)*$")) and
             (.commit_message | type == "string") and
-            (.commit_message | length >= 1 and length <= 120 and (test("[\\r\\n]") | not)) and
-            (.commit_message | test("^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\\([a-z0-9._/-]+\\))?!?: .+")) and
             (.summary | type == "string") and
             (.summary | length >= 1 and length <= 1000) and
             (.tests | type == "array") and
-            (.tests | length >= 1) and
             ([.tests[] |
+              type == "object" and
               (.command | type == "string") and
               (.command | length >= 1) and
               (.result == "passed" or .result == "failed" or .result == "not_run") and
               (if .result == "not_run" then (.details | type == "string" and length >= 1) else true end)
             ] | all) and
-            (if .ready_to_publish then ([.tests[] | select(.result == "failed")] | length == 0) else true end)
+            (if .delivery == "reply" then
+              .feature == "" and
+              .commit_message == ""
+            else
+              (.feature | length >= 3 and length <= 48 and test("^[a-z0-9]+(-[a-z0-9]+)*$")) and
+              (.commit_message | length >= 1 and length <= 120 and (test("[\\r\\n]") | not)) and
+              (.commit_message | test("^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\\([a-z0-9._/-]+\\))?!?: .+")) and
+              (.tests | length >= 1)
+            end)
           ' "$RESULT_FILE" >/dev/null; then
             reject "Codex 结果不符合发布契约或 Conventional Commit 规则。"
-          elif ! jq -e '.ready_to_publish == true' "$RESULT_FILE" >/dev/null; then
-            reject "Codex 将任务标记为尚不可发布。"
+          else
+            contract_valid=true
+            delivery="$(jq -r '.delivery' "$RESULT_FILE")"
+            feature="$(jq -r '.feature' "$RESULT_FILE")"
+            commit_message="$(jq -r '.commit_message' "$RESULT_FILE")"
+          fi
+
+          if [ -z "$reason" ] && [ "$delivery" = "publish" ] && jq -e '.tests | any(.result == "failed")' "$RESULT_FILE" >/dev/null; then
+            reject "Codex 报告存在失败的测试。"
           fi
 
           current_sha="$(git rev-parse HEAD 2>/dev/null || true)"
@@ -636,26 +675,36 @@ jobs:
             reject "Git 无法暂存候选改动。"
           fi
 
-          if [ -z "$reason" ]; then
-            contract_valid=true
-            feature="$(jq -r '.feature' "$RESULT_FILE")"
-            commit_message="$(jq -r '.commit_message' "$RESULT_FILE")"
+          if [ -z "$reason" ] && [ "$delivery" = "publish" ]; then
             if [ "$IS_PR" = "true" ]; then
               publish_branch="$TARGET_REF"
             elif [ -n "$EXISTING_ISSUE_BRANCH" ]; then
               publish_branch="$EXISTING_ISSUE_BRANCH"
             else
               publish_branch="codex/issue-${ISSUE_NUMBER}-${feature}"
+              if jq -e --arg branch "$publish_branch" 'index($branch) != null' <<< "$ISSUE_BRANCHES_JSON" >/dev/null; then
+                publish_branch="${publish_branch}-${RUN_ID}"
+              fi
             fi
           fi
 
-          if [ -z "$reason" ] && find design -type f -name '*.wip.html' -print -quit | grep -q .; then
+          if [ -z "$reason" ] && [ "$delivery" = "publish" ] && find design -type f -name '*.wip.html' -print -quit | grep -q .; then
             reject "仓库中仍存在 WIP 方案文档。"
           fi
 
           if [ -z "$reason" ] && git diff --cached --quiet; then
             no_changes=true
-            reject "未产生仓库改动。"
+            if [ "$delivery" = "publish" ]; then
+              reject "未产生仓库改动。"
+            fi
+          fi
+
+          if [ -z "$reason" ] && [ "$delivery" = "reply" ] && [ "$no_changes" != "true" ]; then
+            reject "回复模式不得产生仓库改动。"
+          fi
+
+          if [ -z "$reason" ] && [ "$delivery" = "publish" ] && [ -n "$PUBLISH_BLOCK_REASON" ]; then
+            reject "$PUBLISH_BLOCK_REASON"
           fi
 
           if [ -z "$reason" ]; then
@@ -671,7 +720,7 @@ jobs:
             reject "git diff --cached --check 未通过。"
           fi
 
-          if [ -z "$reason" ]; then
+          if [ -z "$reason" ] && [ "$delivery" = "publish" ]; then
             ready=true
           fi
 
@@ -687,6 +736,7 @@ jobs:
           fi
           echo "no_changes=$no_changes" >> "$GITHUB_OUTPUT"
           echo "reason=$reason" >> "$GITHUB_OUTPUT"
+          echo "delivery=$delivery" >> "$GITHUB_OUTPUT"
           echo "feature=$feature" >> "$GITHUB_OUTPUT"
           echo "commit_message=$commit_message" >> "$GITHUB_OUTPUT"
           echo "publish_branch=$publish_branch" >> "$GITHUB_OUTPUT"
@@ -694,13 +744,18 @@ jobs:
       - id: app_token
         name: Create short-lived publisher token
         if: |
-          steps.publish_gate.outputs.ready == 'true' ||
           (
-            steps.publish_gate.outputs.contract_valid == 'true' &&
-            steps.publish_gate.outputs.no_changes == 'true' &&
-            steps.context.outputs.is_pr != 'true' &&
-            steps.context.outputs.existing_issue_branch != '' &&
-            steps.context.outputs.existing_issue_pr_number == ''
+            steps.publish_gate.outputs.delivery == 'publish' &&
+            (
+              steps.publish_gate.outputs.ready == 'true' ||
+              (
+                steps.publish_gate.outputs.contract_valid == 'true' &&
+                steps.publish_gate.outputs.no_changes == 'true' &&
+                steps.context.outputs.is_pr != 'true' &&
+                steps.context.outputs.existing_issue_branch != '' &&
+                steps.context.outputs.existing_issue_pr_number == ''
+              )
+            )
           )
         # v3 recommends client-id; actionlint 1.7.12 still carries older app-id metadata.
         uses: actions/create-github-app-token@v3
@@ -763,6 +818,7 @@ jobs:
       - id: create_issue_pr
         name: Create Draft PR for issue work
         if: |
+          steps.publish_gate.outputs.delivery == 'publish' &&
           steps.app_token.outcome == 'success' &&
           steps.context.outputs.is_pr != 'true' &&
           steps.context.outputs.existing_issue_pr_number == '' &&
@@ -835,6 +891,7 @@ jobs:
           CODEX_RESULT_FILE: .codex-result.json
           CODEX_RUN_OUTCOME: ${{ steps.run_codex.outcome }}
           CODEX_CONTRACT_VALID: ${{ steps.publish_gate.outputs.contract_valid }}
+          CODEX_DELIVERY: ${{ steps.publish_gate.outputs.delivery }}
           CODEX_GATE_READY: ${{ steps.publish_gate.outputs.ready }}
           CODEX_GATE_REASON: ${{ steps.publish_gate.outputs.reason }}
           CODEX_NO_CHANGES: ${{ steps.publish_gate.outputs.no_changes }}
@@ -880,14 +937,17 @@ jobs:
 
             let body = "";
             if (validatedResult) {
-              const testLines = validatedResult.tests.map((test) => {
-                let line = `- <code>${escapeHtml(test.command)}</code> — <strong>${escapeHtml(test.result)}</strong>`;
-                if (typeof test.details === "string" && test.details.trim()) {
-                  line += ` — ${escapeHtml(test.details.trim())}`;
-                }
-                return line;
-              });
-              body = `${escapeHtml(validatedResult.summary)}\n\n### 验证\n\n${testLines.join("\n")}`;
+              body = escapeHtml(validatedResult.summary);
+              if (validatedResult.tests.length > 0) {
+                const testLines = validatedResult.tests.map((test) => {
+                  let line = `- <code>${escapeHtml(test.command)}</code> — <strong>${escapeHtml(test.result)}</strong>`;
+                  if (typeof test.details === "string" && test.details.trim()) {
+                    line += ` — ${escapeHtml(test.details.trim())}`;
+                  }
+                  return line;
+                });
+                body += `\n\n### 验证\n\n${testLines.join("\n")}`;
+              }
             } else {
               body = finalMessage;
               if (!body) {
@@ -899,7 +959,9 @@ jobs:
               }
             }
 
-            if (process.env.CODEX_PUBLISH_OUTCOME === "success") {
+            if (process.env.CODEX_DELIVERY === "reply" && process.env.CODEX_CONTRACT_VALID === "true" && process.env.CODEX_NO_CHANGES === "true") {
+              // 纯问答直接使用 summary，不追加发布状态。
+            } else if (process.env.CODEX_PUBLISH_OUTCOME === "success") {
               const shortSha = process.env.CODEX_COMMIT_SHA.slice(0, 7);
               const commitUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/commit/${process.env.CODEX_COMMIT_SHA}`;
               body += `\n\n---\n已发布提交 [\`${shortSha}\`](${commitUrl}) 到 \`${process.env.CODEX_PUBLISH_BRANCH}\`。`;
@@ -914,7 +976,7 @@ jobs:
                   body += " 分支已推送，但 Draft PR 创建失败；请查看 workflow 日志。";
                 }
               }
-            } else if (process.env.CODEX_NO_CHANGES === "true") {
+            } else if (process.env.CODEX_DELIVERY === "publish" && process.env.CODEX_NO_CHANGES === "true") {
               if (process.env.IS_PR !== "true" && process.env.EXISTING_ISSUE_BRANCH && !process.env.EXISTING_PR_NUMBER) {
                 if (process.env.CREATED_PR_URL) {
                   body += `\n\n---\n无需提交仓库改动；已补建缺失的 Draft PR：${process.env.CREATED_PR_URL}`;
@@ -922,7 +984,7 @@ jobs:
                   body += "\n\n---\n未发布：无法为现有 Issue 分支创建 Draft PR；请查看 workflow 日志。";
                 }
               } else {
-                body += "\n\n---\n无需提交仓库改动。";
+                body += `\n\n---\n未发布：${process.env.CODEX_GATE_REASON || "未产生仓库改动。"}`;
               }
             } else {
               let reason = process.env.CODEX_GATE_REASON;
@@ -972,6 +1034,8 @@ jobs:
         if: always() && steps.context.outputs.authorized == 'true' && steps.context.outputs.supported_target == 'true'
         env:
           CODEX_OUTCOME: ${{ steps.run_codex.outcome }}
+          DELIVERY: ${{ steps.publish_gate.outputs.delivery }}
+          CONTRACT_VALID: ${{ steps.publish_gate.outputs.contract_valid }}
           GATE_READY: ${{ steps.publish_gate.outputs.ready }}
           GATE_NO_CHANGES: ${{ steps.publish_gate.outputs.no_changes }}
           APP_TOKEN_OUTCOME: ${{ steps.app_token.outcome }}
@@ -985,13 +1049,19 @@ jobs:
           if [ "$CODEX_OUTCOME" != "success" ]; then
             exit 1
           fi
-          if [ "$GATE_NO_CHANGES" = "true" ]; then
-            if [ "$IS_PR" != "true" ] && [ -n "$EXISTING_ISSUE_BRANCH" ] && [ -z "$EXISTING_PR_NUMBER" ]; then
-              if [ "$APP_TOKEN_OUTCOME" != "success" ] || [ "$CREATED_PR_OUTCOME" != "success" ]; then
-                exit 1
-              fi
+          if [ "$DELIVERY" = "reply" ]; then
+            if [ "$CONTRACT_VALID" != "true" ] || [ "$GATE_NO_CHANGES" != "true" ]; then
+              exit 1
             fi
             exit 0
+          fi
+          if [ "$DELIVERY" = "publish" ] && [ "$GATE_NO_CHANGES" = "true" ]; then
+            if [ "$IS_PR" != "true" ] && [ -n "$EXISTING_ISSUE_BRANCH" ] && [ -z "$EXISTING_PR_NUMBER" ]; then
+              if [ "$CREATED_PR_OUTCOME" = "success" ]; then
+                exit 0
+              fi
+            fi
+            exit 1
           fi
           if [ "$GATE_READY" != "true" ]; then
             exit 1

--- a/design/project/20260718-codex-conversational-requests.active.html
+++ b/design/project/20260718-codex-conversational-requests.active.html
@@ -1,0 +1,288 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Codex 纯问答与代码发布解耦方案</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --ink: #172033;
+      --muted: #5f6b7a;
+      --paper: #f4f7fb;
+      --card: #ffffff;
+      --line: #d9e1ec;
+      --brand: #2457d6;
+      --brand-soft: #e9efff;
+      --warn: #a65300;
+      --warn-soft: #fff2dc;
+      --good: #167052;
+      --good-soft: #e4f6ef;
+      --bad: #a12a38;
+      --bad-soft: #fdecef;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: var(--paper);
+      color: var(--ink);
+      font: 15px/1.65 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    main { width: min(1080px, calc(100% - 32px)); margin: 32px auto 64px; }
+    header, section {
+      background: var(--card);
+      border: 1px solid var(--line);
+      border-radius: 14px;
+      box-shadow: 0 8px 28px rgba(23, 32, 51, .06);
+    }
+    header { padding: 30px; border-top: 5px solid var(--brand); }
+    section { margin-top: 18px; padding: 24px 28px; }
+    h1 { margin: 0 0 8px; font-size: 30px; line-height: 1.25; }
+    h2 { margin: 0 0 14px; font-size: 21px; }
+    h3 { margin: 20px 0 8px; font-size: 16px; }
+    p { margin: 8px 0; }
+    ul, ol { margin: 8px 0; padding-left: 22px; }
+    li + li { margin-top: 5px; }
+    code {
+      padding: 2px 6px;
+      border-radius: 5px;
+      background: #eef2f7;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 13px;
+    }
+    .meta { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 16px; }
+    .pill {
+      padding: 5px 10px;
+      border-radius: 999px;
+      background: var(--brand-soft);
+      color: var(--brand);
+      font-size: 13px;
+      font-weight: 650;
+    }
+    .pill.wip { background: var(--warn-soft); color: var(--warn); }
+    .callout {
+      margin: 14px 0;
+      padding: 13px 15px;
+      border-left: 4px solid var(--brand);
+      border-radius: 8px;
+      background: var(--brand-soft);
+    }
+    .callout.bad { border-color: var(--bad); background: var(--bad-soft); }
+    .callout.good { border-color: var(--good); background: var(--good-soft); }
+    table { width: 100%; border-collapse: collapse; margin: 12px 0; }
+    th, td { padding: 10px 12px; border: 1px solid var(--line); text-align: left; vertical-align: top; }
+    th { background: #eef3fa; }
+    .flow { overflow-x: auto; margin-top: 16px; }
+    .flow svg { width: 100%; min-width: 900px; height: auto; display: block; }
+    .small { color: var(--muted); font-size: 13px; }
+    .status-pending { color: var(--warn); font-weight: 700; }
+    @media (max-width: 640px) {
+      main { width: min(100% - 20px, 1080px); margin-top: 10px; }
+      header, section { padding: 20px; border-radius: 10px; }
+      h1 { font-size: 25px; }
+    }
+  </style>
+</head>
+<body>
+<main>
+  <header>
+    <h1>Codex 纯问答与代码发布解耦方案</h1>
+    <p>让已授权的 Issue 评论始终进入 Codex；只有在确实产生仓库改动时，才用分支状态决定能否发布。</p>
+    <div class="meta">
+      <span class="pill">状态：ACTIVE</span>
+      <span class="pill">创建日期：2026-07-18</span>
+      <span class="pill">所属模块：project</span>
+      <span class="pill">影响范围：GitHub Actions / Codex 提示词 / 工作流测试</span>
+    </div>
+    <p class="small">需求来源：GitHub Issue #875 第二次提及 Codex 的失败回复；前置方案为 <code>design/project/20260718-codex-app-comment-identity.active.html</code> 。</p>
+  </header>
+
+  <section>
+    <h2>原始诉求</h2>
+    <p>Issue #875 中第二次评论仅询问“你的模型详细版本”，没有要求提交代码。工作流却在 Codex 执行前发现历史分支关联已关闭或已合并的 Pull Request，于是直接回复分支冲突。期望行为是：纯问答正常由 Codex App 身份回复；只有需要提交代码时才处理分支冲突或发布限制。</p>
+    <div class="callout bad">
+      <strong>已复现：</strong>评论没有进入 Codex，<code>Resolve request context</code> 先把历史分支判为不支持目标，随后 <code>Explain unsupported target</code> 发布固定错误文本。
+    </div>
+  </section>
+
+  <section>
+    <h2>根因与设计约束</h2>
+    <ol>
+      <li><code>supportedTarget</code> 同时表达“能否执行请求”和“能否把代码发布到某条分支”，两个不同阶段被错误地合并。</li>
+      <li>Issue 的旧 Codex 分支只要关联过已关闭或已合并 PR，就会被当作当前请求的硬错误；实际上它应当是历史记录。</li>
+      <li>现有结果协议只描述可发布代码，纯问答只能伪造 feature、提交信息和测试记录，最终回复也会带上不自然的发布提示。</li>
+      <li>不能依赖“修复、提交、为什么”等关键词判断用户意图；同一句自然语言可能既需要解释，也可能在执行后才发现需要改代码。</li>
+    </ol>
+    <div class="callout good">
+      <strong>已确认的原则：</strong>所有通过权限校验的提及都执行 Codex；执行后根据真实 diff 和 Codex 的交付类型决定是否进入发布门禁。
+    </div>
+  </section>
+
+  <section>
+    <h2>目标与非目标</h2>
+    <table>
+      <thead><tr><th>类型</th><th>内容</th></tr></thead>
+      <tbody>
+        <tr><td>目标</td><td>纯问答在存在历史分支或多个活动分支时仍能正常执行和回复。</td></tr>
+        <tr><td>目标</td><td>已关闭或已合并 PR 对应的 Issue 分支视为历史分支，不参与当前目标选择。</td></tr>
+        <tr><td>目标</td><td>只有实际产生代码改动时才应用发布阻断，并确保阻断前不会创建 PR 或写分支。</td></tr>
+        <tr><td>目标</td><td>结果协议明确区分 <code>reply</code> 与 <code>publish</code>，纯问答回复不显示伪造的测试或提交元数据。</td></tr>
+        <tr><td>非目标</td><td>不通过关键词或模型调用前的分类器猜测评论意图。</td></tr>
+        <tr><td>非目标</td><td>不改变 PR 评论对 fork、关闭 PR、缺失 head repository 的现有安全限制。</td></tr>
+        <tr><td>非目标</td><td>不删除历史远端分支，也不自动重开或覆盖已关闭 PR。</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section>
+    <h2>方案</h2>
+    <h3>1. 将执行目标和发布限制拆开</h3>
+    <p>Issue 评论的上下文解析始终给出可 checkout 的安全目标，并新增 <code>publishBlockReason</code>。它只是一条延迟到 diff 产生后的发布限制，不再让 <code>supportedTarget</code> 变为 false。</p>
+    <table>
+      <thead><tr><th>Issue 分支状态</th><th>checkout 目标</th><th>发布限制</th></tr></thead>
+      <tbody>
+        <tr><td>没有活动分支</td><td>默认分支</td><td>无</td></tr>
+        <tr><td>恰好一个活动分支</td><td>该分支</td><td>无；沿用现有 PR 或恢复缺失 PR</td></tr>
+        <tr><td>多个活动分支</td><td>默认分支</td><td>若产生改动则拒绝发布，并列出分支；无改动则正常回复</td></tr>
+        <tr><td>仅有已关闭或已合并 PR 对应分支</td><td>默认分支</td><td>无；这些分支记为历史，不参与选择。若新任务生成同名发布分支，则追加本次 GitHub run ID，避免覆盖历史分支。</td></tr>
+      </tbody>
+    </table>
+    <p>“活动分支”包括关联 open PR 的分支，以及从未关联 PR 的孤立分支。若同一分支同时存在历史 PR 和 open PR，以 open PR 为准。</p>
+    <p>上下文同时把现有 Issue 分支名作为 JSON 数组传给发布门禁。首次发布根据 feature 生成基础分支名；若该名称已被历史分支占用，门禁生成 <code>基础分支名-run-id</code>。重跑时该分支会成为唯一活动分支并被继续使用，因此不会覆盖历史提交，也不会为同一执行反复派生名称。</p>
+
+    <h3>2. 增加显式交付类型</h3>
+    <p><code>.codex-result.json</code> 用枚举 <code>delivery</code> 替代含义模糊的 <code>ready_to_publish</code>：</p>
+    <table>
+      <thead><tr><th>delivery</th><th>约束</th><th>最终行为</th></tr></thead>
+      <tbody>
+        <tr><td><code>reply</code></td><td>任务已完成但不需要仓库改动；feature 和 commit_message 为空，tests 可以为空，暂存 diff 必须为空。</td><td>只发布 summary；存在真实验证记录时才附加验证段落。</td></tr>
+        <tr><td><code>publish</code></td><td>任务需要发布仓库改动；feature、Conventional Commit 和至少一条测试记录继续采用现有校验。</td><td>通过 diff、设计、测试、分支和 PR 门禁后提交并发布。</td></tr>
+      </tbody>
+    </table>
+    <p>若 Codex 计划发布但无法完成，仍输出 <code>publish</code>，通过失败测试或缺失改动由现有 fail-closed 门禁拒绝；不允许用 <code>reply</code> 掩盖已产生的改动。</p>
+
+    <h3>3. 发布门禁后移到真实 diff 之后</h3>
+    <div class="flow" aria-label="请求执行与发布流程图">
+      <svg viewBox="0 0 1020 320" role="img" aria-labelledby="flow-title flow-desc">
+        <title id="flow-title">Codex 请求执行与发布解耦流程</title>
+        <desc id="flow-desc">授权评论先解析安全 checkout 目标并运行 Codex，之后根据交付类型和真实 diff 分流；纯问答直接回复，代码改动才检查发布限制并创建或更新 PR。</desc>
+        <defs>
+          <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto">
+            <path d="M0,0 L0,6 L9,3 z" fill="#718096"/>
+          </marker>
+        </defs>
+        <g font-family="-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="14" text-anchor="middle">
+          <rect x="24" y="118" width="142" height="70" rx="12" fill="#e9efff" stroke="#2457d6"/>
+          <text x="95" y="147" fill="#172033"><tspan x="95">授权评论</tspan><tspan x="95" dy="20">解析安全目标</tspan></text>
+          <rect x="222" y="118" width="142" height="70" rx="12" fill="#e9efff" stroke="#2457d6"/>
+          <text x="293" y="147" fill="#172033"><tspan x="293">运行 Codex</tspan><tspan x="293" dy="20">产出结果协议</tspan></text>
+          <polygon points="466,105 548,153 466,201 384,153" fill="#fff2dc" stroke="#a65300"/>
+          <text x="466" y="149" fill="#172033"><tspan x="466">delivery</tspan><tspan x="466" dy="19">与真实 diff</tspan></text>
+          <rect x="610" y="34" width="166" height="70" rx="12" fill="#e4f6ef" stroke="#167052"/>
+          <text x="693" y="63" fill="#172033"><tspan x="693">reply 且无改动</tspan><tspan x="693" dy="20">发布正常评论</tspan></text>
+          <rect x="610" y="202" width="166" height="70" rx="12" fill="#fff2dc" stroke="#a65300"/>
+          <text x="693" y="231" fill="#172033"><tspan x="693">publish 且有改动</tspan><tspan x="693" dy="20">检查发布限制</tspan></text>
+          <rect x="832" y="202" width="166" height="70" rx="12" fill="#e4f6ef" stroke="#167052"/>
+          <text x="915" y="231" fill="#172033"><tspan x="915">提交并创建</tspan><tspan x="915" dy="20">或更新 PR</tspan></text>
+          <rect x="832" y="34" width="166" height="70" rx="12" fill="#fdecef" stroke="#a12a38"/>
+          <text x="915" y="63" fill="#172033"><tspan x="915">协议与 diff 冲突</tspan><tspan x="915" dy="20">拒绝并说明原因</tspan></text>
+        </g>
+        <g fill="none" stroke="#718096" stroke-width="2" marker-end="url(#arrow)">
+          <path d="M166 153 H214"/>
+          <path d="M364 153 H377"/>
+          <path d="M506 129 C548 90 565 69 602 69"/>
+          <path d="M506 177 C548 216 565 237 602 237"/>
+          <path d="M776 237 H824"/>
+          <path d="M776 69 H824"/>
+        </g>
+        <g font-family="-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="12" fill="#5f6b7a">
+          <text x="544" y="88">正常回复</text>
+          <text x="542" y="221">代码交付</text>
+          <text x="792" y="226">允许</text>
+          <text x="793" y="58">不一致</text>
+        </g>
+      </svg>
+    </div>
+    <ul>
+      <li><code>reply</code> 且无 diff：忽略 <code>publishBlockReason</code>，正常回复并成功结束。</li>
+      <li><code>reply</code> 但有 diff：拒绝，防止代码改动绕过发布门禁。</li>
+      <li><code>publish</code> 且有 diff：先应用 <code>publishBlockReason</code>，再执行现有设计、测试、分支和 PR 门禁。</li>
+      <li><code>publish</code> 但无 diff：沿用“未产生仓库改动”的失败说明，不伪装成纯问答。</li>
+    </ul>
+
+    <h3>4. 限制所有写操作</h3>
+    <p>GitHub App token 获取、缺失 PR 恢复、新建 Issue PR、提交和 push 的条件全部增加 <code>delivery == publish</code>。因此纯问答只有评论写入，不会意外恢复旧 PR、创建新分支或推送提交。</p>
+
+    <h3>5. 提示词与最终回复</h3>
+    <ul>
+      <li>提示词明确允许信息查询、解释和状态回答，不要求为纯问答创建不相关的设计、测试或仓库改动。</li>
+      <li>提示词仍要求先实际检查仓库和上下文，再选择 <code>reply</code> 或 <code>publish</code>，而不是根据关键词预分类。</li>
+      <li>纯问答最终评论仅使用经过协议校验的 summary；tests 非空时才显示“验证”，不追加“未发布”“无需提交仓库改动”等机械文本。</li>
+      <li>代码交付继续保留现有 PR 链接、验证摘要和失败原因。</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>兼容性与安全性</h2>
+    <ul>
+      <li>身份不变：进度、最终回复和 PR 仍由专用 GitHub App token 发布，继承前置方案。</li>
+      <li>权限不变：未授权用户仍在 Codex 执行前退出。</li>
+      <li>PR 评论不放宽：关闭 PR、fork PR 和缺失 head repository 仍是执行前硬阻断，因为这些目标无法安全 checkout。</li>
+      <li>Issue 评论更安全：多个活动分支时只 checkout 默认分支，避免在不明确分支上修改；若无改动则可以回答，有改动则拒绝发布。</li>
+      <li>结果协议为仓库内部工作流接口，无外部 API、数据库或产品数据迁移。</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>实施范围</h2>
+    <table>
+      <thead><tr><th>文件</th><th>计划改动</th></tr></thead>
+      <tbody>
+        <tr><td><code>.github/workflows/codex.yml</code></td><td>区分活动/历史 Issue 分支，传递延迟发布限制；校验 delivery；调整发布门禁、写操作条件、最终回复和最终状态。</td></tr>
+        <tr><td><code>.github/codex/prompts/comment-response.md</code></td><td>增加纯问答规则并更新结果 JSON 协议。</td></tr>
+        <tr><td><code>tests/test_codex_workflow.py</code></td><td>补充历史分支、多个活动分支、reply 无 diff、reply 有 diff、publish 分流和写操作限制的静态回归测试，并在临时 Git 工作树中真实执行发布门禁的四种分流。</td></tr>
+        <tr><td>本方案</td><td>已回写真实测试结果并转为 ACTIVE；前置身份方案保持 ACTIVE。</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section>
+    <h2>测试结果</h2>
+    <p><strong>当前状态：验证完成</strong></p>
+    <table>
+      <thead><tr><th>验证项</th><th>计划命令或方式</th><th>结果</th></tr></thead>
+      <tbody>
+        <tr><td>工作流回归测试</td><td><code>python3 -m pytest -q tests/test_codex_workflow.py</code></td><td>通过：25 passed；其中行为测试在临时 Git 工作树中验证 reply 零 diff、reply 有 diff、publish 冲突和正常 publish。</td></tr>
+        <tr><td>Actions 静态检查</td><td><code>env GOMODCACHE=/private/tmp/talebook-actionlint-gomodcache go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 -config-file .github/actionlint.yaml .github/workflows/codex.yml</code>；审查修正后从已下载模块源码复检。</td><td>通过：两次均无错误输出。</td></tr>
+        <tr><td>Python 格式化</td><td><code>make lint-py-fix</code></td><td>通过：ruff check 与 format 均无改动或错误。</td></tr>
+        <tr><td>Python lint</td><td><code>make lint-py</code></td><td>通过：96 个后端文件已格式化，ruff 无错误。</td></tr>
+        <tr><td>本机全量测试入口</td><td><code>make pytest</code>；随后执行等价的 <code>python3 -m pytest tests -v --cov=webserver --cov-report=term-missing</code></td><td>环境未满足：本机没有 pytest 控制台入口；Python 模块入口又因缺少 Calibre、QuickJS 与 tomllib 在收集阶段退出。未发现本次工作流测试失败。</td></tr>
+        <tr><td>Docker 全量测试</td><td><code>make test</code></td><td>通过：627 passed、2 skipped、31 warnings，耗时 108.56 秒。Docker 镜像没有 jq，故新增行为测试在容器中跳过；同一测试已在本机通过。</td></tr>
+        <tr><td>补丁完整性</td><td><code>git diff --check</code></td><td>通过：无空白错误。</td></tr>
+        <tr><td>设计约束检查</td><td><code>make check-design</code></td><td>通过：ACTIVE 路径、HTML 结构和单文件资源约束均通过。</td></tr>
+        <tr><td>历史分支同名发布</td><td>在发布门禁行为测试中提供已占用的基础分支名，验证派生分支包含 run ID；随后重新执行工作流测试、Ruff、actionlint 和设计检查。</td><td>通过：先观察到同名分支未派生的失败断言；实现后聚焦测试 2 passed，工作流全量 25 passed。</td></tr>
+        <tr><td>真实 Issue 纯问答</td><td>合并后在 Issue #875 再次提及 Codex，确认正常回答且不创建分支或 PR。</td><td>合并后由维护者验收；这是唯一无法在 PR 合并前模拟的线上事件验证。</td></tr>
+      </tbody>
+    </table>
+    <h3>残余风险与替代验证</h3>
+    <ul>
+      <li>本地全量 Python 环境缺少 Calibre、QuickJS 与 tomllib；已改用仓库标准 <code>make test</code> Docker 入口完成 627 项通过验证，覆盖后端全量回归。</li>
+      <li>标准 Docker 测试镜像不含 jq，因此真实执行发布门禁的行为测试在容器内跳过；同一测试已在本机具备 bash、git、jq 的环境中通过，另由 actionlint 验证工作流语法。残余风险是本机与 GitHub Ubuntu runner 的工具版本差异。</li>
+      <li>GitHub API 的真实分支、PR 状态和评论更新无法在合并前端到端模拟；静态契约测试覆盖上下文路由，合并后仍需在 Issue #875 执行一次纯问答验收。若异常，可回滚本工作流提交，不影响仓库业务数据。</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>审查结论</h2>
+    <ul>
+      <li>使用显式 <code>delivery: reply | publish</code> 结果协议，不做关键词分类。</li>
+      <li>已关闭或已合并 PR 对应分支自动视为历史分支。</li>
+      <li>多个活动分支时允许纯问答，但实际代码改动仍拒绝发布。</li>
+      <li>纯问答只显示自然语言 summary，不显示空的测试和发布说明。</li>
+    </ul>
+    <p>提交前双轴审查发现两项：规范轴指出残余风险记录不完整，已补充“残余风险与替代验证”；规格轴指出历史分支同名时仍会阻断新发布，已增加 run ID 派生分支并完成红绿测试。其余安全和规格项未发现硬性问题。</p>
+    <p class="small">维护者于 2026-07-18 确认初版 WIP 方案；提交前审查修正与复验已经完成，本方案现为 ACTIVE。</p>
+  </section>
+</main>
+</body>
+</html>

--- a/tests/test_codex_workflow.py
+++ b/tests/test_codex_workflow.py
@@ -1,5 +1,10 @@
+import json
+import os
+import shutil
+import subprocess
 from pathlib import Path
 
+import pytest
 import yaml
 
 
@@ -37,6 +42,71 @@ def prompt_text():
 
 def progress_reporter_text():
     return PROGRESS_REPORTER.read_text(encoding="utf-8")
+
+
+def run_publish_gate(
+    tmp_path,
+    result,
+    *,
+    changed=False,
+    publish_block_reason="",
+    issue_branches=(),
+    run_id="123456",
+):
+    tmp_path.mkdir(parents=True)
+    subprocess.run(["git", "init", "-b", "main"], cwd=tmp_path, check=True, capture_output=True, text=True)
+    (tmp_path / "tracked.txt").write_text("base\n", encoding="utf-8")
+    subprocess.run(["git", "add", "tracked.txt"], cwd=tmp_path, check=True, capture_output=True, text=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=Codex Test",
+            "-c",
+            "user.email=codex@example.invalid",
+            "-c",
+            "commit.gpgsign=false",
+            "commit",
+            "-m",
+            "test: base",
+        ],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    target_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=tmp_path, check=True, capture_output=True, text=True
+    ).stdout.strip()
+    (tmp_path / ".git" / "info" / "exclude").write_text(".codex-result.json\n", encoding="utf-8")
+    (tmp_path / ".codex-result.json").write_text(json.dumps(result, ensure_ascii=False), encoding="utf-8")
+    if changed:
+        (tmp_path / "tracked.txt").write_text("changed\n", encoding="utf-8")
+
+    output_file = tmp_path / ".git" / "publish-gate-output"
+    env = {
+        **os.environ,
+        "CODEX_OUTCOME": "success",
+        "TARGET_SHA": target_sha,
+        "TARGET_REF": "main",
+        "IS_PR": "false",
+        "ISSUE_NUMBER": "875",
+        "EXISTING_ISSUE_BRANCH": "",
+        "PUBLISH_BLOCK_REASON": publish_block_reason,
+        "ISSUE_BRANCHES_JSON": json.dumps(issue_branches),
+        "RUN_ID": run_id,
+        "RESULT_FILE": ".codex-result.json",
+        "GITHUB_OUTPUT": str(output_file),
+    }
+    subprocess.run(
+        ["bash", "-c", workflow_step(step_id="publish_gate")["run"]],
+        cwd=tmp_path,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return dict(line.split("=", 1) for line in output_file.read_text(encoding="utf-8").splitlines())
 
 
 def test_employee_job_is_bounded_and_serialized_per_request_target():
@@ -137,17 +207,31 @@ def test_request_context_rejects_missing_or_external_pr_head_repositories():
     assert "headRepo: headRepoFullName" in context_script
     assert "sameRepository: headRepoFullName === `${owner}/${repo}`" in context_script
     assert "pr.head.repo.full_name" not in context_script
-    assert "github.rest.git.listMatchingRefs" in context_script
-    assert "codex/issue-${issueNumber}-" in context_script
-    assert "已存在多个 Codex 分支" in context_script
-    assert "属于已关闭或已合并的 Pull Request" in context_script
     assert checkout["with"]["ref"] == "${{ steps.context.outputs.target_sha }}"
     assert checkout["with"]["persist-credentials"] is False
     assert "CODEX_PR_DIFF" not in workflow_text()
     assert "CODEX_PR_FILES_JSON" not in workflow_text()
 
 
-def test_agent_contract_requires_a_validated_publish_decision():
+def test_issue_comments_ignore_historical_pr_branches_and_defer_active_branch_conflicts():
+    context_script = workflow_step(step_id="context")["with"]["script"]
+
+    assert "github.rest.git.listMatchingRefs" in context_script
+    assert "codex/issue-${issueNumber}-" in context_script
+    assert "const activeIssueTargets = [];" in context_script
+    assert "const historicalIssueBranches = [];" in context_script
+    assert "historicalIssueBranches.push(branchName);" in context_script
+    assert "activeIssueTargets.push" in context_script
+    assert "activeIssueTargets.length === 1" in context_script
+    assert "activeIssueTargets.length > 1" in context_script
+    assert "已存在多个活动 Codex 分支" in context_script
+    assert "publishBlockReason" in context_script
+    assert 'core.setOutput("publish_block_reason", publishBlockReason);' in context_script
+    assert 'core.setOutput("issue_branches_json", JSON.stringify(issueBranches));' in context_script
+    assert "属于已关闭或已合并的 Pull Request" not in context_script
+
+
+def test_agent_contract_distinguishes_conversational_replies_from_code_publication():
     run_step = workflow_step(step_id="run_codex")
     prompt = prompt_text()
 
@@ -155,7 +239,12 @@ def test_agent_contract_requires_a_validated_publish_decision():
     assert "--json" in run_step["run"]
     assert "tee .codex/tmp/codex-events.jsonl" in run_step["run"]
     assert run_step["env"]["CODEX_PROGRESS_TOKEN"] == "${{ steps.interaction_token.outputs.token }}"
-    assert all(field in prompt for field in ('"ready_to_publish"', '"feature"', '"commit_message"', '"summary"', '"tests"'))
+    assert all(field in prompt for field in ('"delivery"', '"feature"', '"commit_message"', '"summary"', '"tests"'))
+    assert '"delivery": "reply"' in prompt
+    assert '"delivery": "publish"' in prompt
+    assert '"ready_to_publish"' not in prompt
+    assert "不得根据关键词预先判断" in prompt
+    assert "纯问答" in prompt
     assert ".codex-result.json" in prompt
     assert ".github/workflows/" in prompt
     assert "不得自行 commit 或 push" in prompt
@@ -203,7 +292,12 @@ def test_publish_gate_rejects_incomplete_or_unsafe_changes():
     script = gate["run"]
 
     assert gate["env"]["RESULT_FILE"] == ".codex-result.json"
-    assert ".ready_to_publish == true" in script
+    assert gate["env"]["PUBLISH_BLOCK_REASON"] == "${{ steps.context.outputs.publish_block_reason }}"
+    assert '(keys | sort) == ["commit_message", "delivery", "feature", "summary", "tests"]' in script
+    assert '(.delivery == "reply" or .delivery == "publish")' in script
+    assert 'delivery="$(jq -r \'.delivery\' "$RESULT_FILE")"' in script
+    assert 'echo "delivery=$delivery" >> "$GITHUB_OUTPUT"' in script
+    assert "ready_to_publish" not in script
     assert 'test("^[a-z0-9]+(-[a-z0-9]+)*$")' in script
     assert "Conventional Commit" in script
     assert "git rev-parse HEAD" in script
@@ -213,6 +307,82 @@ def test_publish_gate_rejects_incomplete_or_unsafe_changes():
     assert "^\\.github/workflows/" in script
     assert 'echo "ready=true" >> "$GITHUB_OUTPUT"' in script
     assert 'echo "ready=false" >> "$GITHUB_OUTPUT"' in script
+
+
+def test_conversational_reply_bypasses_publish_conflicts_only_when_the_diff_is_empty():
+    script = workflow_step(step_id="publish_gate")["run"]
+    no_change_gate = 'if [ -z "$reason" ] && git diff --cached --quiet; then'
+    reply_diff_gate = 'if [ -z "$reason" ] && [ "$delivery" = "reply" ] && [ "$no_changes" != "true" ]; then'
+    publish_conflict_gate = 'if [ -z "$reason" ] && [ "$delivery" = "publish" ] && [ -n "$PUBLISH_BLOCK_REASON" ]; then'
+
+    assert 'if [ "$delivery" = "publish" ]; then' in script
+    assert 'reject "回复模式不得产生仓库改动。"' in script
+    assert 'reject "$PUBLISH_BLOCK_REASON"' in script
+    assert script.index(no_change_gate) < script.index(reply_diff_gate)
+    assert script.index(reply_diff_gate) < script.index(publish_conflict_gate)
+
+
+@pytest.mark.skipif(
+    any(shutil.which(command) is None for command in ("bash", "git", "jq")),
+    reason="发布门禁行为测试需要 bash、git 和 jq",
+)
+def test_publish_gate_executes_reply_and_publish_paths_against_a_real_git_worktree(tmp_path):
+    reply = {
+        "delivery": "reply",
+        "feature": "",
+        "commit_message": "",
+        "summary": "当前运行模型由工作流配置决定。",
+        "tests": [],
+    }
+    publish = {
+        "delivery": "publish",
+        "feature": "conversation-routing",
+        "commit_message": "fix(codex): route conversational requests",
+        "summary": "已修复纯问答路由。",
+        "tests": [{"command": "pytest -q tests/test_codex_workflow.py", "result": "passed"}],
+    }
+
+    reply_outputs = run_publish_gate(
+        tmp_path / "reply",
+        reply,
+        publish_block_reason="存在冲突分支。",
+    )
+    assert reply_outputs == {
+        "ready": "false",
+        "contract_valid": "true",
+        "no_changes": "true",
+        "reason": "",
+        "delivery": "reply",
+        "feature": "",
+        "commit_message": "",
+        "publish_branch": "",
+    }
+
+    changed_reply_outputs = run_publish_gate(tmp_path / "changed-reply", reply, changed=True)
+    assert changed_reply_outputs["reason"] == "回复模式不得产生仓库改动。"
+    assert changed_reply_outputs["no_changes"] == "false"
+
+    blocked_publish_outputs = run_publish_gate(
+        tmp_path / "blocked-publish",
+        publish,
+        changed=True,
+        publish_block_reason="存在冲突分支。",
+    )
+    assert blocked_publish_outputs["reason"] == "存在冲突分支。"
+    assert blocked_publish_outputs["ready"] == "false"
+
+    publish_outputs = run_publish_gate(tmp_path / "publish", publish, changed=True)
+    assert publish_outputs["ready"] == "true"
+    assert publish_outputs["publish_branch"] == "codex/issue-875-conversation-routing"
+
+    collision_outputs = run_publish_gate(
+        tmp_path / "historical-collision",
+        publish,
+        changed=True,
+        issue_branches=["codex/issue-875-conversation-routing"],
+    )
+    assert collision_outputs["ready"] == "true"
+    assert collision_outputs["publish_branch"] == "codex/issue-875-conversation-routing-123456"
 
 
 def test_repository_wip_gate_runs_before_no_change_classification():
@@ -243,6 +413,14 @@ def test_controlled_publisher_uses_a_short_lived_app_token_and_fast_forward_push
     assert 'git commit -m "$COMMIT_MESSAGE"' in publish["run"]
     assert 'git push "$authenticated_remote" "HEAD:refs/heads/$PUBLISH_BRANCH"' in publish["run"]
     assert "--force" not in publish["run"]
+
+
+def test_reply_delivery_never_requests_a_publisher_token_or_creates_a_pull_request():
+    token_condition = workflow_step(step_id="app_token")["if"]
+    create_pr_condition = workflow_step(step_id="create_issue_pr")["if"]
+
+    assert "steps.publish_gate.outputs.delivery == 'publish'" in token_condition
+    assert "steps.publish_gate.outputs.delivery == 'publish'" in create_pr_condition
 
 
 def test_all_interactive_github_calls_use_the_low_privilege_app_token():
@@ -312,6 +490,7 @@ def test_comment_reports_validated_metadata_and_remote_delivery_result():
     script = response["with"]["script"]
 
     assert response["env"]["CODEX_CONTRACT_VALID"] == "${{ steps.publish_gate.outputs.contract_valid }}"
+    assert response["env"]["CODEX_DELIVERY"] == "${{ steps.publish_gate.outputs.delivery }}"
     assert response["env"]["CODEX_RESULT_FILE"] == ".codex-result.json"
     assert "const validatedResult" in script
     assert "validatedResult.summary" in script
@@ -321,6 +500,28 @@ def test_comment_reports_validated_metadata_and_remote_delivery_result():
     assert "CODEX_COMMIT_SHA" in response["env"]
     assert "CREATED_PR_URL" in response["env"]
     assert "github.rest.issues.updateComment" in script
+
+
+def test_reply_comment_is_the_summary_with_validation_only_when_records_exist():
+    response_script = workflow_step(name="Post Codex response")["with"]["script"]
+    final_status = workflow_step(step_id="final_status")
+
+    assert "if (validatedResult.tests.length > 0)" in response_script
+    assert 'if (process.env.CODEX_DELIVERY === "reply"' in response_script
+    assert "纯问答直接使用 summary，不追加发布状态。" in response_script
+    assert final_status["env"]["DELIVERY"] == "${{ steps.publish_gate.outputs.delivery }}"
+    assert final_status["env"]["CONTRACT_VALID"] == "${{ steps.publish_gate.outputs.contract_valid }}"
+    assert 'if [ "$DELIVERY" = "reply" ]; then' in final_status["run"]
+
+
+def test_publish_delivery_without_a_diff_only_succeeds_for_missing_pr_recovery():
+    response_script = workflow_step(name="Post Codex response")["with"]["script"]
+    final_status_script = workflow_step(step_id="final_status")["run"]
+
+    assert 'else if (process.env.CODEX_DELIVERY === "publish" && process.env.CODEX_NO_CHANGES === "true")' in response_script
+    assert '未发布：${process.env.CODEX_GATE_REASON || "未产生仓库改动。"}' in response_script
+    assert 'if [ "$DELIVERY" = "publish" ] && [ "$GATE_NO_CHANGES" = "true" ]; then' in final_status_script
+    assert 'if [ "$CREATED_PR_OUTCOME" = "success" ]; then' in final_status_script
 
 
 def test_one_progress_comment_is_created_then_updated_throughout_the_run():


### PR DESCRIPTION
## 问题

Issue #875 的第二次 @codex 只是询问模型版本，却被历史 Codex 分支关联的已关闭/已合并 PR 提前阻断。

## 修改

- 把请求执行与代码发布门禁解耦，授权评论始终进入 Codex
- 过滤已关闭或已合并 PR 对应的历史分支
- 用 delivery: reply | publish 显式区分纯问答和代码交付
- reply 仅在零 diff 时成功，且不会申请发布 token、创建分支或 PR
- 多活动分支只阻断真实代码发布
- 历史分支与新 feature 同名时，用 GitHub run ID 派生安全的新分支名

## 验证

- python3 -m pytest -q tests/test_codex_workflow.py：25 passed
- make test：627 passed，2 skipped
- make lint-py-fix / make lint-py：通过
- actionlint：通过
- make check-design：26 份方案通过
- git diff --check：通过

## 方案

design/project/20260718-codex-conversational-requests.active.html

Refs #875