### PR TITLE
fix(codex): 为 runner 提供 ruff 与 pytest

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -80,12 +80,14 @@ jobs:
             const codexHome = `${runnerTemp}/codex-home`;
             const codexPromptTemplate = `${runnerTemp}/codex-comment-response.md`;
             const codexProgressReporter = `${runnerTemp}/codex-progress-reporter.py`;
+            const codexTestRequirements = `${runnerTemp}/codex-requirements-test.txt`;
             const codexRequestJson = `${runnerTemp}/codex-request.json`;
             const workflowSha = process.env.WORKFLOW_SHA;
 
             core.exportVariable("CODEX_HOME", codexHome);
             core.exportVariable("CODEX_PROMPT_TEMPLATE", codexPromptTemplate);
             core.exportVariable("CODEX_PROGRESS_REPORTER", codexProgressReporter);
+            core.exportVariable("CODEX_TEST_REQUIREMENTS", codexTestRequirements);
             core.exportVariable("CODEX_REQUEST_JSON", codexRequestJson);
 
             let body = "";
@@ -365,6 +367,21 @@ jobs:
                   Buffer.from(progressReporterResult.data.content, "base64"),
                   { mode: 0o600 },
                 );
+
+                const testRequirementsResult = await github.rest.repos.getContent({
+                  owner,
+                  repo,
+                  path: "requirements-test.txt",
+                  ref: workflowSha,
+                });
+                if (Array.isArray(testRequirementsResult.data) || !testRequirementsResult.data.content) {
+                  throw new Error("Trusted Codex test requirements are missing from the workflow commit.");
+                }
+                fs.writeFileSync(
+                  codexTestRequirements,
+                  Buffer.from(testRequirementsResult.data.content, "base64"),
+                  { mode: 0o600 },
+                );
               } catch (error) {
                 if (progressCommentId) {
                   try {
@@ -423,6 +440,20 @@ jobs:
           ref: ${{ steps.context.outputs.target_sha }}
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Setup Python for Codex validation
+        if: steps.context.outputs.authorized == 'true' && steps.context.outputs.supported_target == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install Codex test tools
+        if: steps.context.outputs.authorized == 'true' && steps.context.outputs.supported_target == 'true'
+        run: |
+          set -euo pipefail
+          python3 -m pip install --disable-pip-version-check -r "$CODEX_TEST_REQUIREMENTS"
+          ruff --version
+          python3 -m pytest --version
 
       - name: Install Codex CLI
         if: steps.context.outputs.authorized == 'true' && steps.context.outputs.supported_target == 'true'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,21 @@ make dev     # 挂载 webserver/ 进容器，用于后端开发调试
 
 自然语言中输出文件路径、目录路径或 URL 时，路径与后续中英文标点之间必须留一个空格。例如“请查看 `design/project/example.active.html` 。”代码块、命令、HTML 属性和 Markdown 链接语法内部不插入额外空格。
 
+### Pull Request 提交规范
+
+- PR 标题应准确概括改动，正文不得为空或只重复提交消息。正文至少包含：背景或目标、关键改动、实际验证结果、风险或兼容性，以及方案路径或豁免原因。
+- 测试结果必须列出实际执行的命令与结果；未执行的项目应说明原因和风险，不得写成已通过。
+- 涉及界面、布局、交互或其他可视结果时必须附带截图；其他改动在截图有助于评审理解时也应优先附带。无法截图时在正文说明原因。
+- PR 引用 `design/` 下的 ACTIVE 单文件 HTML 方案时，必须同时提供 GitHub 文件链接和 RawGitHack 在线预览链接。两个链接都使用已推送提交的完整 commit SHA，不得使用会漂移的分支名或 `HEAD`。新增提交导致方案内容变化后，应同步更新链接。
+- 固定链接按以下格式转换：
+  ```text
+  https://github.com/<owner>/<repo>/blob/<commit-sha>/<path>
+  https://raw.githack.com/<owner>/<repo>/<commit-sha>/<path>
+  ```
+- 示例：
+  - GitHub 文件：`https://github.com/talebook/talebook/blob/18113f147aefa0ad79e8c7efd93f1c882610b3ed/design/webserver/20260721-booksource-large-json-import.active.html`
+  - RawGitHack 预览：`https://raw.githack.com/talebook/talebook/18113f147aefa0ad79e8c7efd93f1c882610b3ed/design/webserver/20260721-booksource-large-json-import.active.html`
+
 ### 测试
 
 - **每次新增或修改功能，必须附带对应的测试用例**，不允许只改业务代码不写测试。

--- a/design/project/20260721-codex-test-tools.active.html
+++ b/design/project/20260721-codex-test-tools.active.html
@@ -1,0 +1,85 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Codex 测试工具运行环境</title>
+  <style>
+    :root { color-scheme: light; font-family: system-ui, sans-serif; color: #17202a; background: #f4f7fb; }
+    body { max-width: 960px; margin: 0 auto; padding: 32px 20px 64px; }
+    header, section { background: white; border: 1px solid #dce4ee; border-radius: 12px; padding: 22px; margin-bottom: 18px; }
+    h1, h2 { margin-top: 0; }
+    .meta { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 10px; }
+    .meta div { background: #edf4ff; border-radius: 8px; padding: 10px 12px; }
+    code { background: #eef1f5; border-radius: 4px; padding: 2px 5px; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { border: 1px solid #dce4ee; padding: 9px; text-align: left; vertical-align: top; }
+    th { background: #edf4ff; }
+    .pending { color: #8a5a00; font-weight: 700; }
+    svg { width: 100%; height: auto; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Codex 测试工具运行环境</h1>
+    <div class="meta">
+      <div><strong>创建日期</strong><br>2026-07-21</div>
+      <div><strong>所属模块</strong><br>project / GitHub Actions</div>
+      <div><strong>状态</strong><br>ACTIVE</div>
+      <div><strong>需求来源</strong><br>维护者指出 Codex runner 未安装 ruff 与 pytest</div>
+    </div>
+  </header>
+
+  <section>
+    <h2>原始诉求与问题</h2>
+    <p>Codex 在 <code>.github/workflows/codex.yml</code> 的 runner 中执行维护任务时，会把需要运行的 ruff 或 pytest 验证记录为“未执行”，原因是 runner 没有安装对应命令。当前 workflow 只安装 Codex CLI 和 sandbox 组件，没有准备仓库声明的 Python 测试工具。</p>
+  </section>
+
+  <section>
+    <h2>目标与边界</h2>
+    <ul>
+      <li>Codex 启动前，runner 必须能执行 <code>ruff</code> 和 <code>python3 -m pytest</code>。</li>
+      <li>工具版本继续由 <code>requirements-test.txt</code> 管理，不在 workflow 中重复维护版本。</li>
+      <li>依赖清单必须来自不可变的 <code>github.workflow_sha</code>，不得安装 PR head 可修改的清单。</li>
+      <li>安装发生在可信 workflow 步骤中，不扩大 Codex sandbox 权限，不暴露凭据。</li>
+      <li>本次不改变常规 <code>ci.yml</code>、生产镜像或 Docker 测试阶段。</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>方案</h2>
+    <svg viewBox="0 0 900 190" role="img" aria-label="Codex runner 测试工具准备流程">
+      <defs><marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto"><path d="M0,0 L0,6 L9,3 z" fill="#4577b4"/></marker></defs>
+      <g fill="#edf4ff" stroke="#4577b4" stroke-width="2">
+        <rect x="25" y="50" width="180" height="85" rx="10"/><rect x="260" y="50" width="180" height="85" rx="10"/>
+        <rect x="495" y="50" width="180" height="85" rx="10"/><rect x="730" y="50" width="145" height="85" rx="10"/>
+      </g>
+      <g fill="#17202a" text-anchor="middle" font-size="16">
+        <text x="115" y="78">读取受信任清单</text><text x="115" y="102">workflow SHA</text><text x="115" y="122">requirements-test</text>
+        <text x="350" y="84">Checkout</text><text x="350" y="108">目标提交</text>
+        <text x="585" y="78">setup-python 3.13</text><text x="585" y="102">安装受信任清单</text><text x="585" y="122">验证 ruff / pytest</text>
+        <text x="802" y="84">Run Codex</text><text x="802" y="108">受限 sandbox</text>
+      </g>
+      <g stroke="#4577b4" stroke-width="2" marker-end="url(#arrow)"><line x1="205" y1="92" x2="250" y2="92"/><line x1="440" y1="92" x2="485" y2="92"/><line x1="675" y1="92" x2="720" y2="92"/></g>
+    </svg>
+    <p>上下文解析步骤从不可变的 <code>github.workflow_sha</code> 读取受信任 <code>requirements-test.txt</code>，保存到 runner 临时目录；不得直接安装 PR head 中的依赖清单。checkout 后新增 Python 环境准备与测试工具安装步骤，安装临时目录中的受信任清单，随后运行版本命令快速失败，从而把依赖准备错误暴露在 Codex 启动前。</p>
+  </section>
+
+  <section>
+    <h2>测试计划与结果</h2>
+    <table>
+      <thead><tr><th>验证项</th><th>预期</th><th>实际结果</th></tr></thead>
+      <tbody>
+        <tr><td>workflow 契约回归</td><td>从 <code>github.workflow_sha</code> 获取受信任清单，安装步骤不读取 PR head 清单，并位于 checkout 与 Run Codex 之间</td><td>通过；测试在修复前因缺少步骤失败，加入受信任清单约束后再次得到 2 项失败，实现后 <code>2 passed</code>。</td></tr>
+        <tr><td>相关 pytest</td><td><code>python3 -m pytest -q tests/test_codex_workflow.py tests/test_codex_progress_reporter.py tests/test_check_design_docs.py tests/test_project_instructions.py</code></td><td>通过，<code>52 passed</code>。</td></tr>
+        <tr><td>完整 Docker 测试</td><td><code>make test</code></td><td>通过，Python 3.13 / Calibre 环境中 <code>636 passed, 2 skipped</code>；包含新增 workflow 与研发规范测试。</td></tr>
+        <tr><td>工具可执行性</td><td><code>docker run --rm talebook/test sh -c 'ruff --version &amp;&amp; python3 -m pytest --version'</code></td><td>通过，输出 <code>ruff 0.15.22</code> 与 <code>pytest 7.4.4</code>。</td></tr>
+        <tr><td>Python lint / format</td><td><code>ruff check tests/test_codex_workflow.py tests/test_project_instructions.py --no-cache</code>；<code>ruff format --check</code></td><td>通过，2 个文件无 lint 或格式问题；<code>make lint-py-fix</code> 与 <code>make lint-py</code> 也通过。</td></tr>
+        <tr><td>workflow 静态检查</td><td><code>go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -config-file .github/actionlint.yaml .github/workflows/codex.yml</code></td><td>通过，无输出。</td></tr>
+        <tr><td>宿主组合测试说明</td><td>曾把 <code>tests/test_docker_stages.py</code> 加入宿主 Python 3.9 组合测试</td><td>收集阶段因 Python 3.9 无标准库 <code>tomllib</code> 中止；同一文件随后已在 Python 3.13 的 <code>make test</code> 中通过，不构成相关失败。</td></tr>
+        <tr><td>设计门禁</td><td><code>make check-design</code></td><td>通过，32 份方案文档均满足路径、状态、HTML 与单文件资源约束。</td></tr>
+      </tbody>
+    </table>
+  </section>
+</body>
+</html>

--- a/design/project/20260721-pr-description-preview.active.html
+++ b/design/project/20260721-pr-description-preview.active.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Pull Request 描述与方案预览规范</title>
+  <style>
+    :root { font-family: system-ui, sans-serif; color: #1d2733; background: #f6f8fb; }
+    body { max-width: 980px; margin: 0 auto; padding: 32px 20px 64px; }
+    header, section { background: #fff; border: 1px solid #d9e1ea; border-radius: 12px; margin-bottom: 18px; padding: 22px; }
+    h1, h2 { margin-top: 0; }
+    .meta { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 10px; }
+    .meta div { background: #eef5ff; border-radius: 8px; padding: 10px 12px; }
+    code { background: #eef1f4; border-radius: 4px; padding: 2px 5px; overflow-wrap: anywhere; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { border: 1px solid #d9e1ea; padding: 9px; text-align: left; vertical-align: top; }
+    th { background: #eef5ff; }
+    .pending { color: #8a5a00; font-weight: 700; }
+    .url { display: block; margin: 8px 0; overflow-wrap: anywhere; }
+    svg { width: 100%; height: auto; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Pull Request 描述与方案预览规范</h1>
+    <div class="meta">
+      <div><strong>创建日期</strong><br>2026-07-21</div>
+      <div><strong>所属模块</strong><br>project</div>
+      <div><strong>状态</strong><br>ACTIVE</div>
+      <div><strong>需求来源</strong><br>维护者要求完善 PR 正文、截图与 RawGitHack 预览</div>
+    </div>
+  </header>
+
+  <section>
+    <h2>原始诉求</h2>
+    <p>更新仓库级研发约束：提交 PR 时正文必须完整；条件允许时附带截图；引用单文件 HTML 方案时，除 GitHub 固定 commit 文件链接外，还要提供可直接渲染的 RawGitHack 预览链接。</p>
+  </section>
+
+  <section>
+    <h2>目标与规则</h2>
+    <ul>
+      <li>PR 正文至少说明背景或目标、关键改动、实际验证结果、风险或兼容性，以及方案路径或豁免原因。</li>
+      <li>涉及界面、布局、交互或其他可视结果时必须附截图；其他改动在截图能帮助评审时优先附带。</li>
+      <li>引用 ACTIVE HTML 方案时同时提供 GitHub blob 链接和 RawGitHack 预览链接。</li>
+      <li>两个链接都使用已推送的完整 commit SHA，避免分支移动后评审内容漂移。</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>固定链接转换</h2>
+    <svg viewBox="0 0 900 190" role="img" aria-label="GitHub 方案链接转换为 RawGitHack 预览链接">
+      <defs><marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto"><path d="M0,0 L0,6 L9,3 z" fill="#3b73af"/></marker></defs>
+      <rect x="25" y="45" width="350" height="100" rx="12" fill="#eef5ff" stroke="#3b73af" stroke-width="2"/>
+      <rect x="525" y="45" width="350" height="100" rx="12" fill="#eefaf4" stroke="#37845c" stroke-width="2"/>
+      <line x1="385" y1="95" x2="515" y2="95" stroke="#3b73af" stroke-width="3" marker-end="url(#arrow)"/>
+      <g text-anchor="middle" fill="#1d2733"><text x="200" y="78" font-size="17" font-weight="700">GitHub blob 固定链接</text><text x="200" y="107" font-size="15">/blob/&lt;commit-sha&gt;/&lt;path&gt;</text><text x="700" y="78" font-size="17" font-weight="700">RawGitHack 在线预览</text><text x="700" y="107" font-size="15">/&lt;commit-sha&gt;/&lt;path&gt;</text></g>
+    </svg>
+    <p><strong>转换公式：</strong></p>
+    <code class="url">https://github.com/&lt;owner&gt;/&lt;repo&gt;/blob/&lt;commit-sha&gt;/&lt;path&gt;</code>
+    <code class="url">https://raw.githack.com/&lt;owner&gt;/&lt;repo&gt;/&lt;commit-sha&gt;/&lt;path&gt;</code>
+    <p><strong>维护者提供的示例：</strong></p>
+    <code class="url">https://github.com/talebook/talebook/blob/18113f147aefa0ad79e8c7efd93f1c882610b3ed/design/webserver/20260721-booksource-large-json-import.active.html</code>
+    <code class="url">https://raw.githack.com/talebook/talebook/18113f147aefa0ad79e8c7efd93f1c882610b3ed/design/webserver/20260721-booksource-large-json-import.active.html</code>
+  </section>
+
+  <section>
+    <h2>测试计划与结果</h2>
+    <table>
+      <thead><tr><th>验证项</th><th>预期</th><th>实际结果</th></tr></thead>
+      <tbody>
+        <tr><td>研发规范契约测试</td><td><code>python3 -m pytest -q tests/test_project_instructions.py</code></td><td>通过；修复前因缺少 PR 提交规范失败，写入规则后 <code>1 passed</code>。</td></tr>
+        <tr><td>完整 Docker 测试</td><td><code>make test</code></td><td>通过，<code>636 passed, 2 skipped</code>，包含新增研发规范契约。</td></tr>
+        <tr><td>Python lint / format</td><td><code>ruff check tests/test_project_instructions.py --no-cache</code>；<code>ruff format --check tests/test_project_instructions.py</code></td><td>通过，文件格式无需调整。</td></tr>
+        <tr><td>设计文档门禁</td><td><code>make check-design</code></td><td>通过，32 份方案文档均满足路径、状态、HTML 与单文件资源约束。</td></tr>
+      </tbody>
+    </table>
+  </section>
+</body>
+</html>

--- a/tests/test_codex_workflow.py
+++ b/tests/test_codex_workflow.py
@@ -119,6 +119,30 @@ def test_employee_job_is_bounded_and_serialized_per_request_target():
     }
 
 
+def test_codex_runtime_installs_declared_test_tools_before_agent_execution():
+    steps = codex_job()["steps"]
+    checkout = workflow_step(name="Checkout repository")
+    setup_python = workflow_step(name="Setup Python for Codex validation")
+    install_tools = workflow_step(name="Install Codex test tools")
+    run_codex = workflow_step(name="Run Codex")
+    context_script = workflow_step(step_id="context")["with"]["script"]
+
+    assert "const codexTestRequirements = `${runnerTemp}/codex-requirements-test.txt`;" in context_script
+    assert 'core.exportVariable("CODEX_TEST_REQUIREMENTS", codexTestRequirements);' in context_script
+    assert 'path: "requirements-test.txt"' in context_script
+    assert "ref: workflowSha" in context_script
+
+    assert setup_python["uses"] == "actions/setup-python@v5"
+    assert setup_python["with"] == {"python-version": "3.13"}
+
+    install_script = install_tools["run"]
+    assert 'python3 -m pip install --disable-pip-version-check -r "$CODEX_TEST_REQUIREMENTS"' in install_script
+    assert "-r requirements-test.txt" not in install_script
+    assert "ruff --version" in install_script
+    assert "python3 -m pytest --version" in install_script
+    assert steps.index(checkout) < steps.index(setup_python) < steps.index(install_tools) < steps.index(run_codex)
+
+
 def test_only_repository_writers_can_trigger_the_employee():
     job = codex_job()
     job_condition = job["if"]
@@ -185,7 +209,8 @@ def test_trusted_assets_follow_the_immutable_workflow_version_and_acknowledge_fi
     assert "const workflowSha = process.env.WORKFLOW_SHA;" in script
     assert 'path: ".github/codex/prompts/comment-response.md"' in script
     assert 'path: ".github/codex/scripts/codex_progress_reporter.py"' in script
-    assert script.count("ref: workflowSha") == 2
+    assert 'path: "requirements-test.txt"' in script
+    assert script.count("ref: workflowSha") == 3
     assert "ref: defaultBranch" not in script
     assert script.index("reactions.createForIssueComment") < script.index("issues.createComment")
     assert script.index("issues.createComment") < script.index('path: ".github/codex/prompts/comment-response.md"')

--- a/tests/test_project_instructions.py
+++ b/tests/test_project_instructions.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+AGENTS = ROOT / "AGENTS.md"
+
+
+def test_pull_request_description_and_design_preview_rules_are_documented():
+    instructions = AGENTS.read_text(encoding="utf-8")
+
+    assert "### Pull Request 提交规范" in instructions
+    assert all(
+        requirement in instructions
+        for requirement in (
+            "背景或目标",
+            "关键改动",
+            "实际验证结果",
+            "风险或兼容性",
+            "方案路径或豁免原因",
+            "截图",
+            "完整 commit SHA",
+        )
+    )
+    assert "https://github.com/<owner>/<repo>/blob/<commit-sha>/<path>" in instructions
+    assert "https://raw.githack.com/<owner>/<repo>/<commit-sha>/<path>" in instructions
+    assert (
+        "https://raw.githack.com/talebook/talebook/18113f147aefa0ad79e8c7efd93f1c882610b3ed/"
+        "design/webserver/20260721-booksource-large-json-import.active.html"
+    ) in instructions


### PR DESCRIPTION
## 背景与目标

Codex workflow 的 runner 没有准备 `ruff` 和 `pytest`，导致维护任务只能把相关验证记录为“未执行”。本 PR 在 Codex 启动前提供仓库声明的测试工具，并补充 PR 正文、截图和 HTML 方案预览的仓库级研发规范。

## 关键改动

- `codex.yml` 使用 Python 3.13，并在 Run Codex 前安装 `requirements-test.txt` 中声明的 ruff、pytest、pytest-cov 等测试工具。
- 依赖清单从不可变的 `github.workflow_sha` 读取到 runner 临时目录，不安装 PR head 可修改的依赖清单，避免在凭据型 job 中扩大不受信任代码执行面。
- 安装后显式执行 `ruff --version` 和 `python3 -m pytest --version`，环境缺失会在 Codex 启动前快速失败。
- `AGENTS.md` 新增 Pull Request 提交规范：完整正文、真实测试结果、截图要求，以及 GitHub 固定链接到 RawGitHack 预览链接的转换规则。
- 新增 workflow 与研发规范回归测试，锁定步骤顺序、受信任依赖来源和 PR 描述要求。

## 实际验证

- `python3 -m pytest -q tests/test_codex_workflow.py tests/test_codex_progress_reporter.py tests/test_check_design_docs.py tests/test_project_instructions.py`：52 passed。
- `make test`：636 passed，2 skipped；Python 3.13 / Calibre 测试环境通过。
- `ruff check tests/test_codex_workflow.py tests/test_project_instructions.py --no-cache`：通过。
- `ruff format --check tests/test_codex_workflow.py tests/test_project_instructions.py`：2 files already formatted。
- `make lint-py-fix && make lint-py`：通过，96 个后端文件无修改。
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -config-file .github/actionlint.yaml .github/workflows/codex.yml`：通过。
- `make check-design`：32 份方案文档通过。
- `docker run --rm talebook/test sh -c 'ruff --version && python3 -m pytest --version'`：ruff 0.15.22，pytest 7.4.4。

## 风险与兼容性

- 每次 Codex 请求会增加一次小规模 Python 测试依赖安装；未启用依赖缓存，以避免 runner 临时目录路径兼容问题，优先保证可靠性。
- 不修改普通 `ci.yml`、生产依赖、生产镜像或 Docker 测试阶段。
- 受信任依赖清单固定到 workflow commit；PR 对 `requirements-test.txt` 的修改不会在同一次 Codex 请求中被安装，这是有意的安全边界。

## 截图

本次仅修改 GitHub Actions 与研发规范，没有 UI、布局或可视交互变化，因此不附产品截图。两份 HTML 方案可通过下方 RawGitHack 链接直接预览。

## 方案文档

### Codex 测试工具运行环境

- [GitHub 固定文件](https://github.com/talebook/talebook/blob/edbc531fc2de81357531b59f7d48e81b9b9a271a/design/project/20260721-codex-test-tools.active.html)
- [RawGitHack 在线预览](https://raw.githack.com/talebook/talebook/edbc531fc2de81357531b59f7d48e81b9b9a271a/design/project/20260721-codex-test-tools.active.html)

### Pull Request 描述与方案预览规范

- [GitHub 固定文件](https://github.com/talebook/talebook/blob/edbc531fc2de81357531b59f7d48e81b9b9a271a/design/project/20260721-pr-description-preview.active.html)
- [RawGitHack 在线预览](https://raw.githack.com/talebook/talebook/edbc531fc2de81357531b59f7d48e81b9b9a271a/design/project/20260721-pr-description-preview.active.html)
