### PR TITLE
ci(agents): run Claude and Codex in dev container

### DIFF
--- a/.github/workflows/agent-dev-smoke.yml
+++ b/.github/workflows/agent-dev-smoke.yml
@@ -1,0 +1,54 @@
+name: Agent development image smoke test
+
+"on":
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: Exercise development and test toolchain
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    container:
+      image: talebook/talebook:dev
+      options: --user root --security-opt seccomp=unconfined
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Verify development environment and sandbox
+        run: |
+          set -euo pipefail
+          ebook-convert --version
+          python3 --version
+          node --version
+          npm --version
+          make --version
+          git --version
+          jq --version
+          python3 -m pytest --version
+          ruff --version
+          codex --version
+          bwrap --version
+          if ! codex sandbox -- /bin/true 2>/dev/null; then
+            echo "::error::Codex sandbox self-test failed"
+            exit 1
+          fi
+
+      - name: Synchronize project dependencies
+        run: |
+          make init
+          npm --prefix app ci
+
+      - name: Run development checks
+        run: |
+          make lint-py
+          make pytest
+          npm --prefix app run lint
+          npm --prefix app run build
+          make check-design

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,6 +133,20 @@ jobs:
           cache-from: type=gha,scope=ssr-${{ steps.pname.outputs.name }}
           cache-to: type=gha,scope=ssr-${{ steps.pname.outputs.name }},mode=max
 
+      - name: Build development image
+        if: matrix.platform == 'linux/amd64' && (github.event_name == 'pull_request' || github.ref == 'refs/heads/master')
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          target: dev
+          platforms: linux/amd64
+          provenance: false
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev
+          labels: org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=gha,scope=dev-linux-amd64
+          cache-to: type=gha,scope=dev-linux-amd64,mode=max
+
       - name: Export digests
         if: github.event_name != 'pull_request'
         run: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,6 +18,12 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
+    container:
+      image: talebook/talebook:dev
+      options: --user root
+    defaults:
+      run:
+        shell: bash
     permissions:
       contents: read
       pull-requests: read
@@ -29,6 +35,21 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+
+      - name: Verify development environment
+        run: |
+          ebook-convert --version
+          python3 --version
+          node --version
+          npm --version
+          make --version
+          python3 -m pytest --version
+          ruff --version
+
+      - name: Synchronize project dependencies
+        run: |
+          make init
+          npm --prefix app ci
 
       - name: Run Claude Code
         id: claude
@@ -47,4 +68,4 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           claude_args: |
-            --allowed-tools "Bash(pip3 install:*),Bash(make init),Bash(make lint-py),Bash(make lint-py-fix),Bash(make pytest),Bash(ruff:*)"
+            --allowedTools "Bash(make:*),Bash(npm:*),Bash(npx:*),Bash(node:*),Bash(python3:*),Bash(pytest:*),Bash(ruff:*)"

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -48,8 +48,13 @@ jobs:
         )
       )
     runs-on: ubuntu-latest
+    container:
+      image: talebook/talebook:dev
+      options: --user root --security-opt seccomp=unconfined
+    defaults:
+      run:
+        shell: bash
     env:
-      CODEX_VERSION: "0.144.4"
       CODEX_MODEL: ${{ vars.CODEX_MODEL || 'gpt-5.6-sol' }}
       CODEX_REASONING_EFFORT: ${{ vars.CODEX_REASONING_EFFORT || 'high' }}
     steps:
@@ -80,14 +85,12 @@ jobs:
             const codexHome = `${runnerTemp}/codex-home`;
             const codexPromptTemplate = `${runnerTemp}/codex-comment-response.md`;
             const codexProgressReporter = `${runnerTemp}/codex-progress-reporter.py`;
-            const codexTestRequirements = `${runnerTemp}/codex-requirements-test.txt`;
             const codexRequestJson = `${runnerTemp}/codex-request.json`;
             const workflowSha = process.env.WORKFLOW_SHA;
 
             core.exportVariable("CODEX_HOME", codexHome);
             core.exportVariable("CODEX_PROMPT_TEMPLATE", codexPromptTemplate);
             core.exportVariable("CODEX_PROGRESS_REPORTER", codexProgressReporter);
-            core.exportVariable("CODEX_TEST_REQUIREMENTS", codexTestRequirements);
             core.exportVariable("CODEX_REQUEST_JSON", codexRequestJson);
 
             let body = "";
@@ -367,21 +370,6 @@ jobs:
                   Buffer.from(progressReporterResult.data.content, "base64"),
                   { mode: 0o600 },
                 );
