### PR TITLE
ci: publish shared development container

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,6 +133,20 @@ jobs:
           cache-from: type=gha,scope=ssr-${{ steps.pname.outputs.name }}
           cache-to: type=gha,scope=ssr-${{ steps.pname.outputs.name }},mode=max
 
+      - name: Build development image
+        if: matrix.platform == 'linux/amd64' && (github.event_name == 'pull_request' || github.ref == 'refs/heads/master')
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          target: dev
+          platforms: linux/amd64
+          provenance: false
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev
+          labels: org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=gha,scope=dev-linux-amd64
+          cache-to: type=gha,scope=dev-linux-amd64,mode=max
+
       - name: Export digests
         if: github.event_name != 'pull_request'
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -250,7 +250,7 @@ RUN apt-get update -y && \
         jq \
         uidmap && \
     if [ "$TARGETARCH" = "amd64" ] || [ "$TARGETARCH" = "arm64" ]; then \
-        curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+        curl -fsSL https://deb.nodesource.com/setup_24.x | bash - && \
         apt-get install -y nodejs; \
     fi && \
     apt-get clean && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -228,12 +228,6 @@ RUN rm -rf /var/www/talebook/app/.output/public/logo && \
 
 
 # ----------------------------------------
-# 生产环境（spa版，作为默认 docker build 结果）
-FROM production AS production-spa
-# no more actions
-
-
-# ----------------------------------------
 # 开发环境（前端使用 npm run dev，可将本地 app/ 目录挂载进来实时开发）
 # 构建：docker build --target dev -t talebook/talebook:dev .
 # 使用：docker-compose -f dev.yml up
@@ -327,3 +321,9 @@ EXPOSE 80 443
 VOLUME ["/data"]
 
 CMD ["/var/www/talebook/docker/start-dev.sh"]
+
+
+# ----------------------------------------
+# 生产环境（spa版，作为默认 docker build 结果）
+FROM production AS production-spa
+# no more actions

--- a/Dockerfile
+++ b/Dockerfile
@@ -237,22 +237,39 @@ FROM production AS production-spa
 # 开发环境（前端使用 npm run dev，可将本地 app/ 目录挂载进来实时开发）
 # 构建：docker build --target dev -t talebook/talebook:dev .
 # 使用：docker-compose -f dev.yml up
-FROM server AS dev
+FROM test AS dev
 ARG BUILD_COUNTRY=""
 ARG GIT_VERSION=""
 ARG TARGETARCH
 ARG TARGETVARIANT
+ARG CODEX_VERSION="0.144.6"
 
 USER root
 
-# Install Node.js 20
+# Install the common development and agent toolchain.
 RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        bubblewrap \
+        ca-certificates \
+        curl \
+        git \
+        jq \
+        uidmap && \
     if [ "$TARGETARCH" = "amd64" ] || [ "$TARGETARCH" = "arm64" ]; then \
         curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
         apt-get install -y nodejs; \
     fi && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=cache,target=/root/.npm \
+    npm install -g "@openai/codex@${CODEX_VERSION}" && \
+    node --version && \
+    npm --version && \
+    codex --version && \
+    python3 -m pytest --version && \
+    ruff --version && \
+    bwrap --version
 
 ENV TZ=Asia/Shanghai
 ENV LANG=C.UTF-8

