### PR TITLE
fix(app): 修复书籍状态刷新与详情标签可见性

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,8 @@ make dev     # 挂载 webserver/ 进容器，用于后端开发调试
 
 - 修改前端交互、样式、主题、页面布局或弹窗时，除单元/组件测试外，必须使用 Chrome DevTools MCP 在浏览器中做实际渲染验证，并在回复中说明验证过的页面、主题或关键状态。
 - 前端改动完成后，如果需要 dev server 才能体验，必须启动本地 dev server，并在最终回复中提供可访问地址（例如 `http://127.0.0.1:3000/` ）。
+- 永远禁止设置 `CHOKIDAR_USEPOLLING=true` 启动 Nuxt、Vite 或其他前端开发服务，不允许在交互命令、脚本、Makefile、CI 或文档示例中启用该轮询模式，也不为 Docker、worktree、网络文件系统或热更新故障设置例外。
+- 文件监听或热更新异常时，必须停止 dev server 并报告现象，改用原生文件事件、手动刷新或其他不启用 Chokidar polling 的方案。发现由智能体启动的 dev server 异常占用 CPU 时，应立即停止该进程并检查残留。
 - 前端本地体验默认启动方式：
   ```bash
   cd app

--- a/app/composables/useBookReadingState.js
+++ b/app/composables/useBookReadingState.js
@@ -1,0 +1,63 @@
+import { ref, watch } from 'vue';
+
+export const READING_STATE = { UNREAD: 0, READING: 1, FINISHED: 2 };
+
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export const calculateReadDays = (readDate, now = Date.now()) => {
+  const startedAt = Date.parse(readDate || '');
+  const currentTime = typeof now === 'number' ? now : Date.parse(now);
+  if (!Number.isFinite(startedAt) || !Number.isFinite(currentTime)) {
+    return 0;
+  }
+  return Math.max(0, Math.floor((currentTime - startedAt) / MILLISECONDS_PER_DAY));
+};
+
+export const useBookReadingState = ({ bookId, isLogin, backend, now = Date.now }) => {
+  const isInShelf = ref(false);
+  const readingState = ref(READING_STATE.UNREAD);
+  const readDays = ref(0);
+  const lastReadTime = ref('');
+  let requestId = 0;
+
+  const reset = () => {
+    isInShelf.value = false;
+    readingState.value = READING_STATE.UNREAD;
+    readDays.value = 0;
+    lastReadTime.value = '';
+  };
+
+  const load = async (targetBookId, targetRequestId) => {
+    try {
+      const rsp = await backend(`/book/${targetBookId}/readstate`);
+      if (targetRequestId !== requestId || bookId.value !== targetBookId || !isLogin.value) {
+        return;
+      }
+      if (rsp.err === 'ok') {
+        isInShelf.value = !!rsp.wants;
+        readingState.value = rsp.read_state || READING_STATE.UNREAD;
+        lastReadTime.value = rsp.read_date || '';
+        readDays.value = readingState.value === READING_STATE.READING
+          ? calculateReadDays(lastReadTime.value, now())
+          : 0;
+      }
+    } catch (e) {
+      console.error('Failed to load reading state:', e);
+    }
+  };
+
+  watch([bookId, isLogin], ([targetBookId, loggedIn]) => {
+    const targetRequestId = ++requestId;
+    reset();
+    if (targetBookId && loggedIn) {
+      load(targetBookId, targetRequestId);
+    }
+  }, { immediate: true });
+
+  return {
+    isInShelf,
+    readingState,
+    readDays,
+    lastReadTime,
+  };
+};

--- a/app/pages/book/[bid]/index.vue
+++ b/app/pages/book/[bid]/index.vue
@@ -1024,6 +1024,7 @@ import { useRoute, useRouter } from 'vue-router';
 import { useAsyncData, useNuxtApp } from 'nuxt/app';
 import { useMainStore } from '@/stores/main';
 import BookCards_Small from '~/components/BookCards_Small.vue';
+import { READING_STATE, useBookReadingState } from '~/composables/useBookReadingState';
 
 const route = useRoute();
 const router = useRouter();
@@ -1031,7 +1032,7 @@ const store = useMainStore();
 const { $backend, $backend_stream, $alert } = useNuxtApp();
 const { t } = useI18n();
 
-const bookid = route.params.bid;
+const bookid = computed(() => route.params.bid);
 const book = ref({
     id: 0,
     title: '',
@@ -1101,7 +1102,7 @@ store.setNavbar(true);
 // Methods
 const get_txt_parse_status = async () => {
     try {
-        const res = await $backend(`/book/txt/init?id=${bookid}&test=1`);
+        const res = await $backend(`/book/txt/init?id=${bookid.value}&test=1`);
         if (res.err === 'ok' && res.msg === '已解析') {
             txt_parse_inited.value = true;
         }
@@ -1111,8 +1112,9 @@ const get_txt_parse_status = async () => {
 };
 
 // 数据获取逻辑
-const { data: fetchData, error: fetchError, pending: fetchPending, refresh } = useAsyncData(`book-${bookid}`, async () => {
-    const response = await $backend(`/book/${bookid}`);
+const bookDataKey = computed(() => `book-${bookid.value}`);
+const { data: fetchData, error: fetchError, pending: fetchPending, refresh } = useAsyncData(bookDataKey, async () => {
+    const response = await $backend(`/book/${bookid.value}`);
     
     if (response.err === 'ok') {
         return response;
@@ -1122,8 +1124,7 @@ const { data: fetchData, error: fetchError, pending: fetchPending, refresh } = u
 }, {
     lazy: false,
     default: () => null,
-    server: true,
-    getCachedData: key => useNuxtData(key).data.value
+    server: true
 });
 
 // 监听数据变化并更新 book.value
@@ -1149,7 +1150,7 @@ watch(() => fetchError.value, (newError) => {
 // 监听加载状态
 watch(() => fetchPending.value, (newPending) => {
     pending.value = newPending;
-});
+}, { immediate: true });
 
 // Computed properties
 const pub_year = computed(() => {
@@ -1316,7 +1317,7 @@ const sendToDevice = async () => {
             };
         }
 
-        const response = await $backend(`/book/${bookid}/send_to_device`, {
+        const response = await $backend(`/book/${bookid.value}/send_to_device`, {
             method: 'POST',
             body: JSON.stringify(requestBody),
         });
@@ -1341,7 +1342,7 @@ const get_refer = async () => {
 
     let firstLine = true;
     try {
-        for await (const data of $backend_stream(`/book/${bookid}/refer?stream=1`)) {
+        for await (const data of $backend_stream(`/book/${bookid.value}/refer?stream=1`)) {
             if (firstLine) {
                 firstLine = false;
                 refer_books_loading.value = false;
@@ -1372,7 +1373,7 @@ const set_refer = async (provider_key, provider_value, opt = {}) => {
     data.append('provider_value', provider_value);
 
     try {
-        const rsp = await $backend(`/book/${bookid}/refer`, {
+        const rsp = await $backend(`/book/${bookid.value}/refer`, {
             method: 'POST',
             body: data,
         });
@@ -1380,7 +1381,7 @@ const set_refer = async (provider_key, provider_value, opt = {}) => {
         dialog_refer.value = false;
         if (rsp.err === 'ok') {
             if ($alert) $alert('success', t('book.setSuccess'));
-            router.push(`/book/${bookid}`);
+            router.push(`/book/${bookid.value}`);
             location.reload();
         } else {
             if ($alert) $alert('error', rsp.msg);
@@ -1394,13 +1395,13 @@ const set_refer = async (provider_key, provider_value, opt = {}) => {
 
 const set_scope = async () => {
     try {
-        const rsp = await $backend(`/book/${bookid}/setscope`, {
+        const rsp = await $backend(`/book/${bookid.value}/setscope`, {
             method: 'POST',
         });
 
         if (rsp.err === 'ok') {
             if ($alert) $alert('success', rsp.msg);
-            const refreshRsp = await $backend(`/book/${bookid}`);
+            const refreshRsp = await $backend(`/book/${bookid.value}`);
             if (refreshRsp.err === 'ok' && refreshRsp.book) {
                 Object.assign(book.value, refreshRsp.book);
             }
@@ -1416,7 +1417,7 @@ const delete_book = async () => {
     if (!confirm(t('book.confirmDelete'))) return;
 
     try {
-        const rsp = await $backend(`/book/${bookid}/delete`, {
+        const rsp = await $backend(`/book/${bookid.value}/delete`, {
             method: 'POST',
         });
 
@@ -1627,36 +1628,17 @@ watch(selectedDeviceOption, (newValue) => {
     }
 });
 
-const READING_STATE = { UNREAD: 0, READING: 1, FINISHED: 2 };
-
-const isInShelf = ref(false);
-const readingState = ref(0);
 const readingStateLoading = ref(false);
-const readDays = ref(0);
-const lastReadTime = ref('');
-
-const loadReadingState = async () => {
-    if (!store.user.is_login || !book.value.id) return;
-    try {
-        const rsp = await $backend(`/book/${book.value.id}/readstate`);
-        if (rsp.err === 'ok') {
-            isInShelf.value = !!rsp.wants;
-            readingState.value = rsp.read_state || 0;
-            readDays.value = rsp.read_days || 0;
-            lastReadTime.value = rsp.read_date || '';
-        }
-        if (book.value.state) {
-            if (!rsp || rsp.err !== 'ok') {
-                isInShelf.value = !!book.value.state.wants;
-                readingState.value = book.value.state.read_state || 0;
-            }
-            readDays.value = book.value.state.read_days || 0;
-            lastReadTime.value = book.value.state.last_read_time || '';
-        }
-    } catch (e) {
-        console.error('Failed to load reading state:', e);
-    }
-};
+const {
+    isInShelf,
+    readingState,
+    readDays,
+    lastReadTime,
+} = useBookReadingState({
+    bookId: computed(() => Number(bookid.value) || 0),
+    isLogin: computed(() => store.user?.is_login),
+    backend: $backend,
+});
 
 const toggleShelf = async () => {
     readingStateLoading.value = true;
@@ -1737,12 +1719,6 @@ const readingStateButtonText = computed(() => {
         return t('readingState.setDone');
     }
     return t('readingState.setReading');
-});
-
-watch(() => book.value.id, (newId) => {
-    if (newId) {
-        loadReadingState();
-    }
 });
 
 // Load devices on mount

--- a/app/pages/book/[bid]/index.vue
+++ b/app/pages/book/[bid]/index.vue
@@ -747,6 +747,7 @@
                                         {{ author }}
                                     </v-chip>
                                     <v-chip
+                                        v-if="book.publisher"
                                         class="ma-1"
                                         size="small"
                                         color="primary"
@@ -1771,10 +1772,6 @@ onMounted(async () => {
 
 .tag-chips a {
     margin: 4px 2px;
-}
-
-.tag-chips :deep(.v-chip) {
-    color: white !important;
 }
 
 /* 减小管理菜单图标和文字的间距 */

--- a/app/test/composables/useBookReadingState.spec.ts
+++ b/app/test/composables/useBookReadingState.spec.ts
@@ -1,0 +1,98 @@
+import { flushPromises } from '@vue/test-utils';
+import { nextTick, ref } from 'vue';
+import { describe, expect, it, vi } from 'vitest';
+import {
+    calculateReadDays,
+    READING_STATE,
+    useBookReadingState,
+} from '~/composables/useBookReadingState';
+
+const flushState = async () => {
+    await nextTick();
+    await flushPromises();
+    await nextTick();
+};
+
+const deferred = <T>() => {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((resolvePromise) => {
+        resolve = resolvePromise;
+    });
+    return { promise, resolve };
+};
+
+describe('useBookReadingState', () => {
+    it('derives elapsed reading days from the API read date', () => {
+        expect(calculateReadDays('2026-07-19T08:00:00.000Z', Date.parse('2026-07-22T08:00:00.000Z'))).toBe(3);
+        expect(calculateReadDays('invalid', Date.parse('2026-07-22T08:00:00.000Z'))).toBe(0);
+    });
+
+    it('clears state on logout and restores it after login', async () => {
+        const bookId = ref(1);
+        const isLogin = ref(true);
+        const backend = vi.fn().mockResolvedValue({
+            err: 'ok',
+            wants: true,
+            read_state: READING_STATE.READING,
+            read_date: '2026-07-19T08:00:00.000Z',
+        });
+        const state = useBookReadingState({
+            bookId,
+            isLogin,
+            backend,
+            now: () => Date.parse('2026-07-22T08:00:00.000Z'),
+        });
+
+        await flushState();
+        expect(state.isInShelf.value).toBe(true);
+        expect(state.readingState.value).toBe(READING_STATE.READING);
+        expect(state.readDays.value).toBe(3);
+
+        isLogin.value = false;
+        await flushState();
+        expect(state.isInShelf.value).toBe(false);
+        expect(state.readingState.value).toBe(READING_STATE.UNREAD);
+        expect(state.readDays.value).toBe(0);
+
+        isLogin.value = true;
+        await flushState();
+        expect(backend).toHaveBeenCalledTimes(2);
+        expect(state.isInShelf.value).toBe(true);
+        expect(state.readingState.value).toBe(READING_STATE.READING);
+    });
+
+    it('ignores an old response after switching books', async () => {
+        const firstResponse = deferred<Record<string, unknown>>();
+        const bookId = ref(1);
+        const isLogin = ref(true);
+        const backend = vi.fn((url: string) => {
+            if (url === '/book/1/readstate') {
+                return firstResponse.promise;
+            }
+            return Promise.resolve({
+                err: 'ok',
+                wants: false,
+                read_state: READING_STATE.FINISHED,
+                read_date: '2026-07-22T08:00:00.000Z',
+            });
+        });
+        const state = useBookReadingState({ bookId, isLogin, backend });
+
+        await nextTick();
+        bookId.value = 2;
+        await flushState();
+        expect(state.isInShelf.value).toBe(false);
+        expect(state.readingState.value).toBe(READING_STATE.FINISHED);
+
+        firstResponse.resolve({
+            err: 'ok',
+            wants: true,
+            read_state: READING_STATE.READING,
+            read_date: '2026-07-19T08:00:00.000Z',
+        });
+        await flushState();
+
+        expect(state.isInShelf.value).toBe(false);
+        expect(state.readingState.value).toBe(READING_STATE.FINISHED);
+    });
+});

--- a/app/test/e2e/book-detail.spec.ts
+++ b/app/test/e2e/book-detail.spec.ts
@@ -11,15 +11,24 @@ const mockDir = path.join(__dirname, 'mocks');
 const books = JSON.parse(fs.readFileSync(path.join(mockDir, 'books.json'), 'utf-8'));
 const bookId = books[0].id;
 const apiBook = JSON.parse(fs.readFileSync(path.join(mockDir, `api_book_${bookId}.json`), 'utf-8'));
+const mockApiUrl = process.env.MOCK_API_URL || 'http://127.0.0.1:8080';
 
 test.describe('Book Detail Page', () => {
-    // No page.route, relying on real mock server
+    test.beforeEach(async ({ page, request }) => {
+        await request.post(`${mockApiUrl}/_test/reset`, {
+            data: { installed: true },
+        });
+        await page.context().clearCookies();
+        await page.addInitScript(() => {
+            window.localStorage.removeItem('talebook.activeTheme');
+        });
+    });
 
     test('displays book details', async ({ page }) => {
         await page.goto(`/book/${bookId}`);
 
         // Check title
-        await expect(page.getByText(apiBook.book.title).first()).toBeVisible();
+        await expect(page.getByText(apiBook.book.title).first()).toBeVisible({ timeout: 15_000 });
 
         // Check author
         if (apiBook.book.authors && apiBook.book.authors.length > 0) {
@@ -37,5 +46,34 @@ test.describe('Book Detail Page', () => {
     
         // Check download button (dialog trigger)
         await expect(page.getByText('下载').first()).toBeVisible();
+    });
+
+    test('keeps metadata chips readable and linked in the default light theme', async ({ page }) => {
+        await page.goto(`/book/${bookId}`);
+        await expect(page.getByText(apiBook.book.title).first()).toBeVisible({ timeout: 15_000 });
+
+        const metadata = page.locator('.tag-chips');
+        const author = apiBook.book.authors[0];
+        const tag = apiBook.book.tags[0];
+        const authorChip = metadata.locator(`a[href="/author/${encodeURIComponent(author)}"]`);
+        const tagChip = metadata.locator(`a[href="/tag/${encodeURIComponent(tag)}"]`);
+        const publisherChip = metadata.locator('a', { hasText: apiBook.book.publisher });
+
+        await expect(authorChip).toBeVisible();
+        await expect(authorChip).toContainText(author);
+        await expect(tagChip).toBeVisible();
+        await expect(tagChip).toContainText(tag);
+
+        const authorTextColor = await authorChip.evaluate(element => getComputedStyle(element).color);
+        expect(authorTextColor).not.toBe('rgb(255, 255, 255)');
+
+        await expect(publisherChip).toBeVisible();
+        await expect(publisherChip).toHaveAttribute('href', `/publisher/${encodeURIComponent(apiBook.book.publisher)}`);
+
+        if (apiBook.book.series) {
+            const seriesChip = metadata.locator(`a[href="/series/${encodeURIComponent(apiBook.book.series)}"]`);
+            await expect(seriesChip).toBeVisible();
+            await expect(seriesChip).toContainText(apiBook.book.series);
+        }
     });
 });

--- a/app/test/e2e/shelf.spec.ts
+++ b/app/test/e2e/shelf.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -9,10 +9,29 @@ const __dirname = path.dirname(__filename);
 const mockDir = path.join(__dirname, 'mocks');
 const books = JSON.parse(fs.readFileSync(path.join(mockDir, 'books.json'), 'utf-8'));
 const book = books[0];
+const mockApiUrl = process.env.MOCK_API_URL || 'http://127.0.0.1:8080';
+
+const navigateWithinApp = async (page: Page, target: string) => {
+    await page.evaluate(async (path) => {
+        const root = document.querySelector('#__nuxt') as Element & {
+            __vue_app__?: {
+                config: {
+                    globalProperties: {
+                        $router: { push: (location: string) => Promise<unknown> };
+                    };
+                };
+            };
+        };
+        if (!root?.__vue_app__) {
+            throw new Error('Nuxt application is not mounted');
+        }
+        await root.__vue_app__.config.globalProperties.$router.push(path);
+    }, target);
+};
 
 test.describe('Shelf', () => {
     test.beforeEach(async ({ request }) => {
-        await request.post('http://127.0.0.1:8080/_test/reset', {
+        await request.post(`${mockApiUrl}/_test/reset`, {
             data: { installed: true }
         });
     });
@@ -21,7 +40,7 @@ test.describe('Shelf', () => {
         await page.goto('/user/shelf');
         await expect(page.getByText('书架上还没有书，快去加入吧！')).toBeVisible();
 
-        await request.post(`http://127.0.0.1:8080/api/book/${book.id}/shelf`, {
+        await request.post(`${mockApiUrl}/api/book/${book.id}/shelf`, {
             data: { shelf: true }
         });
 