-
-                const testRequirementsResult = await github.rest.repos.getContent({
-                  owner,
-                  repo,
-                  path: "requirements-test.txt",
-                  ref: workflowSha,
-                });
-                if (Array.isArray(testRequirementsResult.data) || !testRequirementsResult.data.content) {
-                  throw new Error("Trusted Codex test requirements are missing from the workflow commit.");
-                }
-                fs.writeFileSync(
-                  codexTestRequirements,
-                  Buffer.from(testRequirementsResult.data.content, "base64"),
-                  { mode: 0o600 },
-                );
               } catch (error) {
                 if (progressCommentId) {
                   try {
@@ -441,76 +429,33 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Setup Python for Codex validation
-        if: steps.context.outputs.authorized == 'true' && steps.context.outputs.supported_target == 'true'
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-
-      - name: Install Codex test tools
+      - name: Verify development environment and sandbox
         if: steps.context.outputs.authorized == 'true' && steps.context.outputs.supported_target == 'true'
         run: |
           set -euo pipefail
-          python3 -m pip install --disable-pip-version-check -r "$CODEX_TEST_REQUIREMENTS"
-          ruff --version
+
+          ebook-convert --version
+          python3 --version
+          node --version
+          npm --version
+          make --version
           python3 -m pytest --version
+          ruff --version
+          codex --version
+          bwrap --version
 
-      - name: Install Codex CLI
-        if: steps.context.outputs.authorized == 'true' && steps.context.outputs.supported_target == 'true'
-        run: npm install -g "@openai/codex@${CODEX_VERSION}"
+          if codex sandbox -- /bin/true 2>/dev/null; then
+            echo "✅ Codex sandbox test passed"
+          else
+            echo "::error::Codex sandbox self-test failed"
+            exit 1
+          fi
 
-      - name: Setup bubblewrap and AppArmor for sandbox
+      - name: Synchronize project dependencies
         if: steps.context.outputs.authorized == 'true' && steps.context.outputs.supported_target == 'true'
         run: |
-          set -euo pipefail
-          
-          echo "::group::Installing bubblewrap and dependencies"
-          sudo apt-get update
-          sudo apt-get install -y bubblewrap uidmap apparmor-profiles apparmor-utils
-          echo "::endgroup::"
-          
-          echo "::group::Configuring AppArmor for bubblewrap"
-          # Install and load the bwrap AppArmor profile
-          PROFILE_SRC="/usr/share/apparmor/extra-profiles/bwrap-userns-restrict"
-          PROFILE_DST="/etc/apparmor.d/bwrap-userns-restrict"
-          
-          if [ ! -f "$PROFILE_SRC" ]; then
-            echo "::error::Required AppArmor profile source is missing: $PROFILE_SRC"
-            exit 1
-          fi
-          sudo install -m 0644 "$PROFILE_SRC" "$PROFILE_DST"
-          sudo apparmor_parser -r "$PROFILE_DST"
-          echo "✅ AppArmor profile loaded successfully"
-          
-          # Enable userns restrictions with bwrap exception
-          sudo tee /etc/sysctl.d/99-codex-apparmor-hardening.conf >/dev/null <<'EOF'
-          kernel.apparmor_restrict_unprivileged_userns=1
-          kernel.apparmor_restrict_unprivileged_unconfined=1
-          EOF
-          
-          sudo sysctl --system >/dev/null
-          echo "::endgroup::"
-          
-          echo "::group::Verifying installation"
-          # Verify bubblewrap is installed
-          bwrap --version
-          
-          # Test bubblewrap sandbox creation
-          if bwrap --ro-bind / / /bin/true 2>/dev/null; then
-            echo "✅ bubblewrap sandbox test passed"
-          else
-            echo "::error::Bubblewrap sandbox self-test failed"
-            exit 1
-          fi
-          
-          # Check AppArmor status
-          if sudo aa-status | grep -qE '(^|[[:space:]])bwrap($|[[:space:]])'; then
-            echo "✅ AppArmor profile is active for bwrap"
-          else
-            echo "::error::AppArmor profile is not active for bubblewrap"
-            exit 1
-          fi
-          echo "::endgroup::"
+          make init
+          npm --prefix app ci
 
       - name: Restore Codex ChatGPT auth
         if: steps.context.outputs.authorized == 'true' && steps.context.outputs.supported_target == 'true'

--- a/Dockerfile
+++ b/Dockerfile
@@ -237,22 +237,39 @@ FROM production AS production-spa
 # 开发环境（前端使用 npm run dev，可将本地 app/ 目录挂载进来实时开发）
 # 构建：docker build --target dev -t talebook/talebook:dev .
 # 使用：docker-compose -f dev.yml up
-FROM server AS dev
+FROM test AS dev
 ARG BUILD_COUNTRY=""
 ARG GIT_VERSION=""
 ARG TARGETARCH
 ARG TARGETVARIANT
+ARG CODEX_VERSION="0.144.6"
 
 USER root
 
-# Install Node.js 20
+# Install the common development and agent toolchain.
 RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        bubblewrap \
+        ca-certificates \
+        curl \
+        git \
+        jq \
+        uidmap && \
     if [ "$TARGETARCH" = "amd64" ] || [ "$TARGETARCH" = "arm64" ]; then \
         curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
         apt-get install -y nodejs; \
     fi && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=cache,target=/root/.npm \
+    npm install -g "@openai/codex@${CODEX_VERSION}" && \
+    node --version && \
+    npm --version && \
+    codex --version && \
+    python3 -m pytest --version && \
+    ruff --version && \
+    bwrap --version
 
 ENV TZ=Asia/Shanghai
 ENV LANG=C.UTF-8

--- a/design/project/20260721-agent-dev-container.active.html
+++ b/design/project/20260721-agent-dev-container.active.html
@@ -1,0 +1,314 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Claude 与 Codex 统一开发容器</title>
+  <style>
+    :root {
+      color-scheme: light;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", sans-serif;
+      color: #18202a;
+      background: #edf2f7;
+      line-height: 1.65;
+    }
+    * { box-sizing: border-box; }
+    body { max-width: 1120px; margin: 0 auto; padding: 32px 20px 72px; }
+    header, section {
+      background: #fff;
+      border: 1px solid #d8e1eb;
+      border-radius: 14px;
+      padding: 24px;
+      margin-bottom: 18px;
+      box-shadow: 0 7px 24px rgba(27, 45, 65, .055);
+    }
+    header { border-top: 5px solid #375f8c; }
+    h1 { margin: 0 0 8px; font-size: clamp(1.8rem, 4vw, 2.7rem); line-height: 1.2; }
+    h2 { margin: 0 0 14px; font-size: 1.35rem; }
+    h3 { margin: 22px 0 8px; font-size: 1.05rem; }
+    p, ul, ol { margin-top: 8px; }
+    code {
+      padding: 2px 6px;
+      border-radius: 5px;
+      background: #edf2f7;
+      overflow-wrap: anywhere;
+    }
+    .subtitle { color: #536477; margin: 0 0 20px; }
+    .meta { display: grid; grid-template-columns: repeat(auto-fit, minmax(190px, 1fr)); gap: 10px; }
+    .meta div { background: #edf4fb; border-radius: 9px; padding: 11px 13px; }
+    .status { color: #8b5600; font-weight: 750; }
+    .callout {
+      border-left: 4px solid #3f78ae;
+      background: #edf6ff;
+      padding: 12px 15px;
+      border-radius: 7px;
+    }
+    .warn { border-left-color: #b16b1b; background: #fff6e9; }
+    .ok { border-left-color: #28835a; background: #edf9f3; }
+    .table-wrap { overflow-x: auto; }
+    table { width: 100%; border-collapse: collapse; min-width: 700px; }
+    th, td { border: 1px solid #d8e1eb; padding: 10px; text-align: left; vertical-align: top; }
+    th { background: #edf4fb; color: #274765; }
+    figure { margin: 18px 0 8px; }
+    svg { width: 100%; height: auto; border: 1px solid #d8e1eb; border-radius: 11px; background: #f9fbfd; }
+    figcaption { margin-top: 8px; color: #607184; font-size: .92rem; }
+    .pending { color: #8b5600; font-weight: 750; }
+    .passed { color: #16723a; font-weight: 750; }
+    .small { color: #607184; font-size: .92rem; }
+    @media (max-width: 720px) {
+      body { padding: 18px 12px 48px; }
+      header, section { padding: 18px; }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Claude 与 Codex 统一开发容器</h1>
+    <p class="subtitle">维护统一的 <code>dev</code> 镜像，让两套 agent 在同一个可构建、可测试的 Docker job container 中工作</p>
+    <div class="meta">
+      <div><strong>创建日期</strong><br>2026-07-21</div>
+      <div><strong>所属模块</strong><br>project</div>
+      <div><strong>状态</strong><br><span class="status">ACTIVE</span></div>
+      <div><strong>需求来源</strong><br>维护者要求统一 Claude/Codex 开发与测试环境</div>
+      <div><strong>工作分支</strong><br><code>feat/20260721-agent-dev-container</code></div>
+      <div><strong>影响范围</strong><br>Dockerfile、Actions、tests</div>
+      <div><strong>官方调研</strong><br><code>document/claude-code-action-environment-research.md</code></div>
+    </div>
+  </header>
+
+  <section>
+    <h2>1. 原始诉求与已确认决策</h2>
+    <p>完整优化 <code>.github/workflows/claude.yml</code> 与 <code>.github/workflows/codex.yml</code>，使用仓库 <code>Dockerfile</code> 构建具备开发能力的镜像，让 Claude 与 Codex 的实际运行进程都位于该容器中，并保证容器能够完成前后端开发、lint、构建与测试。修改完成后必须使用本地 GitHub Actions 执行验证，全部通过后才允许提交和创建 Pull Request。</p>
+    <div class="callout ok">
+      <strong>已确认：</strong>沿用 <code>ci.yml</code> 的 job container 模式；只维护浮动标签 <code>talebook/talebook:dev</code>，不发布 commit SHA 标签。只有 <code>master</code> push 可以覆盖该镜像。实际文件名是 <code>claude.yml</code>，原始诉求中的 <code>claude.yaml</code> 视为同一文件。
+    </div>
+    <p>本次只改交互式 Claude workflow，不改变独立的 <code>claude-code-review.yml</code>。后者是 PR 自动审查入口，不属于原始诉求点名的两份 workflow；若未来也要迁移，应在本方案生效后另开变更，避免同时改变三条机器人链路。</p>
+  </section>
+
+  <section>
+    <h2>2. 当前问题</h2>
+    <div class="table-wrap">
+      <table>
+        <thead><tr><th>位置</th><th>当前行为</th><th>问题</th></tr></thead>
+        <tbody>
+          <tr><td><code>ci.yml</code></td><td>后端 job 使用 <code>talebook/talebook-base:latest</code></td><td>已证明 job container 能解决 Calibre/Python 系统依赖，但该 base 不含前端与 agent 工具。</td></tr>
+          <tr><td><code>Dockerfile dev</code></td><td>提供应用开发运行环境并安装 Node 与 app 依赖</td><td>仍缺 git、jq、pytest、ruff、bubblewrap、Codex CLI 等业务与 agent 工具；无法直接承担 Actions agent job。</td></tr>
+          <tr><td><code>claude.yml</code></td><td>运行于裸 <code>ubuntu-latest</code>，允许命令范围主要覆盖后端</td><td>业务环境与仓库 CI 不一致，不能稳定执行前端 lint/build/test；Claude Action 自身的运行时由 Action 管理，不等同于项目依赖。</td></tr>
+          <tr><td><code>codex.yml</code></td><td>运行时安装 Python 工具、Codex、bubblewrap、AppArmor 配置</td><td>每次重复安装，步骤长且依赖宿主状态；与本地开发镜像、常规 CI 环境产生漂移。</td></tr>
+          <tr><td>本地验收</td><td>单元测试和 actionlint 能检查静态契约</td><td>缺少用 <code>act</code> 真正在 job container 中执行完整工具链与项目命令的验收入口。</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section>
+    <h2>3. Anthropic 与 GitHub 官方调研结论</h2>
+    <div class="table-wrap">
+      <table>
+        <thead><tr><th>官方证据</th><th>结论</th><th>对本方案的影响</th></tr></thead>
+        <tbody>
+          <tr>
+            <td><a href="https://github.com/anthropics/claude-code-action/blob/main/action.yml">claude-code-action/action.yml</a></td>
+            <td><code>@v1</code> 是 composite action；默认在调用 job 中安装固定 Bun、安装 Action 自身依赖并启动 Claude。所有内部 run step 使用 bash。</td>
+            <td>使用 job container 后，Action 和它启动的 Claude 都在该容器中运行；dev 镜像必须有 bash、curl、CA 证书等基础能力，但无需替 Action 固定 Claude 版本。</td>
+          </tr>
+          <tr>
+            <td><a href="https://github.com/anthropics/claude-code-action/blob/main/docs/configuration.md#custom-tools">官方 Custom Tools 文档</a></td>
+            <td>业务命令不会被 Action 自动准备，也默认不能随意执行；仓库应先提供可执行环境，再用 <code>--allowedTools</code> 精确授权 npm、测试等命令。</td>
+            <td>Talebook 的 Python、Calibre、Node、lint/test 工具放进 dev 镜像；<code>claude.yml</code> 只负责授权已有命令。</td>
+          </tr>
+          <tr>
+            <td><a href="https://github.com/anthropics/claude-code-action/blob/main/action.yml#L1391-L1404">官方 custom executable inputs</a></td>
+            <td><code>path_to_claude_code_executable</code> 与 <code>path_to_bun_executable</code> 会跳过自动安装；官方警告旧版或不兼容版本可能失败，并说明通常只用于调试或特殊环境。</td>
+            <td>本方案不设置这两个输入，不把它们误作业务依赖机制；跟随 <code>@v1</code> 自己选择兼容运行时。</td>
+          </tr>
+          <tr>
+            <td><a href="https://github.com/anthropics/claude-code-action/blob/main/.github/workflows/test-custom-executables.yml">官方 custom executables 测试</a></td>
+            <td>若确需自定义路径，官方测试会先显式安装并验证 Bun/Claude，再把两个绝对路径同时传给 Action。</td>
+            <td>证明自定义路径是完整替换机制，不适合只在镜像里随意预装一个 Claude CLI；当前没有采用它的必要。</td>
+          </tr>
+          <tr>
+            <td><a href="https://docs.github.com/en/actions/how-tos/write-workflows/choose-where-workflows-run/run-jobs-in-a-container">GitHub job container 文档</a></td>
+            <td><code>jobs.&lt;job_id&gt;.container</code> 会让没有另行指定容器的 job steps 在目标容器中执行；容器内 run step 默认 shell 是 sh，可由 workflow 改成 bash。</td>
+            <td>这是让 composite Claude Action 使用 Talebook 业务环境的官方 GitHub 机制，与当前 <code>ci.yml</code> 一致。</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div class="callout">
+      <strong>仓库搜索结果：</strong>Anthropic 官方仓库没有提供 <code>container:</code> 或 <code>setup-python</code> 的现成示例，也没有“安装业务依赖”的 Action input。官方示例只通过 <code>--allowedTools</code> 开放 npm/bun 等命令，隐含前提是这些命令已存在于 runner。故 Talebook 应采用 GitHub 官方 job container 负责业务环境，同时保留 Claude Action 的默认运行时管理。
+    </div>
+  </section>
+
+  <section>
+    <h2>4. 目标与非目标</h2>
+    <h3>目标</h3>
+    <ul>
+      <li>同一个 <code>dev</code> target 提供 Calibre、Python 生产/测试依赖、Node/npm、常用开发命令、Codex CLI，以及 Claude Action 自动安装自身运行时所需的基础系统能力。</li>
+      <li><code>build.yml</code> 对 PR 构建该 target，只在 <code>master</code> push 时发布 <code>talebook/talebook:dev</code>。</li>
+      <li><code>claude.yml</code> 与 <code>codex.yml</code> 使用 <code>jobs.&lt;job&gt;.container.image</code> 消费同一个固定名称的开发镜像。</li>
+      <li>目标代码 checkout 仍可指向 issue/PR 的目标 SHA；提示模板与 workflow 资源继续来自不可变 workflow SHA，容器环境使用 master 最新成功发布的 dev 镜像。</li>
+      <li>Claude job 在 checkout 后按当前分支执行 <code>make init</code> 与 <code>npm ci</code>；镜像负责系统与语言基线，lockfile 同步负责目标分支依赖准确性。</li>
+      <li>本地使用 Docker 构建同名镜像，并通过 <code>act</code> 在该容器中真实执行工具检查、后端测试、前端 lint 与构建。</li>
+    </ul>
+    <h3>非目标</h3>
+    <ul>
+      <li>不改变 Claude/Codex 的触发语法、维护者授权规则、评论格式、Codex 发布门禁与 fast-forward push 规则。</li>
+      <li>不替换生产镜像，不把测试/agent 工具带入 production stages。</li>
+      <li>不让 agent 获得 Docker socket、宿主文件系统或特权容器权限。</li>
+      <li>不在 PR 阶段向 Docker Hub 推送镜像；PR 只验证 dev target 可构建。</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>5. 总体方案</h2>
+    <figure>
+      <svg viewBox="0 0 1040 470" role="img" aria-labelledby="arch-title arch-desc">
+        <title id="arch-title">开发镜像构建与消费架构</title>
+        <desc id="arch-desc">Dockerfile dev target 经 build workflow 构建并发布 dev 标签，Claude、Codex 和本地 act 使用同一镜像。</desc>
+        <defs>
+          <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto"><path d="M0,0 L0,6 L9,3 z" fill="#456f9d"/></marker>
+        </defs>
+        <g fill="#edf4fb" stroke="#456f9d" stroke-width="2">
+          <rect x="50" y="55" width="250" height="105" rx="12"/>
+          <rect x="395" y="55" width="250" height="105" rx="12"/>
+          <rect x="740" y="55" width="250" height="105" rx="12"/>
+        </g>
+        <g fill="#edf9f3" stroke="#28835a" stroke-width="2">
+          <rect x="95" y="280" width="230" height="110" rx="12"/>
+          <rect x="405" y="280" width="230" height="110" rx="12"/>
+          <rect x="715" y="280" width="230" height="110" rx="12"/>
+        </g>
+        <g fill="#18202a" text-anchor="middle" font-size="16">
+          <text x="175" y="88" font-weight="700">Dockerfile · dev</text>
+          <text x="175" y="116">后端 + 前端 + 测试</text>
+          <text x="175" y="140">业务工具 + Codex + bwrap</text>
+          <text x="520" y="88" font-weight="700">build.yml</text>
+          <text x="520" y="116">PR：只构建</text>
+          <text x="520" y="140">push：构建并发布</text>
+          <text x="865" y="88" font-weight="700">Docker Hub</text>
+          <text x="865" y="116">talebook/talebook</text>
+          <text x="865" y="140">talebook/talebook:dev</text>
+          <text x="210" y="315" font-weight="700">claude.yml</text>
+          <text x="210" y="344">Claude Action 调用</text>
+          <text x="210" y="368">Action 在镜像内运行</text>
+          <text x="520" y="315" font-weight="700">codex.yml</text>
+          <text x="520" y="344">直接调用镜像内 codex</text>
+          <text x="520" y="368">保留发布门禁</text>
+          <text x="830" y="315" font-weight="700">本地 act smoke</text>
+          <text x="830" y="344">同一镜像与 workflow</text>
+          <text x="830" y="368">真实运行开发/测试</text>
+        </g>
+        <g stroke="#456f9d" stroke-width="2.5" fill="none" marker-end="url(#arrow)">
+          <path d="M300 108H385"/><path d="M645 108H730"/>
+          <path d="M865 160V220H210V270"/><path d="M865 160V220H520V270"/><path d="M865 160V220H830V270"/>
+        </g>
+      </svg>
+      <figcaption>图 1：单一 Dockerfile 产出、master 维护一个 dev 标签、三条消费链路共享同一开发环境。</figcaption>
+    </figure>
+
+    <h3>4.1 Dockerfile</h3>
+    <ul>
+      <li><code>dev</code> 从 <code>test</code> stage 继承，使 pytest、ruff 等测试依赖天然存在；production 仍从 <code>server</code> 分叉，不受影响。</li>
+      <li>显式安装 git、jq、Node.js 20、bubblewrap、uidmap 等 Actions 与 agent 需要的用户态工具。</li>
+      <li>固定安装 Codex CLI <code>0.144.6</code>，版本由 Docker build arg 声明并在构建日志中验证；不预装 Claude/Bun，由 <code>claude-code-action@v1</code> 在 job container 内按其官方默认流程管理兼容版本。</li>
+      <li>保留现有应用开发能力、Nuxt 源码和 npm 依赖。镜像内的依赖服务于其自带应用副本，不能替代 Actions workspace 对当前 checkout 执行 lockfile 同步。</li>
+    </ul>
+
+    <h3>4.2 build.yml 与镜像生命周期</h3>
+    <ul>
+      <li>PR 的 linux/amd64 构建矩阵额外构建 <code>dev</code> target，不推送。</li>
+      <li>只有 <code>refs/heads/master</code> 的受信任 push 在 linux/amd64 构建并推送 <code>talebook/talebook:dev</code>；dev、claude、codex 等其他分支不得覆盖它。</li>
+      <li>镜像写入构建 commit 的 OCI revision label，并在构建日志中记录 digest，保留“当前 dev 来自哪个提交”的排查证据；标签本身按维护者决定保持浮动。</li>
+      <li>Claude/Codex 固定使用 <code>talebook/talebook:dev</code>，目标 PR 无法选择其他运行镜像。镜像拉取失败时 job 在 agent 启动前失败关闭，不回退到 base 或裸 runner。</li>
+    </ul>
+
+    <h3>4.3 Claude workflow</h3>
+    <ul>
+      <li>增加 <code>talebook/talebook:dev</code> job container，并把 run shell 统一为 bash。</li>
+      <li>checkout 后先探测 Calibre、Python、Node、make、pytest、ruff 等业务工具，再执行 <code>make init</code> 与 <code>npm --prefix app ci</code>；任何一步失败都不启动 Claude。</li>
+      <li>不设置 <code>path_to_claude_code_executable</code> 或 <code>path_to_bun_executable</code>；Action 的 composite steps 会在 dev 容器里完成自身运行时准备，避免与浮动 <code>@v1</code> 产生兼容性错配。</li>
+      <li>允许的开发命令覆盖仓库既有 Makefile、Python/ruff/pytest、npm/npx/node，继续依赖 Action 自身的权限控制，不额外开放宿主资源。</li>
+    </ul>
+
+    <h3>4.4 Codex workflow</h3>
+    <ul>
+      <li>增加同一个 <code>talebook/talebook:dev</code> job container，删除 setup-python、pip 安装、npm 全局安装与宿主 AppArmor 改写。</li>
+      <li>保留启动前的工具版本与 <code>codex sandbox -- /bin/true</code> 自检；开发镜像缺工具或 sandbox 无法创建时直接失败。</li>
+      <li>预检通过后执行 <code>make init</code> 与 <code>npm --prefix app ci</code>，使当前 checkout 的 lockfile 依赖在恢复模型凭据前就绪；不依赖镜像中其他路径的 <code>node_modules</code>。</li>
+      <li>容器仅增加 user namespace 所需的 <code>seccomp=unconfined</code>；本机已验证默认容器创建 user namespace 失败，加入该选项后成功。不得使用 <code>--privileged</code>、Docker socket 或 <code>danger-full-access</code>。</li>
+      <li>保留现有自定义 <code>codex-employee</code> 权限、凭据环境剥离、受信任 prompt/progress reporter、结构化结果门禁和受控发布流程。</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>6. 信任边界与失败策略</h2>
+    <div class="table-wrap">
+      <table>
+        <thead><tr><th>风险</th><th>控制</th><th>失败行为</th></tr></thead>
+        <tbody>
+          <tr><td>浮动 dev 标签改变内容</td><td>接受维护者指定的单一 dev 标签；仅 master 可发布，并记录 OCI revision 与 digest</td><td>拉取失败时 job 不启动；工具自检不通过时 agent 不运行</td></tr>
+          <tr><td>PR 修改 Dockerfile 注入工具</td><td>PR 只构建不推送；agent 固定使用 master 最近成功发布的 dev</td><td>未信任镜像不会被 agent workflow 消费</td></tr>
+          <tr><td>Codex 越出工作区</td><td>外层 job container + 内层 Codex workspace 权限 + bwrap</td><td>bwrap 自检失败则不运行 Codex</td></tr>
+          <tr><td>secret 泄漏给子命令</td><td>延续 Codex shell environment 排除规则；Claude 继续由官方 Action 管理 token</td><td>认证缺失或格式错误时快速失败</td></tr>
+          <tr><td>目标分支依赖变更</td><td>镜像提供编译器/运行时；Claude 与 Codex job 都在模型凭据可用前按当前 checkout 的 lockfile 同步依赖</td><td>依赖安装失败时不启动 agent</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section>
+    <h2>7. 本地 GitHub Actions 验收</h2>
+    <p>新增一个只负责环境验收的 workflow，生产 agent workflow 与本地 smoke workflow 共享相同的镜像表达式。它不接收 agent 凭据、不发布代码，适合 <code>act</code> 真实执行。</p>
+    <ol>
+      <li>本地构建 <code>talebook/talebook:dev</code>，覆盖本机同名测试镜像但不推送。</li>
+      <li>用 <code>act workflow_dispatch</code> 启动 smoke workflow，禁止拉取同名远端镜像，确保使用刚构建的本地镜像。</li>
+      <li>容器内验证 bash、curl、git、jq、Node/npm、Python/pip、make、ruff、pytest、Codex、bubblewrap；Claude/Bun 由 Action 自己安装，不作为业务镜像预装工具断言。</li>
+      <li>容器内先执行与 Claude job 相同的 <code>make init</code> 和前端 <code>npm ci</code>，再运行设计检查、Python lint、完整后端 pytest、前端 lint 与 Nuxt build。</li>
+      <li>使用 actionlint 和 workflow 契约测试覆盖 <code>claude.yml</code>、<code>codex.yml</code>、<code>build.yml</code> 及 smoke workflow。</li>
+    </ol>
+    <div class="callout warn">
+      <strong>边界：</strong>本地验收不调用真实 Claude/OpenAI API，不向 GitHub 写评论或推送分支，避免消耗凭据和制造外部副作用。两套真实 agent workflow 的认证/API 阶段由精确契约测试覆盖；共同的容器、工具和项目开发测试由 <code>act</code> 实际运行覆盖。
+    </div>
+  </section>
+
+  <section>
+    <h2>8. 测试计划与结果</h2>
+    <div class="table-wrap">
+      <table>
+        <thead><tr><th>验证项</th><th>计划命令或证据</th><th>当前结果</th></tr></thead>
+        <tbody>
+          <tr><td>Dockerfile / Workflow 契约</td><td><code>python3 -m pytest -q tests/test_agent_workflows.py tests/test_codex_workflow.py tests/test_docker_stages.py</code></td><td class="passed">通过：36 passed，1 skipped</td></tr>
+          <tr><td>Claude 官方契约</td><td>检查不使用 custom executable inputs，且 checkout、环境探测、lockfile 同步均位于 Claude Action 之前</td><td class="passed">通过；官方 Action runtime 与业务依赖职责已分离</td></tr>
+          <tr><td>Actions 静态检查</td><td><code>actionlint v1.7.12</code> 检查四份修改/新增 workflow</td><td class="passed">通过：无诊断</td></tr>
+          <tr><td>开发镜像构建</td><td><code>make build-dev</code></td><td class="passed">通过：本地 arm64 镜像 <code>sha256:fbf5a21625fa…</code></td></tr>
+          <tr><td>容器工具与 sandbox</td><td>版本检查及 <code>codex sandbox -- /bin/true</code></td><td class="passed">通过：Calibre 8.5.0、Node 20.20.2、Codex 0.144.6、pytest、ruff、git、jq、bubblewrap 均可用</td></tr>
+          <tr><td>本地 GitHub Actions</td><td><code>go run github.com/nektos/act@v0.2.89 workflow_dispatch -W .github/workflows/agent-dev-smoke.yml --pull=false --container-architecture linux/arm64</code></td><td class="passed">通过：本地 dev 镜像完整 job succeeded，未传模型凭据</td></tr>
+          <tr><td>后端</td><td><code>make lint-py-fix</code>；smoke 中执行 <code>make lint-py</code> 与 <code>make pytest</code></td><td class="passed">通过：96 files unchanged；完整 pytest 通过</td></tr>
+          <tr><td>前端</td><td>smoke 中执行 <code>npm --prefix app ci</code>、lint、Nuxt build</td><td class="passed">通过；构建完成</td></tr>
+          <tr><td>完整 Docker 测试</td><td><code>make test</code></td><td class="passed">通过：646 passed，2 skipped，32 warnings</td></tr>
+          <tr><td>设计门禁</td><td><code>make check-design</code>，激活后确认无 WIP</td><td class="passed">通过：43 design document(s) passed</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section>
+    <h2>9. 发布、回滚与实施顺序</h2>
+    <ol>
+      <li>先以测试驱动更新契约，再修改 Dockerfile、build workflow 与两套 agent workflow。</li>
+      <li>完成本地 Docker + act + 项目测试；失败时保持 WIP，不提交、不创建 PR。</li>
+      <li>验证全部通过后回写本页真实命令、结果与限制，将文件改为 <code>.active.html</code>。</li>
+      <li>提交功能分支、推送并创建 PR；PR 构建验证 dev target，但不发布镜像。</li>
+      <li>合并到 master 后，build workflow 覆盖发布 <code>talebook/talebook:dev</code>；发布完成前，新 workflow 可能暂时消费旧 dev 并在工具自检处失败，禁止静默回退。</li>
+    </ol>
+    <p>回滚时从最后一个已知正常的 master 提交重新构建并覆盖 <code>talebook/talebook:dev</code>，或回退相关 master 提交后让 build workflow 重新发布。不得从未信任分支手工覆盖 dev；回滚完成后重新运行工具自检与本地 smoke。</p>
+  </section>
+
+  <section>
+    <h2>10. 审查门</h2>
+    <p class="status">本方案已完成实现与项目验证，状态为 ACTIVE；最终提交与 Pull Request 仍以本地 act 全绿为门禁。</p>
+    <p class="small">验证期间发现既有异步扫描测试以队列为空误判任务完成；已改为按数据库状态轮询并显式刷新 session。隔离测试、完整 Docker 测试和 act 全套后端测试均验证该修正。</p>
+  </section>
+</body>
+</html>

--- a/document/claude-code-action-environment-research.md
+++ b/document/claude-code-action-environment-research.md
@@ -1,0 +1,246 @@
+# Claude Code Action v1 的业务环境依赖调研
+
+- 调研日期：2026-07-21
+- 调研对象：`anthropics/claude-code-action@v1`
+- 官方仓库基准：[`b76a0776ae74036e77cd11018083743453d7ad35`](https://github.com/anthropics/claude-code-action/tree/b76a0776ae74036e77cd11018083743453d7ad35)
+- 来源范围：Anthropic 官方仓库的 README、文档、示例和 Action 元数据，以及 GitHub Actions 官方文档。本文未用第三方博客作为依据，也未用 Issue/Discussion 推导主结论。
+
+## 结论摘要
+
+1. `anthropics/claude-code-action@v1` **不会准备业务项目的 Python、Node.js、Calibre、编译器或项目依赖**。它负责的是自身运行：安装或选择 Bun、安装 Action 自己的 production dependencies，并启动 Claude Code。官方元数据明确显示它是一个 **composite action**，其 `Install Dependencies` 在 `${GITHUB_ACTION_PATH}` 中执行，而不是在业务仓库中安装依赖。[Action 元数据，第 186–212 行](https://github.com/anthropics/claude-code-action/blob/b76a0776ae74036e77cd11018083743453d7ad35/action.yml#L186-L212)
+2. Anthropic 官方没有宣称“业务依赖必须用 setup/install”或“必须用 job container”。官方入门示例只使用 `ubuntu-latest`，checkout 后直接调用 Action；它仅示范通过 `--allowedTools` 授权 Claude 执行 `npm install`、build、test、lint，并没有准备 Python、Node 或系统包。[官方 `examples/claude.yml`，第 20–50 行](https://github.com/anthropics/claude-code-action/blob/b76a0776ae74036e77cd11018083743453d7ad35/examples/claude.yml#L20-L50)
+3. 在普通 GitHub-hosted runner 上，GitHub 官方推荐用 `actions/setup-python` / `actions/setup-node` 固定语言版本，再用 `pip` / `npm ci` 安装业务依赖。[GitHub：构建和测试 Python](https://docs.github.com/en/actions/how-tos/use-cases-and-examples/building-and-testing/building-and-testing-python)、[GitHub：构建和测试 Node.js](https://docs.github.com/en/actions/tutorials/build-and-test-code/nodejs)
+4. 对包含 Calibre 和较多系统依赖的 Talebook，使用 `jobs.<job_id>.container.image: talebook/talebook:dev` 提供统一开发环境是合理且受 GitHub 官方支持的选择。GitHub 明确说明，job container 会运行该 job 中所有未另行声明容器的步骤；Docker container action 才会作为 sibling container 运行。[GitHub：在容器中运行 job](https://docs.github.com/en/actions/how-tos/write-workflows/choose-where-workflows-run/run-jobs-in-a-container)
+5. `path_to_claude_code_executable` 和 `path_to_bun_executable` **只替换 Action 自己使用的 Claude Code / Bun 可执行文件**，不是业务依赖入口。默认不要为了安装 Talebook 依赖而设置它们。[Action 元数据，第 144–151 行](https://github.com/anthropics/claude-code-action/blob/b76a0776ae74036e77cd11018083743453d7ad35/action.yml#L144-L151)
+
+## 1. 官方如何划分 Action 运行时和业务运行时
+
+### Action 自己负责的内容
+
+当前 v1 的 `action.yml` 声明 `runs.using: composite`，随后：
+
+- 没有传 `path_to_bun_executable` 时，调用固定提交的 `oven-sh/setup-bun` 安装指定 Bun 版本；
+- 有自定义 Bun 路径时，把它所在目录写入 `GITHUB_PATH`；
+- 在 `${GITHUB_ACTION_PATH}` 中执行 `bun install --production`，安装的是 **Claude Code Action 自身依赖**；
+- composite action 的多个执行步骤显式使用 `shell: bash`。
+
+以上均可从 [Action 元数据，第 186–212 行](https://github.com/anthropics/claude-code-action/blob/b76a0776ae74036e77cd11018083743453d7ad35/action.yml#L186-L212) 直接核对。
+
+因此，日志中的 `Install Dependencies` 不能理解成“安装 Talebook 的 `requirements.txt` 或 `app/package-lock.json`”。它的工作目录是 Action 下载目录，不是 `${GITHUB_WORKSPACE}`。
+
+### 业务仓库需要自己负责的内容
+
+Anthropic 的高级配置文档明确说，Claude 默认不能执行任意 Bash；若希望它运行 `npm install` 或 `npm run test`，必须通过 `claude_args` 显式授权。[官方配置文档，第 223–244 行](https://github.com/anthropics/claude-code-action/blob/b76a0776ae74036e77cd11018083743453d7ad35/docs/configuration.md#L223-L244)
+
+这说明“命令是否可调用”和“命令及依赖是否已存在”是两件事：
+
+- `--allowedTools` 解决权限问题；
+- workflow 的 setup/install 步骤或 job container 解决环境问题；
+- `settings.env` 只传递测试所需环境变量，例如 `NODE_ENV`、`CI`、`DATABASE_URL`，也不会安装软件。[官方配置文档，第 184–202 行](https://github.com/anthropics/claude-code-action/blob/b76a0776ae74036e77cd11018083743453d7ad35/docs/configuration.md#L184-L202)
+
+## 2. 官方推荐前置 setup/install，还是 job container
+
+### Anthropic 官方仓库没有二选一结论
+
+Anthropic 提供的基础示例是：
+
+```yaml
+runs-on: ubuntu-latest
+steps:
+  - uses: actions/checkout@v6
+  - uses: anthropics/claude-code-action@v1
+```
+
+示例只在注释中展示 `--allowedTools "Bash(npm install),..."`，没有 `setup-python`、`setup-node`、`pip install`、`npm ci` 或 job container。[官方 `examples/claude.yml`，第 20–50 行](https://github.com/anthropics/claude-code-action/blob/b76a0776ae74036e77cd11018083743453d7ad35/examples/claude.yml#L20-L50)
+
+进一步核对该固定提交的 [整个官方 `examples/` 目录](https://github.com/anthropics/claude-code-action/tree/b76a0776ae74036e77cd11018083743453d7ad35/examples) 后，11 个顶层 workflow 示例中没有 `jobs.<job_id>.container` / `container:` 示例。也就是说，**Anthropic 官方文档支持“自定义容器环境”这一用例，但没有提供可直接复制的 job container workflow**；job container 的正确性依据来自 GitHub Actions 官方规范，而不是 Anthropic 示例。
+
+另一个官方 CI 自动修复示例也只是允许 `Bash(bun:*)`、`Bash(npm:*)`、`Bash(npx:*)`，没有替业务仓库建立语言或系统环境。[官方 `ci-failure-auto-fix.yml`，第 101–117 行](https://github.com/anthropics/claude-code-action/blob/b76a0776ae74036e77cd11018083743453d7ad35/examples/ci-failure-auto-fix.yml#L101-L117)
+
+所以不能说 Anthropic 官方“推荐项目在 Claude Action 前安装全部依赖”，也不能说 Anthropic 官方“推荐 job container”。准确说法是：**Action 使用调用方提供的 runner/job 环境，项目自行选择环境准备方式。**
+
+### GitHub 官方对一般项目的建议
+
+GitHub 对 GitHub-hosted runner 的语言项目给出的标准做法是：
+
+- Python：使用 `actions/setup-python` 固定 Python/PyPy 版本，然后用 pip 安装依赖；
+- Node.js：使用 `actions/setup-node` 固定 Node 版本，然后执行 `npm ci`；
+- 自托管 runner 则需要自行安装语言运行时并加入 `PATH`。
+
+来源：[GitHub：构建和测试 Python](https://docs.github.com/en/actions/how-tos/use-cases-and-examples/building-and-testing/building-and-testing-python)、[GitHub：构建和测试 Node.js](https://docs.github.com/en/actions/tutorials/build-and-test-code/nodejs)。
+
+### 复杂系统依赖适合 job container
+
+GitHub 同时正式支持 `jobs.<job_id>.container`：job 中未单独声明容器的步骤都在指定镜像内运行，镜像可以来自 Docker Hub 或其他 registry。[GitHub：在容器中运行 job](https://docs.github.com/en/actions/how-tos/write-workflows/choose-where-workflows-run/run-jobs-in-a-container)
+
+因此选择标准应是：
+
+| 场景 | 更合适的方式 |
+| --- | --- |
+| 仅需标准 Python 或 Node 版本 | `setup-python` / `setup-node` + lockfile 安装 |
+| 依赖 Calibre、系统动态库、编译工具等复杂环境 | 维护项目 dev 镜像，作为 job container |
+| 自托管 runner 已统一预装环境 | 使用 runner 环境，并在 workflow 中做版本探测 |
+| 只需替换 Claude/Bun 自身安装方式 | `path_to_claude_code_executable` / `path_to_bun_executable` |
+
+Talebook 明显属于第二类；现有 `ci.yml` 已通过 `talebook/talebook-base:latest` 解决 Calibre 等依赖，这一模式可以直接推广到 Claude/Codex job。
+
+## 3. job container 是否兼容 Claude Code Action
+
+### 结论：兼容，但需满足镜像契约
+
+首先需要纠正一个表述：当前 `anthropics/claude-code-action@v1` 顶层不是单一 JavaScript Action，而是 composite action。[Action 元数据，第 186–188 行](https://github.com/anthropics/claude-code-action/blob/b76a0776ae74036e77cd11018083743453d7ad35/action.yml#L186-L188)
+
+GitHub 官方规定，配置 job container 后，该 job 中所有没有自行声明 container 的步骤都在 job container 运行；若某一步本身是 Docker container action，它才会在同网络、同 volume mounts 的 sibling container 中运行。[GitHub：在容器中运行 job](https://docs.github.com/en/actions/how-tos/write-workflows/choose-where-workflows-run/run-jobs-in-a-container)
+
+所以 checkout、Claude composite action 的 Bash 步骤、Action 启动的 Claude Code 进程，以及 Claude 获准执行的 `make` / `npm` / `pytest` 命令都会位于 Talebook job container 中。
+
+镜像至少应满足以下契约：
+
+- Linux 镜像；
+- `bash`，因为 Action 的多个 composite run step 显式指定 `shell: bash`；
+- `git`、`curl`、CA certificates 和常用 coreutils；
+- 可写的 workspace、`HOME`、`RUNNER_TEMP` 和 GitHub file-command 目录；
+- 推荐 Debian/Ubuntu/glibc 基线，避免 Alpine/musl 对第三方 Action 和原生可执行文件造成额外兼容风险；
+- 若以非 root 用户运行，需要验证 checkout、`GITHUB_PATH`、Action 安装目录及缓存目录权限。Talebook 当前 `ci.yml` 的 `options: --user root` 是更简单、已验证过的基线；
+- job 内自行编写的 `run` 步骤默认 shell 是 `sh`，GitHub 官方建议按需覆盖；Talebook 可设置 `defaults.run.shell: bash`。[GitHub：在容器中运行 job](https://docs.github.com/en/actions/how-tos/write-workflows/choose-where-workflows-run/run-jobs-in-a-container)
+
+这些属于镜像兼容性要求，不需要给容器 `--privileged`。Claude Action 的常规运行与 Docker-in-Docker 无关。
+
+## 4. 两个 `path_to_*` 输入到底解决什么
+
+### `path_to_claude_code_executable`
+
+它提供自定义 Claude Code 可执行文件路径，并跳过 Action 的自动安装。官方同时警告旧版本可能与 Action 后续使用的新 Claude Code 特性不兼容。[Action 元数据，第 144–147 行](https://github.com/anthropics/claude-code-action/blob/b76a0776ae74036e77cd11018083743453d7ad35/action.yml#L144-L147)
+
+### `path_to_bun_executable`
+
+它提供自定义 Bun 路径，并跳过默认 Bun 安装。官方警告不兼容 Bun 版本可能导致 Action 失败。[Action 元数据，第 148–151 行](https://github.com/anthropics/claude-code-action/blob/b76a0776ae74036e77cd11018083743453d7ad35/action.yml#L148-L151)
+
+官方高级配置把两者定位为 Nix、自定义容器或特殊包管理环境中默认安装不可用时的替代入口，并再次要求版本兼容。[官方配置文档，第 352–378 行](https://github.com/anthropics/claude-code-action/blob/b76a0776ae74036e77cd11018083743453d7ad35/docs/configuration.md#L352-L378)
+
+它们不负责：
+
+- 安装 Calibre；
+- 安装 Talebook 的 `requirements.txt` / `requirements-test.txt`；
+- 安装 `app/package-lock.json` 对应的 `node_modules`；
+- 安装 `make`、ruff、pytest 或浏览器；
+- 授权 Claude 执行业务命令。
+
+对 Talebook 的默认建议是 **不设置这两个输入**，让 `@v1` 使用其配套的 Bun/Claude Code 版本；dev 镜像专注提供业务开发环境。只有在网络受限、确实要离线运行，或已经建立 Action 与 CLI 版本联动测试时，才把 Bun/Claude Code 烘进镜像并传入路径。
+
+## 5. 官方示例是否包含 Python、Node 或自定义工具准备
+
+截至本次固定提交，结论如下：
+
+| 项目 | 官方示例情况 | 含义 |
+| --- | --- | --- |
+| Node 项目依赖 | 示例仅展示允许 `npm install` / build / test / lint，没有 `setup-node` 或 `npm ci` 前置步骤 | 调用方自己准备；授权不等于安装 |
+| Python 项目依赖 | 没有通用 `setup-python` / `pip install -r ...` 示例 | 调用方自己准备 |
+| Python MCP | 有 `uv --directory ... run server_file.py` 配置示例，但没有安装 `uv` 或业务依赖 | 文档假设 `uv` 已在调用环境中，[官方配置文档，第 49–87 行](https://github.com/anthropics/claude-code-action/blob/b76a0776ae74036e77cd11018083743453d7ad35/docs/configuration.md#L49-L87) |
+| Node MCP | 有 `npx` 命令示例，但没有为业务项目建立 Node 环境 | 文档假设相关命令可用，[官方配置文档，第 7–17 行](https://github.com/anthropics/claude-code-action/blob/b76a0776ae74036e77cd11018083743453d7ad35/docs/configuration.md#L7-L17) |
+| Action 自身依赖 | Action 会安装自己的 Bun 和 `${GITHUB_ACTION_PATH}` production dependencies | 与业务仓库依赖严格分开 |
+| 自定义工具权限 | 必须通过 `--allowedTools` 精确授权 | 工具要先存在于 job 环境中 |
+
+## 6. 对 Talebook 的建议
+
+### 推荐结构
+
+继续采用用户已确认的单一 mutable tag：`talebook/talebook:dev`，不引入 dev-SHA 标签。Claude job 使用与现有 `ci.yml` 相同的 job container 模式：
+
+```yaml
+jobs:
+  claude:
+    runs-on: ubuntu-latest
+    container:
+      image: talebook/talebook:dev
+      options: --user root
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify development environment
+        run: |
+          command -v ebook-convert
+          command -v python3
+          command -v npm
+          command -v make
+          ebook-convert --version
+          python3 --version
+          node --version
+
+      - name: Synchronize checkout dependencies
+        run: |
+          make init
+          cd app
+          npm ci
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: |
+            --allowedTools "Bash(make init),Bash(make lint-py),Bash(make lint-py-fix),Bash(make pytest),Bash(npm ci),Bash(npm run lint),Bash(npm run test:*),Bash(npm run build)"
+```
+
+以上是结构示意，最终权限应结合 Talebook 实际命令做最小化整理。官方 v1 文档采用 `--allowedTools` 拼写；迁移表也明确把旧 `allowed_tools` 迁移到 `claude_args: --allowedTools ...`。[官方配置文档，第 336–350 行](https://github.com/anthropics/claude-code-action/blob/b76a0776ae74036e77cd11018083743453d7ad35/docs/configuration.md#L336-L350)
+
+### dev 镜像负责什么
+
+`talebook/talebook:dev` 应至少包含：
+
+- 与后端测试一致的 Calibre 和系统动态库；
+- Python、pip、后端生产与测试依赖；
+- Node.js 20、npm，以及前端 native package 构建所需系统包；
+- git、bash、curl、CA certificates、make、常用诊断工具；
+- ruff、pytest 等仓库规定的开发测试工具。
+
+但要区分“镜像里的预装依赖”和“当前 checkout 的依赖”：GitHub 会把当前仓库 checkout 到工作空间，镜像构建时位于 `/var/www/talebook/app/node_modules` 的内容不会自动变成当前 `${GITHUB_WORKSPACE}/app/node_modules`。为覆盖 PR 修改 lockfile 的场景，仍应在 checkout 后执行 `make init` 和 `npm ci`，或者实现一个经过验证的 workspace dependency seed/copy 机制。前者更简单可靠，也与 GitHub 官方标准流程一致。
+
+dev 镜像的主要价值是消除 Calibre、系统库、编译工具和语言运行时的重复准备；checkout 后的 lockfile 同步负责保证当前分支依赖准确。
+
+### 不建议用 `path_to_*` 解决 Talebook 依赖
+
+建议先让 Claude Action 在 job container 内自行安装它匹配的 Bun/Claude Code，不传 `path_to_*`。这样仍然满足“Claude 运行在 dev container 内”，因为安装和执行都发生在 job container 中；同时避免 mutable `:dev` 镜像中的 Claude/Bun 版本与未来 `@v1` 不匹配。
+
+## 7. 风险与验证重点
+
+### mutable `:dev` 的漂移
+
+`talebook/talebook:dev` 会随 master 更新，同一 workflow 文件在不同时间可能得到不同镜像。用户已明确接受只维护 latest；建议每次 job 输出镜像内的构建版本、Python/Node/Calibre 版本，并在发布 `:dev` 前执行完整 smoke workflow。若 registry 能获得 digest，也应记录在日志中用于追溯。
+
+### Action 与镜像的兼容
+
+- Action 依赖 Bash；镜像缺 Bash 会直接失败。
+- 默认 Bun/Claude 安装需要网络、curl 和可信 CA。
+- 若传 `path_to_*`，版本兼容责任转移给 Talebook 镜像维护者；官方明确警告不兼容版本会失败。
+- 非 root 用户可能碰到 checkout、工具缓存或 `$HOME` 写权限问题；需要真实 GitHub Actions / `act` 测试覆盖。
+
+### 项目依赖与镜像内容不一致
+
+只在镜像构建时跑一次 `npm ci`，不能覆盖 PR 修改 `package-lock.json` 的情况。checkout 后同步依赖是必要的正确性门禁，而不是重复劳动。
+
+### Bash 权限和供应链安全
+
+Anthropic 官方说明 Bash 默认禁用，应只开放必需命令。[官方配置文档，第 223–244 行](https://github.com/anthropics/claude-code-action/blob/b76a0776ae74036e77cd11018083743453d7ad35/docs/configuration.md#L223-L244) 容器提供环境隔离，但不能抵消 prompt injection 或不可信分支在带 secrets job 中执行代码的风险。Anthropic 官方安全文档特别警告 `pull_request_target` / `workflow_run` checkout 不可信 head 到 workspace root 的风险，并建议最小权限与安全 checkout 模式。[官方安全文档](https://github.com/anthropics/claude-code-action/blob/b76a0776ae74036e77cd11018083743453d7ad35/docs/security.md)
+
+### 本地 `act` 不是唯一兼容性证明
+
+`act` 能证明 workflow 结构、镜像依赖和大部分 Action 运行链路，但它不是 GitHub-hosted runner 的完全等价实现。最终应至少覆盖：
+
+1. 本地构建 `talebook/talebook:dev`；
+2. 用 `act` 在 job container 内运行环境探测、checkout、依赖同步和测试；
+3. 用可控的假 prompt / 最小认证路径验证 Claude Action 启动到预期阶段；
+4. 合并后观察一次真实 GitHub Actions 运行，确认 token、file commands、HOME、网络和 artifact 行为。
+
+## 最终判断
+
+`claude.yml` 完全可以像现有 `ci.yml` 一样使用：
+
+```yaml
+container:
+  image: talebook/talebook:dev
+  options: --user root
+```
+
+这比在 Claude workflow 中重复安装 Calibre 和各种系统依赖更适合 Talebook。需要保留的前置步骤不是重新搭建系统环境，而是 checkout 后对当前分支执行 lockfile 驱动的依赖同步与环境 smoke check。`anthropics/claude-code-action@v1` 继续负责自身 Bun/Claude 运行时，`talebook/talebook:dev` 负责业务开发环境，两者职责清晰且与官方行为一致。

--- a/tests/test_agent_workflows.py
+++ b/tests/test_agent_workflows.py
@@ -1,0 +1,107 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def workflow(name):
+    with (ROOT / ".github" / "workflows" / name).open(encoding="utf-8") as file:
+        return yaml.safe_load(file)
+
+
+def workflow_step(job, name):
+    for step in job["steps"]:
+        if step.get("name") == name:
+            return step
+    raise AssertionError(f"workflow step not found: {name}")
+
+
+def test_build_workflow_only_publishes_the_validated_dev_image_from_master():
+    build_job = workflow("build.yml")["jobs"]["build"]
+    step = workflow_step(build_job, "Build development image")
+
+    assert step["if"] == (
+        "matrix.platform == 'linux/amd64' && "
+        "(github.event_name == 'pull_request' || github.ref == 'refs/heads/master')"
+    )
+    assert step["uses"] == "docker/build-push-action@v5"
+    assert step["with"]["target"] == "dev"
+    assert step["with"]["platforms"] == "linux/amd64"
+    assert step["with"]["push"] == "${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}"
+    assert step["with"]["tags"] == "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev"
+    assert step["with"]["labels"] == "org.opencontainers.image.revision=${{ github.sha }}"
+
+
+def test_claude_action_uses_the_dev_container_and_prepares_current_checkout():
+    claude_job = workflow("claude.yml")["jobs"]["claude"]
+    steps = claude_job["steps"]
+    verify = workflow_step(claude_job, "Verify development environment")
+    synchronize = workflow_step(claude_job, "Synchronize project dependencies")
+    run_claude = workflow_step(claude_job, "Run Claude Code")
+
+    assert claude_job["container"] == {"image": "talebook/talebook:dev", "options": "--user root"}
+    assert claude_job["defaults"] == {"run": {"shell": "bash"}}
+    assert all(
+        probe in verify["run"]
+        for probe in (
+            "ebook-convert --version",
+            "python3 --version",
+            "node --version",
+            "npm --version",
+            "make --version",
+            "python3 -m pytest --version",
+            "ruff --version",
+        )
+    )
+    assert synchronize["run"] == "make init\nnpm --prefix app ci\n"
+    assert steps.index(verify) < steps.index(synchronize) < steps.index(run_claude)
+
+    action_inputs = run_claude["with"]
+    assert "path_to_claude_code_executable" not in action_inputs
+    assert "path_to_bun_executable" not in action_inputs
+    assert "--allowedTools" in action_inputs["claude_args"]
+    assert all(
+        command in action_inputs["claude_args"]
+        for command in (
+            "Bash(make:*)",
+            "Bash(npm:*)",
+            "Bash(npx:*)",
+            "Bash(node:*)",
+            "Bash(python3:*)",
+            "Bash(pytest:*)",
+            "Bash(ruff:*)",
+        )
+    )
+
+
+def test_agent_dev_smoke_exercises_the_shared_container_without_model_credentials():
+    smoke = workflow("agent-dev-smoke.yml")
+    job = smoke["jobs"]["smoke"]
+    steps = job["steps"]
+    verify = workflow_step(job, "Verify development environment and sandbox")
+    synchronize = workflow_step(job, "Synchronize project dependencies")
+    validate = workflow_step(job, "Run development checks")
+
+    assert list(smoke["on"]) == ["workflow_dispatch"]
+    assert job["container"] == {
+        "image": "talebook/talebook:dev",
+        "options": "--user root --security-opt seccomp=unconfined",
+    }
+    assert job["defaults"] == {"run": {"shell": "bash"}}
+    assert "codex sandbox -- /bin/true" in verify["run"]
+    assert synchronize["run"] == "make init\nnpm --prefix app ci\n"
+    assert all(
+        command in validate["run"]
+        for command in (
+            "make lint-py",
+            "make pytest",
+            "make check-design",
+            "npm --prefix app run lint",
+            "npm --prefix app run build",
+        )
+    )
+    assert steps.index(verify) < steps.index(synchronize) < steps.index(validate)
+    assert "CLAUDE_CODE_OAUTH_TOKEN" not in str(smoke)
+    assert "CODEX_AUTH_JSON" not in str(smoke)

--- a/tests/test_codex_workflow.py
+++ b/tests/test_codex_workflow.py
@@ -119,28 +119,47 @@ def test_employee_job_is_bounded_and_serialized_per_request_target():
     }
 
 
-def test_codex_runtime_installs_declared_test_tools_before_agent_execution():
+def test_codex_runs_in_the_dev_container_without_runtime_install_steps():
+    job = codex_job()
     steps = codex_job()["steps"]
     checkout = workflow_step(name="Checkout repository")
-    setup_python = workflow_step(name="Setup Python for Codex validation")
-    install_tools = workflow_step(name="Install Codex test tools")
+    verify = workflow_step(name="Verify development environment and sandbox")
+    synchronize = workflow_step(name="Synchronize project dependencies")
+    restore_auth = workflow_step(name="Restore Codex ChatGPT auth")
     run_codex = workflow_step(name="Run Codex")
-    context_script = workflow_step(step_id="context")["with"]["script"]
 
-    assert "const codexTestRequirements = `${runnerTemp}/codex-requirements-test.txt`;" in context_script
-    assert 'core.exportVariable("CODEX_TEST_REQUIREMENTS", codexTestRequirements);' in context_script
-    assert 'path: "requirements-test.txt"' in context_script
-    assert "ref: workflowSha" in context_script
-
-    assert setup_python["uses"] == "actions/setup-python@v5"
-    assert setup_python["with"] == {"python-version": "3.13"}
-
-    install_script = install_tools["run"]
-    assert 'python3 -m pip install --disable-pip-version-check -r "$CODEX_TEST_REQUIREMENTS"' in install_script
-    assert "-r requirements-test.txt" not in install_script
-    assert "ruff --version" in install_script
-    assert "python3 -m pytest --version" in install_script
-    assert steps.index(checkout) < steps.index(setup_python) < steps.index(install_tools) < steps.index(run_codex)
+    assert job["container"] == {
+        "image": "talebook/talebook:dev",
+        "options": "--user root --security-opt seccomp=unconfined",
+    }
+    assert job["defaults"] == {"run": {"shell": "bash"}}
+    assert "CODEX_VERSION" not in job["env"]
+    assert all(
+        probe in verify["run"]
+        for probe in (
+            "ebook-convert --version",
+            "python3 --version",
+            "node --version",
+            "npm --version",
+            "make --version",
+            "python3 -m pytest --version",
+            "ruff --version",
+            "codex --version",
+            "bwrap --version",
+        )
+    )
+    assert all(
+        name not in [step.get("name") for step in steps]
+        for name in (
+            "Setup Python for Codex validation",
+            "Install Codex test tools",
+            "Install Codex CLI",
+            "Setup bubblewrap and AppArmor for sandbox",
+        )
+    )
+    assert synchronize["run"] == "make init\nnpm --prefix app ci\n"
+    assert steps.index(checkout) < steps.index(verify) < steps.index(synchronize) < steps.index(restore_auth)
+    assert steps.index(restore_auth) < steps.index(run_codex)
 
 
 def test_only_repository_writers_can_trigger_the_employee():
@@ -190,15 +209,16 @@ def test_agent_has_public_network_but_cannot_read_host_credentials():
 
 
 def test_sandbox_setup_fails_closed_before_codex_runs():
-    setup_script = workflow_step(name="Setup bubblewrap and AppArmor for sandbox")["run"]
+    setup_script = workflow_step(name="Verify development environment and sandbox")["run"]
     step_names = [step.get("name") for step in codex_job()["steps"]]
 
     assert "continuing" not in setup_script
-    assert "::error::Required AppArmor profile source is missing" in setup_script
-    assert "::error::Bubblewrap sandbox self-test failed" in setup_script
-    assert "::error::AppArmor profile is not active for bubblewrap" in setup_script
-    assert setup_script.count("exit 1") >= 3
-    assert step_names.index("Setup bubblewrap and AppArmor for sandbox") < step_names.index("Run Codex")
+    assert "::error::Codex sandbox self-test failed" in setup_script
+    assert "codex sandbox -- /bin/true" in setup_script
+    assert "exit 1" in setup_script
+    assert "sudo" not in setup_script
+    assert "AppArmor" not in setup_script
+    assert step_names.index("Verify development environment and sandbox") < step_names.index("Run Codex")
 
 
 def test_trusted_assets_follow_the_immutable_workflow_version_and_acknowledge_first():
@@ -209,8 +229,8 @@ def test_trusted_assets_follow_the_immutable_workflow_version_and_acknowledge_fi
     assert "const workflowSha = process.env.WORKFLOW_SHA;" in script
     assert 'path: ".github/codex/prompts/comment-response.md"' in script
     assert 'path: ".github/codex/scripts/codex_progress_reporter.py"' in script
-    assert 'path: "requirements-test.txt"' in script
-    assert script.count("ref: workflowSha") == 3
+    assert 'path: "requirements-test.txt"' not in script
+    assert script.count("ref: workflowSha") == 2
     assert "ref: defaultBranch" not in script
     assert script.index("reactions.createForIssueComment") < script.index("issues.createComment")
     assert script.index("issues.createComment") < script.index('path: ".github/codex/prompts/comment-response.md"')

--- a/tests/test_docker_stages.py
+++ b/tests/test_docker_stages.py
@@ -97,6 +97,26 @@ def test_test_stage_installs_the_test_requirements_only_after_server():
     assert "pip install -r /tmp/requirements-test.txt" in test
 
 
+def test_dev_stage_is_a_complete_agent_development_environment():
+    dev = docker_stage("dev")
+
+    assert dev.startswith("FROM test AS dev")
+    assert all(tool in dev for tool in ("git", "jq", "bubblewrap", "uidmap"))
+    assert 'ARG CODEX_VERSION="0.144.6"' in dev
+    assert 'npm install -g "@openai/codex@${CODEX_VERSION}"' in dev
+    assert all(
+        probe in dev
+        for probe in (
+            "node --version",
+            "npm --version",
+            "codex --version",
+            "python3 -m pytest --version",
+            "ruff --version",
+            "bwrap --version",
+        )
+    )
+
+
 def test_pyproject_declares_test_tools_as_optional_dependencies():
     with (ROOT / "pyproject.toml").open("rb") as file:
         project = tomllib.load(file)["project"]

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -66,15 +66,16 @@ class TestScan(TestWithUserLogin):
         self.assertEqual(d["err"], "ok")
         self.assertEqual(n + 1, threading.active_count())
 
-        # wait job done
-        time.sleep(2)
-        q = ScanService().get_queue("do_scan")
-        n = q.qsize()
-        while n:
-            n = q.qsize()
+        # qsize() becomes zero as soon as the worker takes the task, before the
+        # scan transaction is committed. Wait for the observable database state.
+        deadline = time.monotonic() + 10
+        while True:
+            self.session.expire_all()
+            row = self.session.query(ScanFile).filter(ScanFile.id == self.NEW_ROW_ID).one()
+            if row.status != ScanFile.NEW or time.monotonic() >= deadline:
+                break
             time.sleep(0.1)
 
-        row = self.session.query(ScanFile).filter(ScanFile.id == self.NEW_ROW_ID).one()
         self.assertEqual(row.status, ScanFile.READY)
         # self.assertEqual(row.status, ScanFile.DROP)
 


### PR DESCRIPTION
## 背景

Claude 与 Codex 原先运行在裸 `ubuntu-latest` 上，各自临时准备部分依赖，无法稳定复用 Talebook 的 Calibre、Python、Node 和测试环境。本 PR 统一使用由仓库 `Dockerfile` 构建的 `talebook/talebook:dev` job container。

## 主要改动

- 将 `Dockerfile` 的 `dev` target 建立在 `test` stage 上，加入 Node 20、Codex CLI、git、jq、bubblewrap/uidmap，并在构建阶段验证工具链。
- `build.yml` 在 PR 中构建 dev target 但不推送；仅 `master` push 发布浮动的 `talebook/talebook:dev`，不维护 SHA 标签。
- `claude.yml` 使用 dev job container；checkout 后先检查工具、同步当前分支的 Python/Node 依赖，再调用 `anthropics/claude-code-action@v1`。Claude/Bun 继续由官方 Action 管理。
- `codex.yml` 使用同一 dev job container，移除运行时安装和宿主 AppArmor 改写；以 `codex sandbox -- /bin/true` 失败关闭，并在恢复模型认证前同步项目依赖。
- 新增无模型凭据的 `agent-dev-smoke.yml`，供本地 `act` 真实运行容器、后端测试、前端 lint/build 和方案校验。
- 增加 workflow/Docker 契约测试；修复 `test_scan_background` 依赖队列长度判断造成的异步竞态。

## 安全边界

- PR 不得覆盖 `:dev`；只有 `master` 成功构建可发布。
- 不使用 `--privileged`、Docker socket 或 Codex `danger-full-access`。
- Codex sandbox 预检失败即停止；Claude/Codex 都在模型凭据可用前完成环境和依赖门禁。
- 目标分支只决定 checkout 内容，可信 prompt/progress reporter 仍来自不可变 workflow SHA。

## 验证

- `make build-dev`：通过，镜像 `sha256:fbf5a21625fa65b86580fbe7d38b88b3939602c79d06b7667b5afb2eda8c5f20`
- 容器内 `codex sandbox -- /bin/true`：通过
- `make lint-py-fix`：通过
- `make test`：646 passed, 2 skipped
- workflow/Docker 聚焦测试：36 passed, 1 skipped
- `actionlint`：4 份相关 workflow 全部通过
- `go run github.com/nektos/act@v0.2.89 workflow_dispatch -W .github/workflows/agent-dev-smoke.yml --pull=false --container-architecture linux/arm64`：Job succeeded
- act 内部：后端 lint/test、前端 lint/build、`make check-design` 全部通过（43 份方案）
- `git diff --check`：通过

本地 smoke 不调用真实 Claude/OpenAI API，因此认证及模型响应阶段由静态契约测试覆盖，合并后的真实凭据链路仍需观察一次线上运行。前端 `npm` 检查保留仓库既有的 196 条 lint warning 和 39 个依赖漏洞提示，本 PR 未新增这些问题。

## 方案与调研

- [ACTIVE 方案](https://github.com/talebook/talebook/blob/6ff7919ede89941ebd13f84ceaf50d69724be720/design/project/20260721-agent-dev-container.active.html)
- [HTML 预览](https://raw.githack.com/talebook/talebook/6ff7919ede89941ebd13f84ceaf50d69724be720/design/project/20260721-agent-dev-container.active.html)
- [Claude Code Action 业务环境调研](https://github.com/talebook/talebook/blob/6ff7919ede89941ebd13f84ceaf50d69724be720/document/claude-code-action-environment-research.md)