--- a/design/project/20260722-dev-container-foundation.active.html
+++ b/design/project/20260722-dev-container-foundation.active.html
@@ -1,0 +1,130 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Dev Container 分阶段交付方案</title>
+  <style>
+    :root { color-scheme: light; font-family: system-ui, -apple-system, "Segoe UI", sans-serif; color: #17212b; background: #eef2f6; line-height: 1.65; }
+    * { box-sizing: border-box; }
+    body { max-width: 1080px; margin: 0 auto; padding: 28px 18px 64px; }
+    header, section { margin-bottom: 18px; padding: 22px; border: 1px solid #d4dde7; border-radius: 12px; background: #fff; }
+    header { border-top: 5px solid #23774f; }
+    h1 { margin: 0 0 8px; line-height: 1.2; }
+    h2 { margin: 0 0 12px; font-size: 1.3rem; }
+    p, ul, ol { margin-top: 8px; }
+    code { padding: 2px 5px; border-radius: 4px; background: #edf2f7; overflow-wrap: anywhere; }
+    .meta { display: grid; grid-template-columns: repeat(auto-fit, minmax(190px, 1fr)); gap: 9px; margin-top: 18px; }
+    .meta div { padding: 10px 12px; border-radius: 8px; background: #f3f6f9; }
+    .status, .passed { color: #176a42; font-weight: 700; }
+    .callout { padding: 12px 14px; border-left: 4px solid #386d9e; border-radius: 6px; background: #edf6ff; }
+    .warn { border-left-color: #a96a17; background: #fff6e9; }
+    .table-wrap { overflow-x: auto; }
+    table { width: 100%; min-width: 700px; border-collapse: collapse; }
+    th, td { padding: 10px; border: 1px solid #d4dde7; text-align: left; vertical-align: top; }
+    th { background: #edf3f8; }
+    svg { width: 100%; height: auto; border: 1px solid #d4dde7; border-radius: 10px; background: #fbfcfd; }
+    figcaption { color: #5b6c7d; font-size: .92rem; }
+    @media (max-width: 680px) { body { padding: 14px 10px 40px; } header, section { padding: 16px; } }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Dev Container 分阶段交付方案</h1>
+    <p>先发布并验证开发镜像，再迁移 Claude/Codex 消费端，避免镜像尚未就绪时同时启用消费者。</p>
+    <div class="meta">
+      <div><strong>创建日期</strong><br>2026-07-22</div>
+      <div><strong>所属模块</strong><br>project</div>
+      <div><strong>状态</strong><br><span class="status">ACTIVE</span></div>
+      <div><strong>需求来源</strong><br>维护者要求拆分 PR</div>
+      <div><strong>当前 PR 范围</strong><br>仅 dev container 基础设施</div>
+      <div><strong>影响范围</strong><br>Dockerfile、build workflow、tests</div>
+    </div>
+  </header>
+
+  <section>
+    <h2>1. 原始诉求与最新决策</h2>
+    <p>总体目标仍是让 Claude 与 Codex 最终运行在 Talebook 的统一开发镜像中，并能够完成后端和前端开发测试。但交付必须拆分：第一个 PR 只建立、发布并验证 <code>talebook/talebook:dev</code>；镜像上线后，后续 PR 才修改 <code>claude.yml</code> 与 <code>codex.yml</code>。</p>
+    <div class="callout warn"><strong>明确决策：</strong><code>agent-dev-smoke.yml</code> 不是线上长期使用的 workflow，不得提交到仓库。需要的本地 GitHub Actions 验收使用 <code>/private/tmp</code> 下的一次性 workflow，测试完成后不进入 git。</div>
+  </section>
+
+  <section>
+    <h2>2. 为什么拆分</h2>
+    <p>若同一个合并同时发布镜像并让 Claude/Codex 立即引用 <code>:dev</code>，消费者可能在 master 的镜像构建完成前触发，从而拉取旧镜像或因标签不存在而失败。拆分后的发布顺序把镜像可用性变成第二个 PR 的明确前置条件。</p>
+    <figure>
+      <svg viewBox="0 0 980 280" role="img" aria-labelledby="flow-title flow-desc">
+        <title id="flow-title">Dev Container 分阶段发布流程</title>
+        <desc id="flow-desc">第一个 PR 构建并发布 dev 镜像，验证成功后，第二个 PR 再迁移 Claude 与 Codex。</desc>
+        <defs><marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto"><path d="M0 0L0 6L9 3z" fill="#3d6f9f"/></marker></defs>
+        <g fill="#edf5fc" stroke="#3d6f9f" stroke-width="2">
+          <rect x="35" y="75" width="250" height="120" rx="11"/>
+          <rect x="365" y="75" width="250" height="120" rx="11"/>
+          <rect x="695" y="75" width="250" height="120" rx="11"/>
+        </g>
+        <g fill="#17212b" text-anchor="middle" font-size="16">
+          <text x="160" y="108" font-weight="700">PR 1：镜像基础</text><text x="160" y="138">构建 Dockerfile dev</text><text x="160" y="166">master 发布 :dev</text>
+          <text x="490" y="108" font-weight="700">上线门禁</text><text x="490" y="138">镜像构建成功</text><text x="490" y="166">Hosted Runner 验证</text>
+          <text x="820" y="108" font-weight="700">PR 2：消费者</text><text x="820" y="138">迁移 Claude/Codex</text><text x="820" y="166">复用已发布 :dev</text>
+        </g>
+        <g fill="none" stroke="#3d6f9f" stroke-width="2.5" marker-end="url(#arrow)"><path d="M285 135H353"/><path d="M615 135H683"/></g>
+      </svg>
+      <figcaption>图 1：当前只实施左侧 PR 1；右侧消费者迁移不进入本次 diff。</figcaption>
+    </figure>
+  </section>
+
+  <section>
+    <h2>3. 当前 PR 的边界</h2>
+    <div class="table-wrap">
+      <table>
+        <thead><tr><th>类别</th><th>包含</th><th>不包含</th></tr></thead>
+        <tbody>
+          <tr><td>镜像</td><td><code>dev</code> 从测试 stage 继承；包含 Calibre、Python 测试依赖、Node 20、git、jq、Codex CLI、bubblewrap/uidmap。</td><td>不改变 production stages，不预装 Claude/Bun。</td></tr>
+          <tr><td>发布</td><td>PR 仅构建 linux/amd64 dev target；只有 master push 发布浮动 <code>talebook/talebook:dev</code>。</td><td>不发布 commit SHA 标签；其他分支不得覆盖 <code>:dev</code>。</td></tr>
+          <tr><td>消费者</td><td>无。</td><td>不修改 <code>claude.yml</code>、<code>codex.yml</code> 或 Claude review workflow。</td></tr>
+          <tr><td>验收入口</td><td>Docker 构建、静态 workflow 测试，以及位于 <code>/private/tmp</code> 的临时 act workflow。</td><td>仓库中不新增任何 smoke workflow。</td></tr>
+          <tr><td>旁支修复</td><td>无。</td><td>异步 scan 测试竞态另开独立 PR，不混入镜像基础 PR。</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section>
+    <h2>4. 实现方案</h2>
+    <ol>
+      <li>调整 <code>Dockerfile</code>：让 <code>dev</code> 继承 <code>test</code>，安装 agent 与开发工具，并在构建时执行版本探测。</li>
+      <li>调整 <code>.github/workflows/build.yml</code>：复用现有 build job，在 PR 中只验证构建，在 master push 中发布唯一的 <code>:dev</code> 标签，并写入 OCI revision。</li>
+      <li>添加 Docker stage 与 build workflow 契约测试，锁定继承关系、工具、发布条件和标签策略。</li>
+      <li>本地构建同名镜像后，动态生成临时 workflow 并用 <code>act -W /private/tmp/...</code> 验证 job container 能执行工具探测和开发测试；临时文件不复制进仓库。</li>
+    </ol>
+  </section>
+
+  <section>
+    <h2>5. 发布、失败与回滚</h2>
+    <ul>
+      <li>PR 构建失败时不能合并，因此不会影响 Docker Hub 上已有标签。</li>
+      <li>master 发布失败时，后续消费者 PR 保持阻塞，不修改 Claude/Codex workflow。</li>
+      <li><code>:dev</code> 是维护者确认的浮动标签；OCI revision 与构建日志用于追溯实际来源。</li>
+      <li>如新镜像不可用，在消费者尚未迁移时不会影响 agent；修复 Dockerfile 后重新由 master 发布即可。</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>6. 测试计划</h2>
+    <div class="table-wrap">
+      <table>
+        <thead><tr><th>验证项</th><th>计划命令/证据</th><th>当前结果</th></tr></thead>
+        <tbody>
+          <tr><td>镜像构建</td><td><code>make build-dev</code></td><td class="passed">通过；rebase 到最新 master 后复验生成 <code>sha256:f6b87e6e08518b196c5bd062bada1c85a06bb497d0b0afa0d971fcb74997405c</code></td></tr>
+          <tr><td>容器工具链</td><td>在镜像内探测 Calibre、Python、Node、npm、pytest、ruff、Codex、bwrap，并执行 <code>codex sandbox -- /bin/true</code></td><td class="passed">通过；Calibre 8.5.0、Python 3.13.5、Node 20.20.2、Codex 0.144.6，sandbox 成功</td></tr>
+          <tr><td>静态契约</td><td><code>python3.12 -m pytest -q tests/test_docker_stages.py tests/test_dev_container_workflow.py</code>；固定版本 <code>actionlint</code> 检查 build 与临时 workflow</td><td class="passed">通过；9 passed，actionlint 无错误输出</td></tr>
+          <tr><td>本地 Actions</td><td><code>go run github.com/nektos/act@v0.2.89 workflow_dispatch -W /private/tmp/talebook-dev-container-smoke.yml --pull=false --container-architecture linux/arm64</code></td><td class="passed">通过；Job succeeded。临时 workflow 未进入工作区或 git</td></tr>
+          <tr><td>仓库检查</td><td><code>make lint-py-fix</code>；act 内执行 <code>make lint-py</code> 与 <code>make pytest</code>；另执行 <code>make test</code></td><td class="passed">通过；格式 96 files unchanged；act 后端 645 passed、1 skipped；make test 644 passed、2 skipped</td></tr>
+          <tr><td>前端能力</td><td>临时 act job 内执行 npm lint/build</td><td class="passed">通过；lint 为 0 errors、196 个存量 warnings；Nuxt 4.3.0 build 完成</td></tr>
+          <tr><td>方案校验</td><td><code>make check-design</code></td><td class="passed">通过；最新 master 基线上 44 份方案文档全部通过</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <p>实现与开发测试均已通过，方案转为 ACTIVE。真实 Docker Hub 发布只能在该 PR 合并到 master 后发生，将作为消费者 PR 的前置验收，不在本 PR 中伪报通过。</p>
+  </section>
+</body>
+</html>

--- a/design/project/20260722-dev-container-foundation.active.html
+++ b/design/project/20260722-dev-container-foundation.active.html
@@ -78,7 +78,7 @@
       <table>
         <thead><tr><th>类别</th><th>包含</th><th>不包含</th></tr></thead>
         <tbody>
-          <tr><td>镜像</td><td><code>dev</code> 从测试 stage 继承；包含 Calibre、Python 测试依赖、Node 20、git、jq、Codex CLI、bubblewrap/uidmap。</td><td>不改变 production stages，不预装 Claude/Bun。</td></tr>
+          <tr><td>镜像</td><td><code>dev</code> 从测试 stage 继承；包含 Calibre、Python 测试依赖、Node 20、git、jq、Codex CLI、bubblewrap/uidmap；<code>production-spa</code> 保持为 Dockerfile 最后一个 stage，未指定 target 时仍默认构建 SPA 生产镜像。</td><td>不改变 production stages，不预装 Claude/Bun。</td></tr>
           <tr><td>发布</td><td>PR 仅构建 linux/amd64 dev target；只有 master push 发布浮动 <code>talebook/talebook:dev</code>。</td><td>不发布 commit SHA 标签；其他分支不得覆盖 <code>:dev</code>。</td></tr>
           <tr><td>消费者</td><td>无。</td><td>不修改 <code>claude.yml</code>、<code>codex.yml</code> 或 Claude review workflow。</td></tr>
           <tr><td>验收入口</td><td>Docker 构建、静态 workflow 测试，以及位于 <code>/private/tmp</code> 的临时 act workflow。</td><td>仓库中不新增任何 smoke workflow。</td></tr>
@@ -91,7 +91,7 @@
   <section>
     <h2>4. 实现方案</h2>
     <ol>
-      <li>调整 <code>Dockerfile</code>：让 <code>dev</code> 继承 <code>test</code>，安装 agent 与开发工具，并在构建时执行版本探测。</li>
+      <li>调整 <code>Dockerfile</code>：让 <code>dev</code> 继承 <code>test</code>，安装 agent 与开发工具，并在构建时执行版本探测；<code>production-spa</code> 必须位于文件末尾，维持默认生产构建语义。</li>
       <li>调整 <code>.github/workflows/build.yml</code>：复用现有 build job，在 PR 中只验证构建，在 master push 中发布唯一的 <code>:dev</code> 标签，并写入 OCI revision。</li>
       <li>添加 Docker stage 与 build workflow 契约测试，锁定继承关系、工具、发布条件和标签策略。</li>
       <li>本地构建同名镜像后，动态生成临时 workflow 并用 <code>act -W /private/tmp/...</code> 验证 job container 能执行工具探测和开发测试；临时文件不复制进仓库。</li>
@@ -116,7 +116,8 @@
         <tbody>
           <tr><td>镜像构建</td><td><code>make build-dev</code></td><td class="passed">通过；rebase 到最新 master 后复验生成 <code>sha256:f6b87e6e08518b196c5bd062bada1c85a06bb497d0b0afa0d971fcb74997405c</code></td></tr>
           <tr><td>容器工具链</td><td>在镜像内探测 Calibre、Python、Node、npm、pytest、ruff、Codex、bwrap，并执行 <code>codex sandbox -- /bin/true</code></td><td class="passed">通过；Calibre 8.5.0、Python 3.13.5、Node 20.20.2、Codex 0.144.6，sandbox 成功</td></tr>
-          <tr><td>静态契约</td><td><code>python3.12 -m pytest -q tests/test_docker_stages.py tests/test_dev_container_workflow.py</code>；固定版本 <code>actionlint</code> 检查 build 与临时 workflow</td><td class="passed">通过；9 passed，actionlint 无错误输出</td></tr>
+          <tr><td>静态契约</td><td><code>python3.12 -m pytest -q tests/test_docker_stages.py tests/test_dev_container_workflow.py</code>；固定版本 <code>actionlint</code> 检查 build 与临时 workflow</td><td class="passed">通过；10 passed，其中包含 Dockerfile 最后 stage 回归检查；actionlint 无错误输出</td></tr>
+          <tr><td>默认生产构建</td><td><code>docker build --build-arg BUILD_COUNTRY=CN -t talebook/default-spa-check:pr893 -f Dockerfile .</code>，并检查镜像 CMD</td><td class="passed">通过；生成 <code>sha256:10bc886206f7c092d7aeac15c2636555cd827cd72db217f500f4183426bbd3e3</code>，CMD 为 <code>/var/www/talebook/docker/start.sh</code>，未落入 dev stage</td></tr>
           <tr><td>本地 Actions</td><td><code>go run github.com/nektos/act@v0.2.89 workflow_dispatch -W /private/tmp/talebook-dev-container-smoke.yml --pull=false --container-architecture linux/arm64</code></td><td class="passed">通过；Job succeeded。临时 workflow 未进入工作区或 git</td></tr>
           <tr><td>仓库检查</td><td><code>make lint-py-fix</code>；act 内执行 <code>make lint-py</code> 与 <code>make pytest</code>；另执行 <code>make test</code></td><td class="passed">通过；格式 96 files unchanged；act 后端 645 passed、1 skipped；make test 644 passed、2 skipped</td></tr>
           <tr><td>前端能力</td><td>临时 act job 内执行 npm lint/build</td><td class="passed">通过；lint 为 0 errors、196 个存量 warnings；Nuxt 4.3.0 build 完成</td></tr>

--- a/design/project/20260722-dev-container-node24.active.html
+++ b/design/project/20260722-dev-container-node24.active.html
@@ -1,0 +1,119 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Dev Container 升级 Node 24</title>
+  <style>
+    :root { color-scheme: light; --ink: #17212b; --muted: #5b6875; --line: #d8e0e7; --panel: #f6f8fa; --accent: #0969da; --ok: #1a7f37; }
+    * { box-sizing: border-box; }
+    body { max-width: 960px; margin: 0 auto; padding: 36px 24px 64px; color: var(--ink); background: #fff; font: 16px/1.65 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    header { padding: 26px; border: 1px solid var(--line); border-radius: 14px; background: linear-gradient(135deg, #f6f8fa, #eef5ff); }
+    h1, h2 { line-height: 1.25; }
+    h1 { margin: 0 0 18px; font-size: 30px; }
+    h2 { margin-top: 34px; font-size: 21px; }
+    .meta { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 12px; }
+    .meta div { padding: 10px 12px; border-radius: 8px; background: rgba(255,255,255,.8); }
+    .status { color: var(--ok); font-weight: 700; }
+    code { padding: 2px 5px; border-radius: 4px; background: var(--panel); }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { padding: 11px 12px; border: 1px solid var(--line); text-align: left; vertical-align: top; }
+    th { background: var(--panel); }
+    .flow { display: grid; grid-template-columns: 1fr auto 1fr auto 1fr; gap: 10px; align-items: center; margin: 18px 0; }
+    .flow div { padding: 14px; border: 1px solid var(--line); border-radius: 9px; text-align: center; }
+    .arrow { color: var(--accent); font-size: 24px; }
+    @media (max-width: 700px) { .meta { grid-template-columns: 1fr; } .flow { grid-template-columns: 1fr; } .arrow { transform: rotate(90deg); } }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Dev Container 升级 Node 24</h1>
+    <div class="meta">
+      <div><strong>创建日期</strong><br>2026-07-22</div>
+      <div><strong>所属模块</strong><br>project</div>
+      <div><strong>状态</strong><br><span class="status">ACTIVE</span></div>
+      <div><strong>需求来源</strong><br>维护者确认 dev 先升级，其他环境后续单独 PR</div>
+      <div><strong>关联方案</strong><br><code>20260722-dev-container-foundation.active.html</code></div>
+      <div><strong>目标 PR</strong><br>#893</div>
+    </div>
+  </header>
+
+  <section>
+    <h2>1. 原始诉求与结论</h2>
+    <p>将当前 PR 中新增的 Docker <code>dev</code> stage 从 Node 20 升级到 Node 24。Docker 前端 builder、<code>production-ssr</code> 和 <code>ci.yml</code> 暂不修改，后续通过独立 PR 全面升级。</p>
+    <p>Node 20 虽能运行当前 Codex 和 Claude Action，但已经停止维护；新建的开发镜像直接采用当前 Active LTS Node 24，避免发布即携带 EOL 运行时，并将支持周期延长到 2028 年 4 月。</p>
+    <p>本方案仅替代关联基础方案中 dev stage 采用 Node 20 的决定；基础方案的镜像结构、发布策略和其余验证结论继续有效。</p>
+  </section>
+
+  <section>
+    <h2>2. Node 22 与 Node 24 选型</h2>
+    <table>
+      <thead><tr><th>评估维度</th><th>Node 22</th><th>Node 24</th><th>结论</th></tr></thead>
+      <tbody>
+        <tr><td>Node 官方阶段</td><td>Maintenance LTS，计划 2027 年 4 月 EOL</td><td>Active LTS，计划 2028 年 4 月 EOL</td><td>Node 24 多一年维护窗口。</td></tr>
+        <tr><td>Nuxt 4.3</td><td>满足 22.12 以上要求</td><td>满足要求，并符合 Nuxt 推荐 Active LTS 的方向</td><td>Node 24 更适合新建环境。</td></tr>
+        <tr><td>Codex 0.144.6</td><td>声明兼容，实测可安装运行</td><td>声明兼容，实测可安装运行</td><td>两者均可；最终镜像保留 <code>codex --version</code> 发布探针。</td></tr>
+        <tr><td>Claude Code Action v1</td><td colspan="2">Action 主入口使用 Bun 并安装原生 Claude CLI，不依赖 dev 镜像预装 Node。</td><td>Node 选型主要由业务工具链决定。</td></tr>
+        <tr><td>npm 风险</td><td>npm 10 路径较保守</td><td>npm 11 曾有平台可选依赖安装风险</td><td>用 Codex 启动、前端安装与构建实测控制风险。</td></tr>
+      </tbody>
+    </table>
+    <p>以上结论依据 Node.js 发布周期、Nuxt 4 安装要求、Codex 包元数据及 Claude Code Action v1 官方仓库实现，并通过 Node 22 与 Node 24 一次性容器交叉验证。</p>
+
+    <h2>3. 范围与边界</h2>
+    <table>
+      <thead><tr><th>范围</th><th>本次处理</th><th>本次不处理</th></tr></thead>
+      <tbody>
+        <tr><td>Dockerfile</td><td>仅把 <code>dev</code> stage 的 NodeSource 安装入口改为 <code>setup_24.x</code>。</td><td>不修改 <code>node:20-alpine</code> builder，也不修改 <code>production-ssr</code> 中的 Node 20。</td></tr>
+        <tr><td>Agent 工具</td><td>保留 Codex 0.144.6，并用 Node 24 重新安装、执行版本探测。</td><td>不预装 Claude Code；<code>claude-code-action@v1</code> 仍由 action 自行安装 Bun 和原生 Claude CLI。</td></tr>
+        <tr><td>CI</td><td>PR 的 dev target 构建继续作为发布门禁。</td><td>不修改 <code>ci.yml</code> 的 <code>node:20-alpine</code>。</td></tr>
+        <tr><td>默认镜像</td><td><code>production-spa</code> 继续保持为 Dockerfile 最后 stage。</td><td>不改变默认生产构建结果。</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section>
+    <h2>4. 实施与测试策略</h2>
+    <div class="flow" aria-label="红绿验证流程">
+      <div>契约测试要求<br><strong>dev = Node 24</strong></div><span class="arrow">→</span>
+      <div>旧实现触发红灯<br><strong>setup_20.x</strong></div><span class="arrow">→</span>
+      <div>最小修改转绿<br><strong>setup_24.x</strong></div>
+    </div>
+    <ol>
+      <li>公共测试缝为 Docker <code>dev</code> stage 暴露的 Node 主版本；测试只检查 dev stage，不约束其他 stage。</li>
+      <li>先让契约测试要求 <code>setup_24.x</code> 且拒绝 <code>setup_20.x</code>，确认在旧实现上失败。</li>
+      <li>仅修改 dev stage 的 NodeSource 安装入口，然后运行契约测试。</li>
+      <li>构建 dev 镜像，验证 Node 24、npm、Codex、pytest、ruff 和 bubblewrap 版本探测，并执行前端依赖安装或构建入口。</li>
+      <li>复验未指定 target 的默认构建契约仍为 <code>production-spa</code>。</li>
+    </ol>
+  </section>
+
+  <section>
+    <h2>5. 风险与回滚</h2>
+    <ul>
+      <li>风险：Node 24 自带 npm 11，平台可选依赖解析或 Nuxt 工具链行为可能与 Node 20 不同；通过 Codex 启动探针、镜像构建和前端命令验证。</li>
+      <li>风险：误改其他 stage 会扩大生产影响；契约与 diff 评审限定只出现 dev 安装入口变更。</li>
+      <li>回滚：将 dev stage 安装入口恢复为 <code>setup_20.x</code>，重新发布浮动 <code>:dev</code>。</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>6. 测试结果</h2>
+    <table>
+      <thead><tr><th>验证项</th><th>实际命令或结果</th><th>状态</th></tr></thead>
+      <tbody>
+        <tr><td>红灯</td><td><code>python3.12 -m pytest -q tests/test_docker_stages.py -k node_24_active_lts</code>；旧实现缺少 <code>setup_24.x</code>，按预期 1 项失败。</td><td>通过</td></tr>
+        <tr><td>绿灯</td><td>仅修改 dev stage 后重跑同一命令，1 项通过，9 项取消选择。</td><td>通过</td></tr>
+        <tr><td>完整静态契约</td><td><code>python3.12 -m pytest -q tests/test_docker_stages.py tests/test_dev_container_workflow.py</code>；11 项通过。</td><td>通过</td></tr>
+        <tr><td>dev 镜像</td><td><code>make build-dev</code>；生成 <code>sha256:03c54bbbbd109bef750f4fa843d8282869e18f4e8f208cc44f277952231172c0</code>。</td><td>通过</td></tr>
+        <tr><td>最终镜像运行时</td><td>Node 24.18.0、npm 11.16.0、Codex 0.144.6、pytest 7.4.4、ruff 0.15.22、bubblewrap 0.11.0；<code>codex sandbox -- /bin/true</code> 成功。</td><td>通过</td></tr>
+        <tr><td>真实前端命令</td><td>最终 dev 镜像内执行 <code>npm run lint -- --quiet</code> 和 <code>npm run build</code>；Nuxt 4.3.0 client、server、Nitro 均构建完成。</td><td>通过</td></tr>
+        <tr><td>全量 Docker 测试</td><td><code>make test</code>；首次为 645 项通过、2 项跳过，后台扫描时序用例 1 项失败；该用例单独复跑通过，完整套件再跑为 646 项通过、2 项跳过。</td><td>通过</td></tr>
+        <tr><td>宿主全量测试</td><td><code>make pytest</code> 因宿主 PATH 无 <code>pytest</code> 未启动；改用 <code>python3.12 -m pytest</code> 后因宿主缺少业务依赖而在收集阶段停止，已由标准 Docker 测试路径完成覆盖。</td><td>环境限制，由 Docker 替代</td></tr>
+        <tr><td>Python lint</td><td><code>make lint-py</code>；ruff 检查通过，96 个文件格式不变。</td><td>通过</td></tr>
+        <tr><td>方案检查</td><td><code>make check-design</code>；45 份方案文档通过。</td><td>通过</td></tr>
+      </tbody>
+    </table>
+    <p>非阻断警告：前端构建提示 Browserslist 数据已过期；<code>npm ci</code> 报告当前锁文件依赖的 38 个 audit 项。这些警告未由 Node 主版本切换引入，本方案不扩展处理范围。</p>
+  </section>
+</body>
+</html>

--- a/tests/test_dev_container_workflow.py
+++ b/tests/test_dev_container_workflow.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def workflow(name):
+    with (ROOT / ".github" / "workflows" / name).open(encoding="utf-8") as file:
+        return yaml.safe_load(file)
+
+
+def workflow_step(job, name):
+    for step in job["steps"]:
+        if step.get("name") == name:
+            return step
+    raise AssertionError(f"workflow step not found: {name}")
+
+
+def test_build_workflow_only_publishes_the_validated_dev_image_from_master():
+    build_job = workflow("build.yml")["jobs"]["build"]
+    step = workflow_step(build_job, "Build development image")
+
+    assert step["if"] == (
+        "matrix.platform == 'linux/amd64' && "
+        "(github.event_name == 'pull_request' || github.ref == 'refs/heads/master')"
+    )
+    assert step["uses"] == "docker/build-push-action@v5"
+    assert step["with"]["target"] == "dev"
+    assert step["with"]["platforms"] == "linux/amd64"
+    assert step["with"]["push"] == (
+        "${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}"
+    )
+    assert step["with"]["tags"] == "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev"
+    assert step["with"]["labels"] == "org.opencontainers.image.revision=${{ github.sha }}"

--- a/tests/test_docker_stages.py
+++ b/tests/test_docker_stages.py
@@ -117,6 +117,13 @@ def test_dev_stage_is_a_complete_agent_development_environment():
     )
 
 
+def test_dev_stage_uses_node_24_active_lts():
+    dev = docker_stage("dev")
+
+    assert "https://deb.nodesource.com/setup_24.x" in dev
+    assert "https://deb.nodesource.com/setup_20.x" not in dev
+
+
 def test_production_spa_is_the_final_default_stage():
     stages = re.findall(
         r"^FROM\s+\S+\s+AS\s+(\S+)\s*$",

--- a/tests/test_docker_stages.py
+++ b/tests/test_docker_stages.py
@@ -97,6 +97,26 @@ def test_test_stage_installs_the_test_requirements_only_after_server():
     assert "pip install -r /tmp/requirements-test.txt" in test
 
 
+def test_dev_stage_is_a_complete_agent_development_environment():
+    dev = docker_stage("dev")
+
+    assert dev.startswith("FROM test AS dev")
+    assert all(tool in dev for tool in ("git", "jq", "bubblewrap", "uidmap"))
+    assert 'ARG CODEX_VERSION="0.144.6"' in dev
+    assert 'npm install -g "@openai/codex@${CODEX_VERSION}"' in dev
+    assert all(
+        probe in dev
+        for probe in (
+            "node --version",
+            "npm --version",
+            "codex --version",
+            "python3 -m pytest --version",
+            "ruff --version",
+            "bwrap --version",
+        )
+    )
+
+
 def test_pyproject_declares_test_tools_as_optional_dependencies():
     with (ROOT / "pyproject.toml").open("rb") as file:
         project = tomllib.load(file)["project"]

--- a/tests/test_docker_stages.py
+++ b/tests/test_docker_stages.py
@@ -117,6 +117,16 @@ def test_dev_stage_is_a_complete_agent_development_environment():
     )
 
 
+def test_production_spa_is_the_final_default_stage():
+    stages = re.findall(
+        r"^FROM\s+\S+\s+AS\s+(\S+)\s*$",
+        read("Dockerfile"),
+        re.MULTILINE | re.IGNORECASE,
+    )
+
+    assert stages[-1] == "production-spa"
+
+
 def test_pyproject_declares_test_tools_as_optional_dependencies():
     with (ROOT / "pyproject.toml").open("rb") as file:
         project = tomllib.load(file)["project"]


### PR DESCRIPTION
## 背景

先建立并发布可复用的 `talebook/talebook:dev`，待镜像在 master 上线并验证后，再由后续 PR 迁移 Claude/Codex，避免消费者与镜像发布在同一次合并中产生启动竞态。

## 本 PR 范围

- `Dockerfile` 的 `dev` target 改为继承 `test` stage，包含后端测试依赖。
- 安装 Node 20、git、jq、Codex CLI 0.144.6、bubblewrap/uidmap，并在镜像构建阶段验证版本。
- `build.yml` 在 PR 中构建 linux/amd64 dev target，但不推送。
- 只有 `master` push 可以发布浮动的 `talebook/talebook:dev`；不维护 SHA 标签。
- 增加 Docker stage 和 dev 镜像发布契约测试。

明确不包含：

- 不修改 `claude.yml`、`codex.yml` 或 Claude review workflow。
- 不提交长期 smoke workflow；本地 Actions 验收使用 `/private/tmp` 中的一次性 workflow。
- 不包含此前发现的 `test_scan.py` 异步测试调整。

## 验证

- `make build-dev`：通过；最新 master 基线镜像 `sha256:f6b87e6e08518b196c5bd062bada1c85a06bb497d0b0afa0d971fcb74997405c`
- 容器工具链和 `codex sandbox -- /bin/true`：通过
- 聚焦契约测试：9 passed
- `actionlint`：build workflow 与临时 act workflow 均通过
- `make lint-py-fix`：通过，96 files unchanged
- `make test`：644 passed，2 skipped
- 临时 GitHub Actions：`go run github.com/nektos/act@v0.2.89 workflow_dispatch -W /private/tmp/talebook-dev-container-smoke.yml --pull=false --container-architecture linux/arm64`，rebase 到最新 master 后再次 `Job succeeded`
- act 内后端 lint/test、前端 lint/build 全部通过；前端保留 196 个存量 warnings、0 errors
- `make check-design`：44 份方案通过
- `git diff --check`：通过

## 后续顺序

本 PR 合并后，等待 master 的 Docker workflow 成功发布 `talebook/talebook:dev`，再提交 Claude/Codex 消费端迁移 PR。

## 方案

- [ACTIVE 方案](https://github.com/talebook/talebook/blob/6d792ad276feeef9fb5345c04341430af97e5367/design/project/20260722-dev-container-foundation.active.html)
- [HTML 预览](https://raw.githack.com/talebook/talebook/6d792ad276feeef9fb5345c04341430af97e5367/design/project/20260722-dev-container-foundation.active.html)