@@ -30,8 +49,9 @@ test.describe('Shelf', () => {
         await expect(page.locator(`a[href="/book/${book.id}"]`).first()).toBeVisible();
     });
 
-    test('toggles shelf state from book detail', async ({ page, request }) => {
+    test('restores shelf state after reloading book detail', async ({ page, request }) => {
         await page.goto(`/book/${book.id}`);
+        await expect(page.getByText(book.title).first()).toBeVisible({ timeout: 15_000 });
 
         const addButton = page.getByRole('button', { name: '加入书架' }).last();
         await expect(addButton).toBeVisible();
@@ -40,8 +60,36 @@ test.describe('Shelf', () => {
         await shelfResponse;
 
         await expect(page.getByRole('button', { name: '移除书架' }).first()).toBeVisible();
-        const rsp = await request.get('http://127.0.0.1:8080/api/shelf');
+        const rsp = await request.get(`${mockApiUrl}/api/shelf`);
         const data = await rsp.json();
         expect(data.books.some((item: { id: number }) => item.id === book.id)).toBe(true);
+
+        await page.reload();
+        await expect(page.getByRole('button', { name: '移除书架' }).first()).toBeVisible();
+    });
+
+    test('restores reading state after reload and keeps books independent', async ({ page }) => {
+        await page.goto(`/book/${book.id}`);
+        await expect(page.getByText(book.title).first()).toBeVisible({ timeout: 15_000 });
+
+        const setReadingButton = page.getByRole('button', { name: '设为在读' }).last();
+        await expect(setReadingButton).toBeVisible();
+        const readingResponse = page.waitForResponse(resp => resp.url().includes(`/api/book/${book.id}/readstate`) && resp.request().method() === 'POST');
+        await setReadingButton.evaluate((el: HTMLElement) => el.click());
+        await readingResponse;
+
+        await expect(page.getByRole('button', { name: '标记读完' })).toBeVisible();
+        await expect(page.getByText('在读', { exact: true }).last()).toBeVisible();
+
+        await page.reload();
+        await expect(page.getByRole('button', { name: '标记读完' })).toBeVisible();
+        await expect(page.getByText('在读', { exact: true }).last()).toBeVisible();
+        await expect(page.getByText('已阅读不足一天')).toBeVisible();
+
+        await navigateWithinApp(page, '/book/2');
+        await expect(page).toHaveURL(/\/book\/2$/);
+        await expect(page.getByText(books[1].title).first()).toBeVisible();
+        await expect(page.getByRole('button', { name: '设为在读' })).toBeVisible();
+        await expect(page.getByText('在读', { exact: true })).toHaveCount(0);
     });
 });

--- a/app/test/e2e/shelf.spec.ts
+++ b/app/test/e2e/shelf.spec.ts
@@ -12,20 +12,19 @@ const book = books[0];
 const mockApiUrl = process.env.MOCK_API_URL || 'http://127.0.0.1:8080';
 
 const navigateWithinApp = async (page: Page, target: string) => {
-    await page.evaluate(async (path) => {
-        const root = document.querySelector('#__nuxt') as Element & {
-            __vue_app__?: {
-                config: {
-                    globalProperties: {
-                        $router: { push: (location: string) => Promise<unknown> };
-                    };
-                };
-            };
+    await page.evaluate((path) => {
+        const currentState = window.history.state || {};
+        const nextState = {
+            ...currentState,
+            back: `${window.location.pathname}${window.location.search}${window.location.hash}`,
+            current: path,
+            forward: null,
+            position: Number(currentState.position || 0) + 1,
+            replaced: false,
+            scroll: null,
         };
-        if (!root?.__vue_app__) {
-            throw new Error('Nuxt application is not mounted');
-        }
-        await root.__vue_app__.config.globalProperties.$router.push(path);
+        window.history.pushState(nextState, '', path);
+        window.dispatchEvent(new PopStateEvent('popstate', { state: nextState }));
     }, target);
 };
 

--- a/app/test/mock-server.js
+++ b/app/test/mock-server.js
@@ -17,6 +17,7 @@ let saveStatusPolls = 0;
 let booksourceCheckRunning = false;
 let booksourceCheckPolls = 0;
 let shelfBookIds = new Set();
+let readingStateByBookId = new Map();
 let activeThemeName = '';
 
 const builtinThemes = [
@@ -125,6 +126,7 @@ router.post('/_test/reset', eventHandler(async (event) => {
   booksourceCheckRunning = false;
   booksourceCheckPolls = 0;
   shelfBookIds = new Set();
+  readingStateByBookId = new Map();
   activeThemeName = '';
   return { status: 'ok' };
 }));
@@ -415,19 +417,22 @@ const getShelfBooks = () => {
   const books = readJson('books.json') || [];
   return books
     .filter(book => shelfBookIds.has(Number(book.id)))
-    .map(book => ({
-      ...book,
-      state: {
-        favorite: 0,
-        favorite_date: null,
-        wants: 1,
-        wants_date: '2023-01-01T00:00:00',
-        read_state: 0,
-        read_date: null,
-        online_read: 0,
-        download: 0,
-      },
-    }));
+    .map((book) => {
+      const reading = readingStateByBookId.get(Number(book.id));
+      return {
+        ...book,
+        state: {
+          favorite: 0,
+          favorite_date: null,
+          wants: 1,
+          wants_date: '2023-01-01T00:00:00',
+          read_state: reading?.readState || 0,
+          read_date: reading?.readDate || null,
+          online_read: 0,
+          download: 0,
+        },
+      };
+    });
 };
 
 router.get('/api/shelf', eventHandler(() => {
@@ -453,12 +458,13 @@ router.post('/api/book/:id/shelf', eventHandler(async (event) => {
 
 router.get('/api/book/:id/readstate', eventHandler((event) => {
   const id = Number(getRouterParam(event, 'id'));
+  const reading = readingStateByBookId.get(id);
   return {
     err: 'ok',
     favorite: false,
     wants: shelfBookIds.has(id),
-    read_state: 0,
-    read_date: null,
+    read_state: reading?.readState || 0,
+    read_date: reading?.readDate || null,
     favorite_date: null,
     wants_date: shelfBookIds.has(id) ? '2023-01-01T00:00:00' : null,
     online_read: 0,
@@ -466,10 +472,22 @@ router.get('/api/book/:id/readstate', eventHandler((event) => {
   };
 }));
 
-router.post('/api/book/:id/readstate', eventHandler(() => ({
-  err: 'ok',
-  msg: 'Reading state updated',
-})));
+router.post('/api/book/:id/readstate', eventHandler(async (event) => {
+  const id = Number(getRouterParam(event, 'id'));
+  const body = await readBody(event);
+  const readState = Number(body?.read_state || 0);
+  if (![0, 1, 2].includes(readState)) {
+    return { err: 'params.invalid', msg: 'Invalid reading state' };
+  }
+  readingStateByBookId.set(id, {
+    readState,
+    readDate: new Date().toISOString(),
+  });
+  return {
+    err: 'ok',
+    msg: 'Reading state updated',
+  };
+}));
 
 // Book Detail
 router.get('/api/book/:id', eventHandler((event) => {

--- a/design/app/20260722-book-detail-metadata-chips-visibility.active.html
+++ b/design/app/20260722-book-detail-metadata-chips-visibility.active.html
@@ -1,0 +1,199 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>书籍详情元数据标签可见性修复方案 · ACTIVE</title>
+  <style>
+    :root {
+      --ink: #17263a;
+      --muted: #5e6d7f;
+      --paper: #eef2f6;
+      --card: #ffffff;
+      --line: #c9d4df;
+      --blue: #1c6bc5;
+      --blue-soft: #deedff;
+      --red: #b83d45;
+      --red-soft: #fde8e9;
+      --green: #18765a;
+      --green-soft: #ddf4e9;
+      --amber: #a16207;
+      --mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      --sans: "Avenir Next", "PingFang SC", "Microsoft YaHei", sans-serif;
+    }
+    * { box-sizing: border-box; }
+    html { background: var(--paper); color: var(--ink); font-family: var(--sans); }
+    body { margin: 0; line-height: 1.68; }
+    main { width: min(1080px, calc(100% - 32px)); margin: 32px auto 72px; }
+    header, section { border: 1px solid var(--line); background: var(--card); }
+    header { padding: clamp(28px, 6vw, 58px); border-radius: 24px; background: var(--ink); color: white; }
+    .eyebrow { margin: 0 0 10px; color: #9bc8ff; font: 700 13px/1.4 var(--mono); letter-spacing: .12em; }
+    h1 { max-width: 800px; margin: 0; font-size: clamp(32px, 6vw, 58px); line-height: 1.08; letter-spacing: -.035em; }
+    .lede { max-width: 760px; margin: 20px 0 0; color: #d7e2ee; font-size: 18px; }
+    .meta { display: flex; flex-wrap: wrap; gap: 9px; margin-top: 28px; }
+    .pill { padding: 6px 11px; border: 1px solid rgba(255,255,255,.24); border-radius: 999px; font: 700 12px/1.3 var(--mono); }
+    .pill.status { border-color: #ffb2b6; background: var(--red); }
+    section { margin-top: 22px; padding: clamp(22px, 4vw, 36px); border-radius: 20px; }
+    h2 { margin: 0 0 16px; font-size: 24px; line-height: 1.25; }
+    h3 { margin: 22px 0 8px; font-size: 17px; }
+    p { margin: 10px 0; }
+    ul, ol { margin: 10px 0; padding-left: 22px; }
+    li + li { margin-top: 6px; }
+    code { padding: 2px 5px; border-radius: 5px; background: #e8eef4; color: #194e83; font: 13px/1.5 var(--mono); }
+    table { width: 100%; border-collapse: collapse; font-size: 14px; }
+    th, td { padding: 11px 9px; border-bottom: 1px solid var(--line); text-align: left; vertical-align: top; }
+    th { color: var(--muted); font: 700 12px/1.4 var(--mono); }
+    .callout { padding: 16px 18px; border-left: 5px solid var(--red); border-radius: 10px; background: var(--red-soft); }
+    .decision { border-left-color: var(--blue); background: var(--blue-soft); }
+    .grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 15px; }
+    .mini { padding: 18px; border: 1px solid var(--line); border-radius: 13px; background: #f8fafc; }
+    .mini h3 { margin-top: 0; }
+    .label { color: var(--muted); font: 700 11px/1.4 var(--mono); letter-spacing: .1em; text-transform: uppercase; }
+    .flow { display: grid; grid-template-columns: 1fr 54px 1fr 54px 1fr; align-items: center; gap: 8px; }
+    .node { min-height: 138px; padding: 16px; border: 1px solid var(--line); border-radius: 13px; background: #f8fafc; }
+    .node.bad { border-color: #e2a4a8; background: var(--red-soft); }
+    .node.good { border-color: #92cbb8; background: var(--green-soft); }
+    .arrow { color: var(--blue); text-align: center; font: 800 28px/1 var(--mono); }
+    .pending { color: var(--amber); font-weight: 700; }
+    .passed { color: var(--green); font-weight: 700; }
+    footer { margin-top: 18px; color: var(--muted); text-align: center; font: 12px/1.6 var(--mono); }
+    @media (max-width: 760px) {
+      main { width: min(100% - 20px, 1080px); margin-top: 10px; }
+      header, section { border-radius: 15px; }
+      .grid { grid-template-columns: 1fr; }
+      .flow { grid-template-columns: 1fr; }
+      .arrow { transform: rotate(90deg); }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <p class="eyebrow">DESIGN / APP / VISUAL REGRESSION</p>
+      <h1>书籍详情元数据标签可见性修复</h1>
+      <p class="lede">修正默认浅色主题下作者、出版社、系列、ISBN 与普通标签已经渲染却不可见的问题，并用真实渲染回归覆盖所有内置主题的明暗模式。</p>
+      <div class="meta">
+        <span class="pill status">ACTIVE · 已完成验证</span>
+        <span class="pill">创建日期 2026-07-22</span>
+        <span class="pill">模块 app</span>
+        <span class="pill">分支 fix/20260722-book-reading-state-refresh</span>
+        <span class="pill">需求来源 用户截图反馈</span>
+      </div>
+    </header>
+
+    <section>
+      <h2>01. 原始诉求与缺陷表现</h2>
+      <div class="callout">用户提供默认主题与水墨主题的书籍详情对比截图，并指出前端标签没有显示。默认主题中标签区域只看得到“公共书籍”；水墨主题中作者、出版社、普通标签及“公共书籍”均正常可见。</div>
+      <p>经确认，DOM 与接口数据都存在，缺陷属于颜色规则冲突造成的视觉不可见，不是后端漏字段，也不是 Vue 条件渲染失败。</p>
+      <table>
+        <thead><tr><th>现场</th><th>观察</th><th>判断</th></tr></thead>
+        <tbody>
+          <tr><td>默认浅色主题</td><td>作者、出版社、普通标签不可见；绿色“公共书籍”可见</td><td><code>tonal</code> 标签受错误文字色影响，<code>flat</code> 状态标签仍有实体背景</td></tr>
+          <tr><td>水墨主题</td><td>同一组元数据标签全部可见</td><td>内置主题覆盖层重新指定 tonal 配色，暂时掩盖页面级错误规则</td></tr>
+          <tr><td>接口与模板</td><td><code>authors</code>、<code>publisher</code>、<code>tags</code> 均有值且对应 Chip 已渲染</td><td>无需修改 API、字段或模板数据流</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>02. 根因链路</h2>
+      <div class="flow" aria-label="从历史样式到视觉缺陷的因果链">
+        <article class="node">
+          <p class="label">历史前提</p>
+          <h3>Flat Chip</h3>
+          <p>早期元数据 Chip 使用深色 <code>flat</code> 背景，因此页面添加了强制白字规则。</p>
+        </article>
+        <div class="arrow" aria-hidden="true">→</div>
+        <article class="node bad">
+          <p class="label">2026-07-09 变更</p>
+          <h3>Tonal + 遗留白字</h3>
+          <p><code>9feaea00</code> 将元数据改为 <code>primary + tonal</code>，但 <code>color: white !important</code> 没有同步移除。</p>
+        </article>
+        <div class="arrow" aria-hidden="true">→</div>
+        <article class="node good">
+          <p class="label">计划修复</p>
+          <h3>交还 Vuetify / 主题</h3>
+          <p>移除页面级强制文字色，让默认主题和内置主题分别按各自 primary tonal 调色板生成前景与背景。</p>
+        </article>
+      </div>
+      <p>直接冲突位于 <code>app/pages/book/[bid]/index.vue</code> 的 scoped CSS：<code>.tag-chips :deep(.v-chip) { color: white !important; }</code>。该规则最初服务于深色 <code>flat</code> Chip；变体改成 <code>tonal</code> 后已不再成立。</p>
+    </section>
+
+    <section>
+      <h2>03. 目标与边界</h2>
+      <div class="grid">
+        <article class="mini">
+          <p class="label">必须达成</p>
+          <h3>所有主题中清晰、完整、可用</h3>
+          <ul>
+            <li>默认主题以及五个内置主题的浅色、深色模式均可清楚辨认元数据 Chip。</li>
+            <li>作者、出版社、系列、ISBN、普通标签全部覆盖；有链接的 Chip 保持可点击。</li>
+            <li>公有、私有状态继续保留 teal / orange 语义色。</li>
+            <li>缺少可选元数据时继续遵循现有条件渲染，不制造空标签。</li>
+          </ul>
+        </article>
+        <article class="mini">
+          <p class="label">明确不做</p>
+          <h3>不扩张数据与主题契约</h3>
+          <ul>
+            <li>不修改后端 API、数据库、权限或 Calibre 元数据。</li>
+            <li>不改变 Chip 的文案、顺序、跳转地址、尺寸或间距。</li>
+            <li>不为单个主题硬编码新的颜色。</li>
+            <li>不重构整页样式或内置主题系统。</li>
+          </ul>
+        </article>
+      </div>
+    </section>
+
+    <section>
+      <h2>04. 实现方案</h2>
+      <div class="callout decision">删除详情页对所有元数据 Chip 的强制白字覆盖；保留现有 <code>color="primary"</code> 与 <code>variant="tonal"</code>，由 Vuetify 默认主题或当前内置主题的调色板决定文字与底色。出版社 Chip 改为仅在字段就绪后挂载，避免初始空值生成的 <code>/publisher/</code> 链接被组件缓存。状态 Chip 仍由自身的 <code>flat</code> 变体和 teal / orange 颜色控制。</div>
+      <table>
+        <thead><tr><th>位置</th><th>计划变更</th><th>理由</th></tr></thead>
+        <tbody>
+          <tr><td><code>app/pages/book/[bid]/index.vue</code></td><td>移除 <code>.tag-chips :deep(.v-chip)</code> 的白色文字强制规则；出版社 Chip 增加字段存在条件</td><td>恢复 Vuetify tonal 的前景/背景配对，并确保异步数据返回后以真实出版社生成链接</td></tr>
+          <tr><td><code>app/test/e2e/book-detail.spec.ts</code></td><td>精确定位元数据 Chip，断言作者、出版社、普通标签可见且链接正确；默认浅色主题下验证 tonal 前景色不再被强制为白色</td><td>普通 <code>toBeVisible</code> 无法识别白底白字，需要加入计算样式回归</td></tr>
+          <tr><td>本方案文档</td><td>测试完成后回写命令、主题矩阵、截图路径与实际结果，并改为 <code>.active.html</code></td><td>保存缺陷证据和可复核验收记录</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>05. 验收矩阵</h2>
+      <table>
+        <thead><tr><th>层级</th><th>验证内容</th><th>计划命令 / 页面</th><th>当前状态</th></tr></thead>
+        <tbody>
+          <tr><td>E2E 回归</td><td>作者、出版社、系列、普通标签可见，链接正确，默认浅色 tonal 前景未被强制为白色</td><td><code>npx playwright test test/e2e/book-detail.spec.ts --project=chromium</code></td><td class="passed">通过 · 2 passed</td></tr>
+          <tr><td>真实渲染</td><td>默认主题 + light-gray / minimal / graphite / brass / warm-red，共六种主题的浅色与深色模式</td><td>Chrome DevTools MCP，真实 dev 后端与 production preview 访问 <code>/book/13</code>；逐项检查作者、出版社、ISBN、普通标签、公有状态</td><td class="passed">通过 · 12 / 12 组合</td></tr>
+          <tr><td>交互</td><td>作者、出版社、普通标签 Chip 跳转地址仍正确</td><td>Chrome DevTools MCP 检查真实渲染链接</td><td class="passed">通过</td></tr>
+          <tr><td>前端检查</td><td>目标测试、全量 lint 与 production build</td><td><code>cd app &amp;&amp; npm run lint</code>；<code>cd app &amp;&amp; npm run build</code></td><td class="passed">通过 · lint 0 errors；build 成功</td></tr>
+          <tr><td>工程门禁</td><td>方案、HTML 单文件资源与补丁完整性</td><td><code>make check-design</code>；<code>git diff --check</code></td><td class="passed">通过</td></tr>
+        </tbody>
+      </table>
+      <p>真实验收使用 Docker 中的 Talebook dev 后端（13 本书）与当前前端 production preview。先将安装状态切为未安装，经安装页创建 <code>admin</code> 管理员并完成真实登录，再由主题管理页面逐个激活主题。样本“北风”实际包含作者、出版社、ISBN、普通标签与公有状态；五个内置主题的明暗模式均记录到非透明、可辨认的计算前景色与背景色，最终恢复默认浅色主题。样本没有系列字段，系列由 E2E fixture 单独覆盖。</p>
+      <p>检查中没有与本次改动相关的失败项；eslint 保留仓库既有 warning，但错误数为 0。原生 Nuxt dev watcher 曾因工作区文件数量触发 <code>EMFILE</code>，按工程约束未启用 Chokidar polling，改用同一构建产物的 production preview 完成真实浏览器验收。</p>
+    </section>
+
+    <section>
+      <h2>06. 风险与回滚</h2>
+      <div class="grid">
+        <article class="mini">
+          <h3>风险控制</h3>
+          <ul>
+            <li>移除强制白字可能影响状态 Chip：通过公有与私有两种状态分别验收。</li>
+            <li>单纯 DOM 可见不代表视觉可见：E2E 同时检查默认浅色的计算样式，浏览器检查全部主题矩阵。</li>
+            <li>内置主题覆盖可能隐藏新冲突：浅色和深色必须分别实际渲染。</li>
+          </ul>
+        </article>
+        <article class="mini">
+          <h3>回滚策略</h3>
+          <p>改动限定为一条页面级 CSS 与测试。如果产生主题回归，可整体回退修复提交；不涉及数据、API 或迁移，不需要额外回滚步骤。</p>
+          <p><span class="label">完成条件</span><br>十二种“主题 × 明暗模式”组合均通过，目标 E2E、lint、build 与设计门禁通过后，方案方可转为 ACTIVE。</p>
+        </article>
+      </div>
+    </section>
+
+    <footer>Talebook · app · 20260722-book-detail-metadata-chips-visibility · ACTIVE</footer>
+  </main>
+</body>
+</html>

--- a/design/app/20260722-book-detail-metadata-chips-visibility.active.html
+++ b/design/app/20260722-book-detail-metadata-chips-visibility.active.html
@@ -164,13 +164,13 @@
         <thead><tr><th>层级</th><th>验证内容</th><th>计划命令 / 页面</th><th>当前状态</th></tr></thead>
         <tbody>
           <tr><td>E2E 回归</td><td>作者、出版社、系列、普通标签可见，链接正确，默认浅色 tonal 前景未被强制为白色</td><td><code>npx playwright test test/e2e/book-detail.spec.ts --project=chromium</code></td><td class="passed">通过 · 2 passed</td></tr>
-          <tr><td>真实渲染</td><td>默认主题 + light-gray / minimal / graphite / brass / warm-red，共六种主题的浅色与深色模式</td><td>Chrome DevTools MCP，真实 dev 后端与 production preview 访问 <code>/book/13</code>；逐项检查作者、出版社、ISBN、普通标签、公有状态</td><td class="passed">通过 · 12 / 12 组合</td></tr>
+          <tr><td>真实渲染</td><td>默认主题 + light-gray / minimal / graphite / brass / warm-red，共六种主题的浅色与深色模式</td><td>Chrome DevTools MCP，真实 dev 后端与 production preview 访问 <code>/book/13</code>；逐项检查作者、出版社、ISBN、普通标签与状态 Chip</td><td class="passed">通过 · 公有状态 12 / 12 组合；默认浅色另验私有状态</td></tr>
           <tr><td>交互</td><td>作者、出版社、普通标签 Chip 跳转地址仍正确</td><td>Chrome DevTools MCP 检查真实渲染链接</td><td class="passed">通过</td></tr>
           <tr><td>前端检查</td><td>目标测试、全量 lint 与 production build</td><td><code>cd app &amp;&amp; npm run lint</code>；<code>cd app &amp;&amp; npm run build</code></td><td class="passed">通过 · lint 0 errors；build 成功</td></tr>
           <tr><td>工程门禁</td><td>方案、HTML 单文件资源与补丁完整性</td><td><code>make check-design</code>；<code>git diff --check</code></td><td class="passed">通过</td></tr>
         </tbody>
       </table>
-      <p>真实验收使用 Docker 中的 Talebook dev 后端（13 本书）与当前前端 production preview。先将安装状态切为未安装，经安装页创建 <code>admin</code> 管理员并完成真实登录，再由主题管理页面逐个激活主题。样本“北风”实际包含作者、出版社、ISBN、普通标签与公有状态；五个内置主题的明暗模式均记录到非透明、可辨认的计算前景色与背景色，最终恢复默认浅色主题。样本没有系列字段，系列由 E2E fixture 单独覆盖。</p>
+      <p>真实验收使用 Docker 中的 Talebook dev 后端（13 本书）与当前前端 production preview。先将安装状态切为未安装，经安装页创建 <code>admin / demodemo</code> 并完成真实登录，再由主题管理页面逐个激活主题。样本“北风”实际包含作者、出版社、ISBN、普通标签与公有状态；五个内置主题的明暗模式均记录到非透明、可辨认的计算前景色与背景色。随后在默认浅色主题将书籍切为私有，确认“私有书籍” Chip 可见且计算样式为黑字橙底，再恢复为公有；最终恢复默认浅色主题。样本没有系列字段，系列由 E2E fixture 单独覆盖。</p>
       <p>检查中没有与本次改动相关的失败项；eslint 保留仓库既有 warning，但错误数为 0。原生 Nuxt dev watcher 曾因工作区文件数量触发 <code>EMFILE</code>，按工程约束未启用 Chokidar polling，改用同一构建产物的 production preview 完成真实浏览器验收。</p>
     </section>
 

--- a/design/app/20260722-book-reading-state-refresh.active.html
+++ b/design/app/20260722-book-reading-state-refresh.active.html
@@ -1,0 +1,261 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>书籍阅读状态刷新一致性修复方案</title>
+  <style>
+    :root {
+      --ink: #173b57;
+      --muted: #587083;
+      --paper: #edf5f7;
+      --card: #ffffff;
+      --line: #bfd4dc;
+      --teal: #168c82;
+      --teal-soft: #d7f2ec;
+      --rust: #c65f3e;
+      --rust-soft: #f9e8e2;
+      --gold: #c28a24;
+      --mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      --sans: "Avenir Next", "PingFang SC", "Microsoft YaHei", sans-serif;
+    }
+
+    * { box-sizing: border-box; }
+    html { background: var(--paper); color: var(--ink); font-family: var(--sans); }
+    body { margin: 0; line-height: 1.68; }
+    main { width: min(1120px, calc(100% - 32px)); margin: 32px auto 72px; }
+    header {
+      position: relative;
+      overflow: hidden;
+      padding: clamp(28px, 6vw, 64px);
+      border: 1px solid var(--line);
+      border-radius: 28px;
+      background: var(--ink);
+      color: #f7fbfc;
+    }
+    header::after {
+      content: "SYNC";
+      position: absolute;
+      right: -10px;
+      bottom: -48px;
+      color: rgba(215, 242, 236, .08);
+      font: 800 clamp(96px, 20vw, 220px)/1 var(--mono);
+      letter-spacing: -.08em;
+    }
+    .eyebrow { margin: 0 0 10px; color: #8fe0d3; font: 700 13px/1.4 var(--mono); letter-spacing: .12em; }
+    h1 { position: relative; z-index: 1; max-width: 780px; margin: 0; font-size: clamp(32px, 6vw, 64px); line-height: 1.08; letter-spacing: -.035em; }
+    .lede { position: relative; z-index: 1; max-width: 720px; margin: 22px 0 0; color: #d8e6eb; font-size: 18px; }
+    .meta { position: relative; z-index: 1; display: flex; flex-wrap: wrap; gap: 9px; margin-top: 30px; }
+    .pill { padding: 6px 11px; border: 1px solid rgba(255,255,255,.22); border-radius: 999px; font: 700 12px/1.3 var(--mono); }
+    .pill.status { border-color: #ffbd89; background: #c65f3e; color: #fff; }
+    section { margin-top: 24px; padding: clamp(22px, 4vw, 38px); border: 1px solid var(--line); border-radius: 22px; background: var(--card); }
+    h2 { margin: 0 0 18px; font-size: 25px; line-height: 1.25; letter-spacing: -.02em; }
+    h3 { margin: 24px 0 10px; font-size: 17px; }
+    p { margin: 10px 0; }
+    ul, ol { margin: 10px 0; padding-left: 22px; }
+    li + li { margin-top: 7px; }
+    code { padding: 2px 5px; border-radius: 5px; background: #e5eff2; color: #19445f; font: 13px/1.5 var(--mono); }
+    .callout { padding: 16px 18px; border-left: 5px solid var(--rust); border-radius: 10px; background: var(--rust-soft); }
+    .success { border-left-color: var(--teal); background: var(--teal-soft); }
+    .grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px; }
+    .mini { padding: 18px; border: 1px solid var(--line); border-radius: 14px; background: #f8fbfc; }
+    .mini h3 { margin-top: 0; }
+    .label { color: var(--muted); font: 700 11px/1.4 var(--mono); letter-spacing: .11em; text-transform: uppercase; }
+    table { width: 100%; border-collapse: collapse; font-size: 14px; }
+    th, td { padding: 12px 10px; border-bottom: 1px solid var(--line); text-align: left; vertical-align: top; }
+    th { color: var(--muted); font: 700 12px/1.4 var(--mono); }
+    .ledger { display: grid; grid-template-columns: 1fr 92px 1fr; align-items: stretch; margin-top: 18px; }
+    .ledger article { padding: 22px; border: 1px solid var(--line); border-radius: 16px; background: #f8fbfc; }
+    .ledger .merge { display: grid; place-items: center; color: var(--teal); }
+    .ledger svg { width: 72px; height: 72px; }
+    .ledger strong { display: block; margin: 8px 0; font-size: 20px; }
+    .sequence { overflow-x: auto; padding: 18px; border: 1px solid var(--line); border-radius: 16px; background: #f8fbfc; }
+    .sequence svg { display: block; width: 100%; min-width: 760px; height: auto; }
+    .tag { display: inline-block; margin: 2px 3px 2px 0; padding: 3px 7px; border-radius: 6px; background: var(--teal-soft); color: #126a63; font: 700 12px/1.3 var(--mono); }
+    .pending { color: var(--gold); font-weight: 700; }
+    footer { margin-top: 20px; color: var(--muted); text-align: center; font: 12px/1.6 var(--mono); }
+    @media (max-width: 760px) {
+      main { width: min(100% - 20px, 1120px); margin-top: 10px; }
+      header, section { border-radius: 16px; }
+      .grid { grid-template-columns: 1fr; }
+      .ledger { grid-template-columns: 1fr; gap: 10px; }
+      .ledger .merge { transform: rotate(90deg); }
+    }
+    @media (prefers-reduced-motion: reduce) { * { scroll-behavior: auto !important; } }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <p class="eyebrow">DESIGN / APP / STATE RECONCILIATION</p>
+      <h1>书籍阅读状态刷新一致性修复</h1>
+      <p class="lede">让“加入书架”和“阅读状态”在首次打开、硬刷新、切换书籍及登录态变化后，始终以服务端已持久化状态为准。</p>
+      <div class="meta">
+        <span class="pill status">ACTIVE · 已验证</span>
+        <span class="pill">创建日期 2026-07-22</span>
+        <span class="pill">模块 app</span>
+        <span class="pill">分支 fix/20260722-book-reading-state-refresh</span>
+      </div>
+    </header>
+
+    <section>
+      <h2>01. 原始诉求与现场证据</h2>
+      <div class="callout">
+        用户提供的视频显示：登录后在书籍详情页执行“加入书架”或“设为在读”，当前页面会即时变化；刷新页面后，按钮却退回默认状态，造成操作未保存的错觉。
+      </div>
+      <p><span class="label">需求来源</span><br>用户于 2026-07-22 提供的本地录屏及随后确认的修复边界。</p>
+      <table>
+        <thead><tr><th>检查项</th><th>结果</th><th>结论</th></tr></thead>
+        <tbody>
+          <tr><td>本地浏览器基线复现</td><td>操作后显示“移除书架”；硬刷新后重新显示“加入书架”</td><td>问题稳定存在于 UI 初始化阶段</td></tr>
+          <tr><td><code>GET /api/book/{id}/readstate</code></td><td>刷新后仍返回 <code>wants: true</code></td><td>服务端已经持久化，不能通过重复写入修复</td></tr>
+          <tr><td>页面状态监听</td><td>仅监听书籍 ID 变化，且没有 <code>immediate</code></td><td>首次挂载时 ID 已就绪，监听器可能永不触发</td></tr>
+          <tr><td>登录态监听</td><td>登录变化只刷新设备列表</td><td>阅读状态不会随登录/退出同步或清空</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>02. 目标与边界</h2>
+      <div class="grid">
+        <article class="mini">
+          <p class="label">必须达成</p>
+          <h3>服务端真值驱动 UI</h3>
+          <ul>
+            <li>首次进入及硬刷新时拉取当前书籍状态。</li>
+            <li>书籍路由切换、登录成功时重新同步。</li>
+            <li>退出登录或没有有效书籍时清空用户态，避免串号。</li>
+            <li>快速切换时丢弃过期响应，避免旧书状态覆盖新书。</li>
+          </ul>
+        </article>
+        <article class="mini">
+          <p class="label">明确不做</p>
+          <h3>保持现有业务契约</h3>
+          <ul>
+            <li>不修改后端 API、数据库或权限模型。</li>
+            <li>不改变“加入/移除书架”“在读/读完”的按钮语义。</li>
+            <li>不新增本地持久化或乐观状态队列。</li>
+            <li>不借此重构整页数据加载架构。</li>
+          </ul>
+        </article>
+      </div>
+    </section>
+
+    <section>
+      <h2>03. 状态账本：默认值与服务端真值合流</h2>
+      <div class="ledger">
+        <article>
+          <p class="label">UI 安全默认值</p>
+          <strong>未加入 · 未标记</strong>
+          <p>仅用于未登录、书籍无效或请求尚未完成时，不能覆盖已经返回的服务端状态。</p>
+          <span class="tag">isInShelf = false</span>
+          <span class="tag">readingState = 0</span>
+        </article>
+        <div class="merge" aria-label="合流到服务端真值">
+          <svg viewBox="0 0 72 72" role="img" aria-hidden="true">
+            <circle cx="36" cy="36" r="31" fill="#d7f2ec" stroke="#168c82" stroke-width="2"/>
+            <path d="M18 27h24l-6-6m18 24H30l6 6" fill="none" stroke="#168c82" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+        </div>
+        <article>
+          <p class="label">API 权威状态</p>
+          <strong>按书籍、按用户恢复</strong>
+          <p><code>/readstate</code> 返回后更新书架、阅读状态和最近阅读时间，并根据 <code>read_date</code> 推导已阅读天数；页面展示以该响应为准。</p>
+          <span class="tag">wants</span>
+          <span class="tag">read_state</span>
+          <span class="tag">read_date</span>
+          <span class="tag">derived read days</span>
+        </article>
+      </div>
+    </section>
+
+    <section>
+      <h2>04. 同步流程</h2>
+      <div class="sequence">
+        <svg viewBox="0 0 980 285" role="img" aria-labelledby="sequence-title sequence-desc">
+          <title id="sequence-title">书籍阅读状态同步时序</title>
+          <desc id="sequence-desc">页面触发立即监听，先重置，再请求服务端，并校验请求对应的书籍后更新界面。</desc>
+          <defs>
+            <marker id="arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto"><path d="M0,0 L8,4 L0,8 Z" fill="#168c82"/></marker>
+            <marker id="bad-arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto"><path d="M0,0 L8,4 L0,8 Z" fill="#c65f3e"/></marker>
+          </defs>
+          <g font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="13" fill="#173b57">
+            <rect x="22" y="24" width="150" height="48" rx="11" fill="#fff" stroke="#bfd4dc"/><text x="97" y="53" text-anchor="middle">页面 / 登录态</text>
+            <rect x="215" y="24" width="180" height="48" rx="11" fill="#d7f2ec" stroke="#168c82"/><text x="305" y="53" text-anchor="middle">immediate watcher</text>
+            <rect x="438" y="24" width="150" height="48" rx="11" fill="#fff" stroke="#bfd4dc"/><text x="513" y="53" text-anchor="middle">本地状态</text>
+            <rect x="631" y="24" width="150" height="48" rx="11" fill="#fff" stroke="#bfd4dc"/><text x="706" y="53" text-anchor="middle">readstate API</text>
+            <rect x="824" y="24" width="134" height="48" rx="11" fill="#fff" stroke="#bfd4dc"/><text x="891" y="53" text-anchor="middle">详情页 UI</text>
+            <g stroke="#bfd4dc" stroke-dasharray="4 5"><path d="M97 72v185"/><path d="M305 72v185"/><path d="M513 72v185"/><path d="M706 72v185"/><path d="M891 72v185"/></g>
+            <path d="M97 103h198" stroke="#168c82" stroke-width="2" marker-end="url(#arrow)"/><text x="196" y="96" text-anchor="middle">首次 / 换书 / 登录变化</text>
+            <path d="M305 137h198" stroke="#168c82" stroke-width="2" marker-end="url(#arrow)"/><text x="404" y="130" text-anchor="middle">先清空旧用户态</text>
+            <path d="M305 173h391" stroke="#168c82" stroke-width="2" marker-end="url(#arrow)"/><text x="500" y="166" text-anchor="middle">已登录且 bookId 有效：GET</text>
+            <path d="M706 207H315" stroke="#168c82" stroke-width="2" marker-end="url(#arrow)"/><text x="510" y="200" text-anchor="middle">返回状态 + 请求对应 bookId</text>
+            <path d="M305 241h576" stroke="#168c82" stroke-width="2" marker-end="url(#arrow)"/><text x="593" y="234" text-anchor="middle">身份仍一致才提交到 UI</text>
+            <path d="M97 272h784" stroke="#c65f3e" stroke-width="2" stroke-dasharray="7 5" marker-end="url(#bad-arrow)"/><text x="489" y="266" text-anchor="middle" fill="#c65f3e">旧流程：首次不触发 watcher → 永久显示默认值</text>
+          </g>
+        </svg>
+      </div>
+      <ol>
+        <li>使用同一个响应式监听器观察当前路由书籍 ID 与登录状态，并启用 <code>immediate: true</code>。</li>
+        <li>每次触发先恢复安全默认值；未登录或书籍无效时到此结束。</li>
+        <li>已登录时请求当前书籍的 <code>/readstate</code>，成功后填充所有相关字段。</li>
+        <li>提交响应前再次核对当前书籍 ID 和登录状态；不匹配说明响应已经过期，直接丢弃。</li>
+        <li>保留按钮操作成功后的即时反馈，下一次同步再由服务端确认最终状态。</li>
+      </ol>
+    </section>
+
+    <section>
+      <h2>05. 实现影响</h2>
+      <table>
+        <thead><tr><th>位置</th><th>计划变更</th><th>兼容性</th></tr></thead>
+        <tbody>
+          <tr><td><code>app/pages/book/[bid]/index.vue</code></td><td>将路由书籍 ID 改为响应式数据源，统一登录态同步，并修正动态 key 的缓存行为</td><td>不改变模板、API 参数或服务端契约</td></tr>
+          <tr><td><code>app/composables/useBookReadingState.js</code></td><td>封装立即同步、退出重置、过期响应保护，并从 <code>read_date</code> 计算阅读天数</td><td>只复用页面现有状态与 API</td></tr>
+          <tr><td><code>app/test/mock-server.js</code></td><td>让 mock 的阅读状态像书架状态一样在测试进程内持久化</td><td>仅测试环境，重置接口同时清空</td></tr>
+          <tr><td><code>app/test/e2e/shelf.spec.ts</code> 与 composable 单测</td><td>补充硬刷新、客户端路由换书、登录态切换和旧响应竞态验收</td><td>复用现有 mock、Vitest 与 Chromium 工程</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>06. 验收矩阵</h2>
+      <table>
+        <thead><tr><th>层级</th><th>验证内容</th><th>实际命令 / 页面</th><th>实际结果</th></tr></thead>
+        <tbody>
+          <tr><td>单元测试</td><td>登录/退出重置、重新登录恢复、旧响应丢弃、阅读天数推导</td><td><code>npx vitest run test/composables/useBookReadingState.spec.ts</code></td><td><strong>通过</strong>：3 passed，3.22 秒</td></tr>
+          <tr><td>E2E</td><td>书架硬刷新、阅读状态与天数硬刷新、客户端路由换书隔离</td><td><code>MOCK_API_URL=http://127.0.0.1:18182 PLAYWRIGHT_BASE_URL=http://127.0.0.1:3002 npx playwright test test/e2e/shelf.spec.ts --project=chromium</code></td><td><strong>通过</strong>：3 passed，30.6 秒</td></tr>
+          <tr><td>交互验收</td><td>刷新恢复、登录态切换和跨书籍状态</td><td>Chrome DevTools MCP，浅色主题，<code>1440 × 1000</code>：<code>/book/1</code>、<code>/book/2</code></td><td><strong>通过</strong>：刷新后显示“移除书架 / 标记读完 / 在读”；退出时隐藏并清空用户操作区，再登录恢复；第二本书保持未读</td></tr>
+          <tr><td>网络证据</td><td>页面确实以服务端真值恢复</td><td>Chrome DevTools Network：<code>GET /api/book/1/readstate</code></td><td><strong>通过</strong>：HTTP 200，返回 <code>wants: true</code>、<code>read_state: 1</code>，页面状态一致</td></tr>
+          <tr><td>前端检查</td><td>目标回归、lint 与 production build</td><td><code>npm run lint</code>；<code>npm run build</code></td><td><strong>通过</strong>：lint 0 error（196 条仓库既有 warning）；Nuxt client、SSR 与 Nitro 构建成功</td></tr>
+          <tr><td>后端回归</td><td>完整 Python 测试与格式检查</td><td><code>make lint-py</code>；在 <code>talebook/talebook-base:latest</code> 中执行 <code>make init &amp;&amp; make pytest</code></td><td><strong>通过</strong>：ruff 全通过；642 passed，2 skipped，31 warnings，101.15 秒</td></tr>
+          <tr><td>工程门禁</td><td>设计文档与补丁完整性</td><td><code>make check-design</code>；<code>git diff --check</code></td><td><strong>通过</strong></td></tr>
+        </tbody>
+      </table>
+      <p class="callout success">本方案已完成实现和验证。Chrome DevTools 验收截图保留为提交过程证据，PR 正文提供本 ACTIVE 方案的 GitHub 与 RawGitHack 固定提交预览链接。</p>
+      <h3>验收环境说明</h3>
+      <p>mock 未实现 <code>/api/book/txt/init</code> 与 <code>/api/user/devices</code>，因此浏览器验收中这两个既有请求返回 404，并触发现有错误弹窗；同时开发模式存在详情页 SSR hydration warning。它们在本次改动前已存在，不涉及 <code>/readstate</code>，目标 E2E、目标网络请求和 production build 均通过。本次不扩展修复范围。</p>
+    </section>
+
+    <section>
+      <h2>07. 风险、监控与回滚</h2>
+      <div class="grid">
+        <article class="mini">
+          <h3>主要风险</h3>
+          <ul>
+            <li>SSR 与客户端监听造成重复请求：以实际网络记录确认，必要时保持幂等并限制触发源。</li>
+            <li>快速切书响应乱序：用请求对应的书籍 ID 与当前身份做提交前校验。</li>
+            <li>退出后残留上一用户信息：同步入口统一先重置四个用户相关字段。</li>
+          </ul>
+        </article>
+        <article class="mini">
+          <h3>回滚策略</h3>
+          <p>改动集中在详情页同步逻辑及测试 mock。若线上出现回归，可整体回退该提交；由于没有 API、数据库或数据迁移变更，不需要额外回滚步骤。</p>
+          <p><span class="label">可观察信号</span><br>详情页 <code>/readstate</code> 请求次数、响应错误提示、刷新前后按钮和阅读状态一致性。</p>
+        </article>
+      </div>
+    </section>
+
+    <footer>Talebook · app · 20260722-book-reading-state-refresh · ACTIVE</footer>
+  </main>
+</body>
+</html>

--- a/design/app/20260722-book-reading-state-refresh.active.html
+++ b/design/app/20260722-book-reading-state-refresh.active.html
@@ -223,8 +223,9 @@
         <thead><tr><th>层级</th><th>验证内容</th><th>实际命令 / 页面</th><th>实际结果</th></tr></thead>
         <tbody>
           <tr><td>单元测试</td><td>登录/退出重置、重新登录恢复、旧响应丢弃、阅读天数推导</td><td><code>npx vitest run test/composables/useBookReadingState.spec.ts</code></td><td><strong>通过</strong>：3 passed，2.79 秒</td></tr>
-          <tr><td>E2E</td><td>书架硬刷新、阅读状态与天数硬刷新、客户端路由换书隔离</td><td><code>MOCK_API_URL=http://127.0.0.1:18182 PLAYWRIGHT_BASE_URL=http://127.0.0.1:3002 npx playwright test test/e2e/shelf.spec.ts --project=chromium</code></td><td><strong>通过</strong>：3 passed，30.6 秒</td></tr>
+          <tr><td>E2E</td><td>书架硬刷新、阅读状态与天数硬刷新、客户端路由换书隔离</td><td><code>MOCK_API_URL=http://127.0.0.1:18183 PLAYWRIGHT_BASE_URL=http://127.0.0.1:3005 npx playwright test test/e2e/shelf.spec.ts --project=chromium</code></td><td><strong>通过</strong>：改用公开浏览器 History API 触发 SPA 换书，3 passed，3.3 秒</td></tr>
           <tr><td>交互验收</td><td>刷新恢复、登录态切换和跨书籍状态</td><td>Chrome DevTools MCP，浅色主题，<code>1440 × 1000</code>：<code>/book/1</code>、<code>/book/2</code></td><td><strong>通过</strong>：刷新后显示“移除书架 / 标记读完 / 在读”；退出时隐藏并清空用户操作区，再登录恢复；第二本书保持未读</td></tr>
+          <tr><td>真实后端复验</td><td>排除 mock 行为差异，确认书架与在读状态均由真实服务持久化并在刷新后恢复</td><td>Chrome DevTools MCP：Docker Talebook dev 后端 <code>127.0.0.1:8080</code> + production preview <code>127.0.0.1:3004/book/13</code>；使用安装流程创建的 <code>admin / demodemo</code> 登录</td><td><strong>通过</strong>：加入书架后清缓存刷新仍显示“移除书架”，验收后恢复未加入；点击“设为在读”后显示“标记读完 / 在读 / 已阅读不足一天”，清缓存刷新后三项仍完整恢复</td></tr>
           <tr><td>网络证据</td><td>页面确实以服务端真值恢复</td><td>Chrome DevTools Network：<code>GET /api/book/1/readstate</code></td><td><strong>通过</strong>：HTTP 200，返回 <code>wants: true</code>、<code>read_state: 1</code>，页面状态一致</td></tr>
           <tr><td>前端检查</td><td>目标回归、lint 与 production build</td><td><code>npm run lint</code>；<code>npm run build</code></td><td><strong>通过</strong>：lint 0 error（196 条仓库既有 warning）；Nuxt client、SSR 与 Nitro 构建成功</td></tr>
           <tr><td>后端回归</td><td>完整 Python 测试与格式检查</td><td><code>make lint-py</code>；在 <code>talebook/talebook-base:latest</code> 中执行 <code>make init &amp;&amp; make pytest</code></td><td><strong>通过</strong>：ruff 全通过；646 passed，2 skipped，31 warnings，80.01 秒</td></tr>
@@ -233,7 +234,7 @@
       </table>
       <p class="callout success">本方案已完成实现和验证。Chrome DevTools 验收截图保留为提交过程证据，PR 正文提供本 ACTIVE 方案的 GitHub 与 RawGitHack 固定提交预览链接。</p>
       <h3>验收环境说明</h3>
-      <p>mock 未实现 <code>/api/book/txt/init</code> 与 <code>/api/user/devices</code>，因此浏览器验收中这两个既有请求返回 404，并触发现有错误弹窗；同时开发模式存在详情页 SSR hydration warning。它们在本次改动前已存在，不涉及 <code>/readstate</code>，目标 E2E、目标网络请求和 production build 均通过。本次不扩展修复范围。</p>
+      <p>自动化浏览器覆盖使用的 mock 未实现 <code>/api/book/txt/init</code> 与 <code>/api/user/devices</code>，因此这两个既有请求返回 404，并触发现有错误弹窗；同时开发模式存在详情页 SSR hydration warning。它们在本次改动前已存在，不涉及 <code>/readstate</code>。后续已在真实 Docker dev 后端完成独立复验，真实验收不使用 mock；因原生 Nuxt watcher 在当前 worktree 触发 <code>EMFILE</code>，且工程约束禁止 polling，前端使用同一源码的 production preview。</p>
     </section>
 
     <section>

--- a/design/project/20260722-disable-chokidar-polling.active.html
+++ b/design/project/20260722-disable-chokidar-polling.active.html
@@ -1,0 +1,131 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>禁止启用 Chokidar 轮询模式 · ACTIVE</title>
+  <style>
+    :root {
+      --navy: #10243e;
+      --ink: #1c2c3e;
+      --muted: #627186;
+      --paper: #f1f5f8;
+      --card: #ffffff;
+      --line: #c9d4df;
+      --signal: #d4472f;
+      --signal-soft: #fff0eb;
+      --safe: #18745a;
+      --safe-soft: #e4f4ee;
+      --code: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      --body: "Avenir Next", "PingFang SC", "Microsoft YaHei", sans-serif;
+    }
+    * { box-sizing: border-box; }
+    html { background: var(--paper); color: var(--ink); font-family: var(--body); }
+    body { margin: 0; line-height: 1.66; }
+    main { width: min(980px, calc(100% - 28px)); margin: 28px auto 64px; }
+    header { padding: clamp(28px, 6vw, 60px); border-radius: 20px; background: var(--navy); color: white; }
+    .eyebrow { margin: 0 0 12px; color: #a9c7e8; font: 700 12px/1.4 var(--code); letter-spacing: .14em; }
+    h1 { max-width: 760px; margin: 0; font-size: clamp(32px, 6vw, 58px); line-height: 1.05; letter-spacing: -.035em; }
+    .lede { max-width: 720px; margin: 18px 0 0; color: #d8e4f0; font-size: 18px; }
+    .meta { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 26px; }
+    .pill { padding: 6px 10px; border: 1px solid rgba(255,255,255,.25); border-radius: 999px; font: 700 12px/1.3 var(--code); }
+    .pill.status { border-color: #ffad9f; background: var(--signal); }
+    section { margin-top: 20px; padding: clamp(22px, 4vw, 34px); border: 1px solid var(--line); border-radius: 18px; background: var(--card); }
+    h2 { margin: 0 0 14px; font-size: 23px; line-height: 1.25; }
+    h3 { margin: 18px 0 8px; font-size: 17px; }
+    p { margin: 9px 0; }
+    ul { margin: 9px 0; padding-left: 22px; }
+    li + li { margin-top: 6px; }
+    code { padding: 2px 5px; border-radius: 5px; background: #e9eff5; color: #174d82; font: 13px/1.5 var(--code); }
+    .fuse { display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; gap: 18px; margin: 18px 0; }
+    .terminal { min-width: 0; padding: 18px; border-radius: 12px; background: #162334; color: #e8eef5; font: 700 clamp(13px, 2vw, 16px)/1.6 var(--code); overflow-wrap: anywhere; }
+    .terminal.bad { outline: 2px solid var(--signal); text-decoration: line-through 3px var(--signal); }
+    .breaker { display: grid; place-items: center; width: 58px; height: 58px; border: 2px solid var(--signal); border-radius: 50%; color: var(--signal); font: 900 24px/1 var(--code); }
+    .terminal.safe { background: var(--safe-soft); color: #125b47; }
+    .callout { padding: 15px 17px; border-left: 5px solid var(--signal); border-radius: 9px; background: var(--signal-soft); }
+    .grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 14px; }
+    .mini { padding: 17px; border: 1px solid var(--line); border-radius: 12px; background: #f8fafc; }
+    .mini h3 { margin-top: 0; }
+    table { width: 100%; border-collapse: collapse; font-size: 14px; }
+    th, td { padding: 11px 9px; border-bottom: 1px solid var(--line); text-align: left; vertical-align: top; }
+    th { color: var(--muted); font: 700 12px/1.4 var(--code); }
+    .pending { color: #9a6100; font-weight: 700; }
+    footer { margin-top: 16px; color: var(--muted); text-align: center; font: 12px/1.5 var(--code); }
+    @media (max-width: 680px) {
+      main { margin-top: 10px; }
+      .grid, .fuse { grid-template-columns: 1fr; }
+      .breaker { margin: auto; transform: rotate(90deg); }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <p class="eyebrow">PROJECT GUARDRAIL / FILE WATCHING</p>
+      <h1>禁止启用 Chokidar 轮询模式</h1>
+      <p class="lede">把一次真实的 CPU 异常转化为仓库级硬约束：任何智能体都不得在 Talebook 的开发命令中加入 Chokidar polling 开关。</p>
+      <div class="meta">
+        <span class="pill status">ACTIVE · 已生效</span>
+        <span class="pill">创建日期 2026-07-22</span>
+        <span class="pill">模块 project</span>
+        <span class="pill">需求来源 用户现场指令</span>
+      </div>
+    </header>
+
+    <section>
+      <h2>原始诉求与原因</h2>
+      <div class="callout">用户明确要求：“备注到 AGENTS.md 里面，永远不要加 <code>CHOKIDAR_USEPOLLING=true</code>。”</div>
+      <p>本次实际启动 Nuxt dev server 时加入该环境变量，Chokidar 因此持续轮询前端目录，造成显著 CPU 占用。本机工作区支持原生文件事件，不需要以全目录轮询换取热更新。</p>
+    </section>
+
+    <section>
+      <h2>规则的唯一解释</h2>
+      <div class="fuse" aria-label="禁止轮询参数，改用原生文件事件">
+        <div class="terminal bad">CHOKIDAR_USEPOLLING=true npx nuxt dev</div>
+        <div class="breaker" aria-hidden="true">×</div>
+        <div class="terminal safe">npx nuxt dev --port 3000 --host 127.0.0.1</div>
+      </div>
+      <ul>
+        <li>这是绝对禁令，不为 Docker、worktree、网络文件系统或热更新故障预设例外。</li>
+        <li>禁止在交互命令、脚本、Makefile、CI、文档示例或临时诊断命令中设置 <code>CHOKIDAR_USEPOLLING=true</code>。</li>
+        <li>文件监听异常时，先停止 dev server 并报告现象；使用原生文件事件、手动刷新或其他不启用 Chokidar polling 的方案。</li>
+        <li>启动后出现异常 CPU 占用时，立即停止由智能体启动的进程并检查残留，不继续带病运行。</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>落地位置</h2>
+      <div class="grid">
+        <article class="mini">
+          <h3><code>AGENTS.md</code></h3>
+          <p>在“前端验收”本地启动说明附近增加醒目的禁止项，让智能体在复制启动命令时直接看到。</p>
+        </article>
+        <article class="mini">
+          <h3>现有启动示例</h3>
+          <p>保留当前不含 polling 的标准命令；不修改应用代码、依赖、Nuxt 配置或 Docker 配置。</p>
+        </article>
+      </div>
+    </section>
+
+    <section>
+      <h2>验证计划</h2>
+      <table>
+        <thead><tr><th>检查</th><th>计划命令</th><th>状态</th></tr></thead>
+        <tbody>
+          <tr><td>仓库约束已包含绝对禁令和替代处理</td><td><code>rg -n "CHOKIDAR_USEPOLLING" AGENTS.md</code></td><td><strong>通过</strong>：规则位于“前端验收”标准启动命令之前，包含绝对禁令、无例外、停服报告和 CPU 异常处理</td></tr>
+          <tr><td>除本方案的事故记录与禁止项外，仓库不存在启用该变量的命令</td><td><code>rg -n --hidden -g '!node_modules/**' -g '!.git/**' "CHOKIDAR_USEPOLLING=true" .</code> 并人工核对语境</td><td><strong>通过</strong>：命中仅为 <code>AGENTS.md</code> 禁止项及本方案的原始诉求、禁用示例和验证说明，没有实际启用命令</td></tr>
+          <tr><td>补丁格式</td><td><code>git diff --check</code></td><td><strong>通过</strong></td></tr>
+          <tr><td>文档单文件与 WIP / ACTIVE 门禁</td><td><code>python3 scripts/check_design_docs.py</code></td><td><strong>通过</strong>：前端标签可见性方案完成验收并转为 ACTIVE 后统一复跑，48 份设计文档全部通过</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>风险与回滚</h2>
+      <p>风险仅在于某些特殊文件系统的热更新可能失效。按照用户给出的绝对约束，该情况下也不启用 polling，而是明确报告并选择手动刷新或其他低 CPU 方案。规则如需改变，必须新建工程治理 WIP 方案，不能静默删除或弱化。</p>
+    </section>
+
+    <footer>Talebook · project · 20260722-disable-chokidar-polling · ACTIVE</footer>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## 问题

书籍详情页存在三类相互关联的用户可见问题：

1. 点击“加入书架”或“设为在读”后页面会即时更新，但硬刷新后按钮和阅读状态恢复默认值；服务端实际已经持久化，前端初始化没有立即同步状态。
2. SPA 客户端换书时，动态路由 ID 与阅读状态没有可靠联动；并且 `/readstate` 返回的是 `read_date`，前端却读取不存在的 `read_days`。
3. 详情页作者、出版社、ISBN、分类、书籍范围等 metadata chip 在默认主题下被强制为白色文字，落在浅色背景时几乎不可见。

本次也补充工程约束：禁止通过 `CHOKIDAR_USEPOLLING=true` 启动 Nuxt watcher，避免轮询导致本地 CPU 异常升高。

## 修改

- 新增 `useBookReadingState` composable，统一处理首次加载、登录/退出、换书同步和旧响应丢弃。
- 以响应式 route key 驱动详情数据；从 API 已有的 `read_date` 推导阅读天数，不修改后端 API 或数据库。
- 扩展 mock server，使书架和阅读状态在测试进程内真实持久化。
- 增加 Vitest 与 Playwright 覆盖：硬刷新恢复、阅读天数、SPA 换书、登录/退出/重登、旧响应竞态以及标签可见性。
- metadata chip 改为使用 Vuetify 主题计算出的前景色；没有出版社时不再渲染空标签。
- E2E 页面内导航改用浏览器 History API，不再访问 Nuxt/Vue 私有全局属性。
- 在 `AGENTS.md` 增加禁止 Chokidar polling 的绝对约束。
- 已合入最新 `master`（`306fe8f`）。

## 真实环境验收

使用真实 Docker 开发后端与 Calibre 环境完成，不使用 mock server：

- 将配置重置为 `installed=false`，通过真实安装页创建 `admin / demodemo`，随后从登录页登录；页面显示管理员账号、邮箱、用户中心和管理员入口。
- 在真实书籍详情页设置“在读”，硬刷新后仍显示“标记读完 / 在读 / 已阅读不足一天”。
- 加入书架后硬刷新仍显示“移除书架”；验收完成后已恢复为未加入书架。
- 默认主题与 5 个内置主题分别验证浅色/深色，共 12/12 个状态；作者、出版社、ISBN、分类及书籍范围标签均清晰可见且链接正确。
- 公有和私有书籍范围均已验证；验收完成后恢复公有书籍与默认浅色主题。

## 自动化验证

- `npx vitest run test/composables/useBookReadingState.spec.ts`：3 passed
- `npx playwright test test/e2e/book-detail.spec.ts --project=chromium`：2 passed
- `npx playwright test test/e2e/shelf.spec.ts --project=chromium`：3 passed
- `npm run build`：通过
- `npm run lint`：0 error（196 条仓库既有 warning）
- `make check-design`：49 份方案通过
- `git diff --check`：通过
- Standards / Spec 双路复审：最终均为 0 finding

## 方案文档

### 书籍阅读状态刷新

- [GitHub 固定提交](https://github.com/talebook/talebook/blob/dbf4060e558bf8c540ffcfbe7b0a61a0d551a758/design/app/20260722-book-reading-state-refresh.active.html)
- [RawGitHack 在线预览](https://raw.githack.com/talebook/talebook/dbf4060e558bf8c540ffcfbe7b0a61a0d551a758/design/app/20260722-book-reading-state-refresh.active.html)

### 书籍详情标签可见性

- [GitHub 固定提交](https://github.com/talebook/talebook/blob/dbf4060e558bf8c540ffcfbe7b0a61a0d551a758/design/app/20260722-book-detail-metadata-chips-visibility.active.html)
- [RawGitHack 在线预览](https://raw.githack.com/talebook/talebook/dbf4060e558bf8c540ffcfbe7b0a61a0d551a758/design/app/20260722-book-detail-metadata-chips-visibility.active.html)

### 禁止 Chokidar 轮询

- [GitHub 固定提交](https://github.com/talebook/talebook/blob/dbf4060e558bf8c540ffcfbe7b0a61a0d551a758/design/project/20260722-disable-chokidar-polling.active.html)
- [RawGitHack 在线预览](https://raw.githack.com/talebook/talebook/dbf4060e558bf8c540ffcfbe7b0a61a0d551a758/design/project/20260722-disable-chokidar-polling.active.html)

## 兼容性与风险

- 不改变 API、数据库、权限模型和按钮业务语义。
- mock server 只用于自动化 E2E；关键流程另用真实 Docker 后端完成验收。
- Nuxt dev watcher 遇到文件描述符或 CPU 问题时应停止进程并排查，禁止以轮询作为绕过方案。
