### PR TITLE
fix(ci): 补齐 Claude 解压依赖并强制本地 act 验收

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -1,0 +1,44 @@
+# GitHub Actions Workflow 开发规范
+
+本文件适用于 `.github/workflows/` 目录中的 GitHub Actions workflow。根目录 `AGENTS.md` 的通用开发、测试、方案和 PR 规范继续生效。
+
+## 修改后必须执行真实 workflow
+
+修改任何 workflow 时，必须在提交 PR 前使用本地 `act` 执行器测试。此要求包括触发器、权限、job、容器、Action、环境变量、步骤和脚本等变更。团队环境如果通过 `gh act` 扩展调用，可以使用该入口，但必须确认底层实际运行的是 `act`，并记录 act 版本。
+
+本地验收必须满足：
+
+1. 使用 `-W .github/workflows/<name>.yml` 加载本次修改的真实 workflow。
+2. 使用与 workflow 匹配触发类型的事件，例如 `issue_comment`、`pull_request` 或 `workflow_dispatch`，并提供能让目标 job 命中的最小事件 JSON。
+3. 使用 `-j <job>` 运行受影响的目标 job；存在多个受影响 job 时逐一验证。
+4. workflow 使用本仓库构建的容器镜像时，先构建对应本地 target，并使用 `--pull=false` 等方式确认 `act` 没有强制拉取旧镜像。
+5. 所有本地可复现的 Action bootstrap、依赖安装、脚本和步骤必须跑通。不得用简化 smoke workflow 替代真实 workflow，也不得用 actionlint、YAML 解析或读取 workflow 文本的单元测试代替真实执行。
+
+参考命令如下，其中 `EVENT_FILE` 应指向当前操作系统临时路径中的事件文件：
+
+```bash
+act issue_comment \
+  -W .github/workflows/claude.yml \
+  -j claude \
+  -e "$EVENT_FILE" \
+  --pull=false
+```
+
+## 事件、密钥与外部边界
+
+- 一次性事件 JSON 放在临时路径中，验证完成后删除，不得提交进仓库。
+- 本地测试不得使用生产密钥、真实 OAuth token 或长期 GitHub token。
+- GitHub OIDC、仓库写入、回帖、发布和真实模型调用等 `act` 无法完整模拟的边界，必须明确记录本地已经通过的最后一个步骤，并在真实 GitHub Actions 运行中继续验收。
+- 如果本地可复现步骤失败，必须先修复，不得声明 workflow 验证通过。
+- 如果环境限制导致 `act` 无法执行，PR 必须写明未执行原因和风险，并把缺失的真实 workflow 验证作为合并阻断项，不能以静态检查通过代替。
+
+## PR 验证记录
+
+PR 正文必须记录：
+
+- `act` 或 `gh act` 的版本；
+- 实际执行命令、事件类型和目标 job；
+- 成功执行到的关键 Action 与步骤；
+- 本地运行的最终结果；
+- 无法本地模拟的外部边界及其真实 GitHub Actions 验证结果；
+- 任何未执行原因和风险。

--- a/Dockerfile
+++ b/Dockerfile
@@ -248,6 +248,7 @@ RUN apt-get update -y && \
         curl \
         git \
         jq \
+        unzip \
         uidmap && \
     if [ "$TARGETARCH" = "amd64" ] || [ "$TARGETARCH" = "arm64" ]; then \
         curl -fsSL https://deb.nodesource.com/setup_24.x | bash - && \
@@ -263,7 +264,8 @@ RUN --mount=type=cache,target=/root/.npm \
     codex --version && \
     python3 -m pytest --version && \
     ruff --version && \
-    bwrap --version
+    bwrap --version && \
+    unzip -v
 
 ENV TZ=Asia/Shanghai
 ENV LANG=C.UTF-8

--- a/design/docker/20260723-dev-image-unzip.active.html
+++ b/design/docker/20260723-dev-image-unzip.active.html
@@ -1,0 +1,123 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Dev 镜像补齐 Claude Action 解压依赖</title>
+  <style>
+    :root { color-scheme: light; --ink: #17212b; --muted: #596675; --line: #d8e0e7; --panel: #f6f8fa; --accent: #0969da; --warn: #9a6700; --danger: #cf222e; --success: #1a7f37; }
+    * { box-sizing: border-box; }
+    body { max-width: 1020px; margin: 0 auto; padding: 36px 24px 64px; color: var(--ink); background: #fff; font: 16px/1.65 "IBM Plex Sans", "Noto Sans SC", "PingFang SC", sans-serif; }
+    header { padding: 26px; border: 1px solid var(--line); border-radius: 14px; background: linear-gradient(135deg, #f6f8fa, #eef5ff); }
+    h1, h2 { font-family: "Avenir Next Condensed", "Arial Narrow", "Noto Sans SC", sans-serif; line-height: 1.15; letter-spacing: .025em; }
+    h1 { margin: 0 0 18px; font-size: 32px; font-weight: 800; }
+    h2 { margin-top: 34px; font-size: 22px; font-weight: 750; }
+    .meta { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 12px; }
+    .meta div { padding: 10px 12px; border-radius: 8px; background: rgba(255,255,255,.82); }
+    .status { color: var(--success); font-weight: 700; }
+    code { padding: 2px 5px; border-radius: 4px; background: var(--panel); font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace; font-size: .92em; overflow-wrap: anywhere; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { padding: 11px 12px; border: 1px solid var(--line); text-align: left; vertical-align: top; }
+    th { background: var(--panel); }
+    .flow { display: grid; grid-template-columns: 1fr auto 1fr auto 1fr auto 1fr; gap: 9px; align-items: center; margin: 18px 0; }
+    .flow div { min-height: 86px; padding: 13px; border: 1px solid var(--line); border-radius: 9px; display: grid; place-items: center; text-align: center; }
+    .arrow { color: var(--accent); font-size: 23px; }
+    .note { padding: 12px 14px; border-left: 4px solid var(--accent); background: #eef6ff; }
+    .warning { padding: 12px 14px; border-left: 4px solid var(--danger); background: #fff1f0; }
+    @media (max-width: 760px) { .meta { grid-template-columns: 1fr; } .flow { grid-template-columns: 1fr; } .arrow { transform: rotate(90deg); } }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Dev 镜像补齐 Claude Action 解压依赖</h1>
+    <div class="meta">
+      <div><strong>创建日期</strong><br>2026-07-23</div>
+      <div><strong>所属模块</strong><br>docker</div>
+      <div><strong>状态</strong><br><span class="status">ACTIVE</span></div>
+      <div><strong>需求来源</strong><br>PR #898 合并后的真实 <code>@claude</code> 运行失败</div>
+      <div><strong>工作分支</strong><br><code>fix/20260723-dev-image-unzip</code></div>
+      <div><strong>影响范围</strong><br>Docker development stage 与镜像契约测试</div>
+    </div>
+  </header>
+
+  <section>
+    <h2>1. 原始诉求与事实</h2>
+    <p>继续保留 <code>talebook/talebook:dev</code> 作为 Claude 与 Codex 的统一业务环境，修复 Claude Action 在 job container 内无法安装 Bun 的问题。用户要求本地验收必须加载真实 <code>.github/workflows/claude.yml</code> 并模拟 <code>@claude</code>，不能再用只执行工具探测和项目检查的替代 smoke 冒充 Action 验收。</p>
+    <table>
+      <thead><tr><th>证据</th><th>结论</th></tr></thead>
+      <tbody>
+        <tr><td>线上 run <code>29974489717</code></td><td>checkout、环境探测和依赖同步成功；Claude Action 内部 <code>setup-bun</code> 下载 Bun 后报 <code>Unable to locate executable file: unzip</code>。</td></tr>
+        <tr><td>本地真实 workflow 复现</td><td><code>act v0.2.82</code> 加载仓库 <code>.github/workflows/claude.yml</code> ，使用 <code>issue_comment</code> 事件与 dummy OAuth token，稳定复现同一 <code>unzip</code> 错误；临时事件文件已删除。</td></tr>
+        <tr><td>旧测试缺口</td><td>旧临时 act workflow 没有执行 Claude Action；YAML contract 只检查步骤顺序和参数；PR 上的 Claude review 是另一份运行在宿主 <code>ubuntu-latest</code> 的 workflow。</td></tr>
+      </tbody>
+    </table>
+    <p class="warning"><strong>纠偏：</strong>旧方案所称“等价 job”只等价到业务环境和项目命令，不等价到第三方 composite action 的 bootstrap 边界。本方案把真实 Action bootstrap 纳入验收。</p>
+  </section>
+
+  <section>
+    <h2>2. 目标与明确边界</h2>
+    <table>
+      <thead><tr><th>包含</th><th>不包含</th></tr></thead>
+      <tbody>
+        <tr><td>development stage 安装 <code>unzip</code>，并在镜像构建阶段执行版本探测。</td><td>不修改 production、builder 或 test stage，不调整 Node 24、Codex 版本及发布标签。</td></tr>
+        <tr><td>扩展 Dockerfile 契约测试，保证 <code>unzip</code> 安装与探测不会回退。</td><td>不修改 <code>.github/workflows/claude.yml</code> 、<code>.github/workflows/codex.yml</code> 或 Claude review workflow。</td></tr>
+        <tr><td>用本地已构建镜像运行真实 <code>.github/workflows/claude.yml</code> ，确认 <code>Install Bun</code> 成功。</td><td>不把临时事件 JSON 或 smoke workflow 提交到仓库，不向本地 act 提供真实 OAuth token。</td></tr>
+        <tr><td>合并发布后，以真实 <code>@claude</code> 成功作为启动 Codex 修复 PR 的发布门禁。</td><td>本 PR 不处理 GitHub Ubuntu 的 Codex AppArmor/user namespace 问题。</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section>
+    <h2>3. 方案与验收链路</h2>
+    <div class="flow" aria-label="Claude Action bootstrap 验收流程">
+      <div>TDD contract<br><strong>要求 unzip</strong></div><span class="arrow">→</span>
+      <div>构建 dev 镜像<br><strong>unzip -v</strong></div><span class="arrow">→</span>
+      <div>本地真实 Claude workflow<br><strong>Install Bun 成功</strong></div><span class="arrow">→</span>
+      <div>master 发布后<br><strong>真实 @claude</strong></div>
+    </div>
+    <ol>
+      <li>先给 <code>test_dev_stage_is_a_complete_agent_development_environment</code> 增加 <code>unzip</code> 安装和版本探测断言，在当前 Dockerfile 上确认红灯。</li>
+      <li>最小修改 dev stage：在已有 apt 清单加入 <code>unzip</code>，并在工具链验证 RUN 中加入 <code>unzip -v</code>。</li>
+      <li>构建本地 dev target，并直接验证 <code>unzip</code>。</li>
+      <li>创建一次性 <code>/private/tmp</code> 事件 JSON，使用 dummy token 运行仓库真实 <code>.github/workflows/claude.yml</code> ；验收点是 Action 内部 <code>Install Bun</code> 成功并进入后续步骤。因 dummy token 导致的后续鉴权失败不视为 bootstrap 失败。</li>
+      <li>删除临时事件文件，确认仓库中不存在 smoke workflow。</li>
+    </ol>
+    <p class="note">本地 act 可以验证真实 composite action、Bun 下载和解压链路，但不能等价证明 GitHub OIDC、仓库 API 回帖和真实模型调用；这些能力由发布后的真实 <code>@claude</code> 验收。</p>
+  </section>
+
+  <section>
+    <h2>4. 发布、风险与回滚</h2>
+    <ul>
+      <li>发布仍由 master 的 build workflow 覆盖浮动 <code>talebook/talebook:dev</code>，不增加 SHA 标签。</li>
+      <li>风险仅为 dev 镜像增加一个 Debian 工具包及少量体积；production 镜像不继承 dev stage。</li>
+      <li>若 Bun bootstrap 仍失败，保持方案 WIP，依据真实 Action 下一条错误补充缺失依赖，不提前扩大到 Claude/Bun 预装。</li>
+      <li>回滚为移除 dev stage 的 <code>unzip</code> 安装和探测；不会影响生产镜像。</li>
+      <li>发布后真实 <code>@claude</code> 未成功前，不启动 Codex sandbox 修复 PR。</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>5. Codex 新失败证据的隔离结论</h2>
+    <p>run <code>30006177093</code> 使用新下载的 dev 镜像，Docker 已收到 <code>--security-opt seccomp=unconfined</code>；所有工具探测成功，但 <code>codex sandbox -- /bin/true</code> 返回非零。当前 workflow 使用 <code>2&gt;/dev/null</code> 丢弃了原始错误，因此只能定位到 sandbox 初始化失败，不能从现有日志证明具体 AppArmor/user namespace 分支。</p>
+    <p>后续独立 Codex 方案必须先取消 stderr 屏蔽并记录宿主策略诊断，再决定是否增加 AppArmor container option 或调整 runner 架构。本 PR 不携带该改动。</p>
+  </section>
+
+  <section>
+    <h2>6. 测试结果</h2>
+    <table>
+      <thead><tr><th>验证项</th><th>实际命令或证据</th><th>结果</th></tr></thead>
+      <tbody>
+        <tr><td>TDD 红灯</td><td><code>python3.12 -m pytest -q tests/test_docker_stages.py</code></td><td>通过：实现前得到预期的 <code>1 failed, 9 passed</code>，唯一失败是 dev stage 缺少 <code>unzip</code>。</td></tr>
+        <tr><td>TDD 绿灯</td><td><code>python3.12 -m pytest -q tests/test_docker_stages.py</code></td><td>通过：实现后 <code>10 passed</code>。</td></tr>
+        <tr><td>dev 镜像构建</td><td><code>make build-dev</code></td><td>通过：构建 <code>linux/arm64</code> 本地镜像 <code>sha256:231bf83ae3fcfcbd02b32624d230d740daa3576be4d1371f137bcb27f36de9ea</code>；构建期 <code>unzip -v</code> 输出版本 <code>6.00</code>。</td></tr>
+        <tr><td>镜像工具</td><td>一次性 <code>talebook/talebook:dev</code> 容器执行 <code>unzip -v</code>、Node、Codex、pytest、ruff 与 bubblewrap 探测</td><td>通过：<code>/usr/bin/unzip</code> 可执行，既有工具探测均成功。</td></tr>
+        <tr><td>真实 Claude bootstrap</td><td><code>act v0.2.82 issue_comment</code> 加载仓库真实 <code>.github/workflows/claude.yml</code> ，使用 dummy OAuth token</td><td>目标通过：真实 <code>setup-bun</code> 调用 <code>/usr/bin/unzip</code> ，Bun <code>1.3.14</code> 安装成功，140 个 Action 依赖安装成功并进入主逻辑；随后因本地 act 不提供 <code>ACTIONS_ID_TOKEN_REQUEST_URL</code> 在 OIDC 边界失败，符合计划限制。一次性事件 JSON 已删除。</td></tr>
+        <tr><td>Python 检查</td><td><code>make lint-py-fix</code>、<code>make lint-py</code></td><td>通过：96 个后端 Python 文件无需格式调整，ruff 检查通过。</td></tr>
+        <tr><td>全量后端测试</td><td><code>make test</code></td><td>通过：Docker 中 <code>667 passed, 2 skipped, 33 warnings</code>。</td></tr>
+        <tr><td>方案与补丁检查</td><td><code>make check-design</code>、<code>git diff --check</code></td><td>通过：53 份方案文档通过路径、状态、HTML 结构和单文件资源检查；补丁无空白错误。</td></tr>
+        <tr><td>发布后验收</td><td>Docker Hub revision 对齐合并提交，真实 <code>@claude</code> run 成功</td><td>未执行：必须等待本 PR 合并并由 master 发布 dev 镜像；仍作为后续 Codex sandbox 修复 PR 的启动门禁。</td></tr>
+      </tbody>
+    </table>
+  </section>
+</body>
+</html>

--- a/design/project/20260724-workflow-local-act-validation.active.html
+++ b/design/project/20260724-workflow-local-act-validation.active.html
@@ -1,0 +1,159 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Workflow 本地 act 强制验收规范</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --ink: #152033;
+      --muted: #5b6678;
+      --line: #ccd6e4;
+      --paper: #f7f9fc;
+      --navy: #132b4f;
+      --cyan: #087ea4;
+      --green: #18794e;
+      --amber: #9a6700;
+    }
+    * { box-sizing: border-box; }
+    body {
+      max-width: 1080px;
+      margin: 0 auto;
+      padding: 38px 24px 72px;
+      color: var(--ink);
+      background: #fff;
+      font: 16px/1.65 "IBM Plex Sans", "Noto Sans SC", "PingFang SC", sans-serif;
+    }
+    h1, h2 {
+      font-family: "Avenir Next Condensed", "Arial Narrow", "Noto Sans SC", sans-serif;
+      line-height: 1.12;
+      letter-spacing: .025em;
+    }
+    h1 { max-width: 780px; margin: 0; font-size: clamp(38px, 6vw, 68px); font-weight: 850; }
+    h2 { margin: 40px 0 16px; font-size: 25px; font-weight: 800; }
+    code {
+      padding: 2px 5px;
+      border-radius: 4px;
+      background: #edf2f7;
+      font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
+      font-size: .92em;
+      overflow-wrap: anywhere;
+    }
+    header {
+      position: relative;
+      overflow: hidden;
+      padding: 34px;
+      color: #fff;
+      background: var(--navy);
+      border-radius: 14px;
+    }
+    header::after {
+      content: "ACT / REAL WORKFLOW / LOCAL";
+      position: absolute;
+      right: -20px;
+      bottom: 8px;
+      color: rgba(255,255,255,.08);
+      font: 800 40px/1 "JetBrains Mono", monospace;
+      transform: rotate(-4deg);
+    }
+    .eyebrow { margin-bottom: 10px; color: #72d7ef; font: 700 13px/1.2 "JetBrains Mono", monospace; letter-spacing: .14em; }
+    .meta { position: relative; z-index: 1; display: flex; flex-wrap: wrap; gap: 8px 18px; margin-top: 25px; color: #d8e8ff; }
+    .meta strong { color: #fff; }
+    .status { color: #ffd580; }
+    .thesis { max-width: 810px; margin: 20px 0 0; font-size: 19px; }
+    .tracks { display: grid; grid-template-columns: 1fr 54px 1fr; gap: 14px; align-items: stretch; margin: 22px 0; }
+    .track { padding: 20px; border: 1px solid var(--line); border-radius: 12px; background: var(--paper); }
+    .track strong { display: block; margin-bottom: 8px; font-size: 18px; }
+    .static strong { color: var(--amber); }
+    .real { border-color: #8bc9b0; background: #f0fbf5; }
+    .real strong { color: var(--green); }
+    .gate { display: grid; place-items: center; color: var(--cyan); font: 800 25px/1 "JetBrains Mono", monospace; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { padding: 11px 13px; border: 1px solid var(--line); text-align: left; vertical-align: top; }
+    th { background: #edf3fa; }
+    .callout { padding: 14px 16px; border-left: 4px solid var(--cyan); background: #edf9fc; }
+    .blocker { border-left-color: var(--amber); background: #fff8e6; }
+    ol li, ul li { margin: 7px 0; }
+    @media (max-width: 720px) {
+      body { padding: 20px 14px 50px; }
+      header { padding: 25px 20px; }
+      .tracks { grid-template-columns: 1fr; }
+      .gate { transform: rotate(90deg); min-height: 34px; }
+      table { display: block; overflow-x: auto; }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="eyebrow">WORKFLOW EXECUTION CONTRACT</div>
+    <h1>Workflow 修改必须经过真实 act 本地执行</h1>
+    <p class="thesis">静态 YAML 正确只说明文件可解析；只有加载仓库真实 workflow、匹配真实事件并执行目标 job，才能证明第三方 Action bootstrap、容器依赖和步骤连接可工作。</p>
+    <div class="meta">
+      <span><strong>创建日期</strong> 2026-07-24</span>
+      <span><strong>所属模块</strong> project</span>
+      <span><strong>状态</strong> <span class="status">ACTIVE</span></span>
+      <span><strong>需求来源</strong> 用户要求 Claude 报错修复提交 PR 前补充 workflow 目录规范</span>
+    </div>
+  </header>
+
+  <section>
+    <h2>1. 原始诉求与目标</h2>
+    <p>在 <code>.github/workflows/AGENTS.md</code> 中明确：修改任何 GitHub Actions workflow 时，必须在本地使用真实 <code>act</code> 执行器测试，确保本地可复现的功能链路跑通。团队若使用 <code>gh act</code> 扩展入口，也必须落到同一真实执行器和真实 workflow，不能用静态检查或简化 smoke 代替。</p>
+    <div class="tracks" aria-label="静态检查与真实执行的双轨验收">
+      <div class="track static">
+        <strong>静态校验轨</strong>
+        YAML 解析、actionlint、契约单测。保留，但不能证明 Action 下载、容器工具和 composite action 能运行。
+      </div>
+      <div class="gate">→</div>
+      <div class="track real">
+        <strong>真实执行轨</strong>
+        <code>act</code> 加载被修改的真实 workflow、匹配触发事件、运行目标 job，并记录实际越过的步骤边界。
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>2. 目录规范</h2>
+    <table>
+      <thead><tr><th>规则</th><th>明确要求</th></tr></thead>
+      <tbody>
+        <tr><td>真实文件</td><td>使用 <code>-W .github/workflows/&lt;name&gt;.yml</code> 加载实际提交文件；不得复制成临时简化 workflow。</td></tr>
+        <tr><td>真实事件</td><td>使用与 workflow 触发器匹配的事件类型和最小事件 JSON，例如 <code>issue_comment</code>、<code>pull_request</code> 或 <code>workflow_dispatch</code>。</td></tr>
+        <tr><td>真实依赖</td><td>job 使用本仓库构建镜像时，先构建本地 target，并以禁止强制拉取的方式确保测试实际使用本地镜像。</td></tr>
+        <tr><td>安全边界</td><td>临时事件放在当前操作系统提供的临时路径中并在测试后删除；不得写入真实密钥。GitHub OIDC、回帖或模型调用等外部边界必须如实标注。</td></tr>
+        <tr><td>证据记录</td><td>PR 列出 act 版本、实际执行命令、目标 job、通过步骤、预期外部边界和最终结果。</td></tr>
+        <tr><td>失败即阻断</td><td>本地可执行步骤没有跑通，不得声明 workflow 验证通过。环境确实无法执行时，必须写明未执行原因和风险，并将其作为合并阻断项处理。</td></tr>
+      </tbody>
+    </table>
+    <p class="callout blocker"><strong>不接受：</strong>只运行 actionlint、只解析 YAML、只跑读取 workflow 文本的单元测试，或创建没有执行真实第三方 Action 的替代 smoke workflow。</p>
+  </section>
+
+  <section>
+    <h2>3. 实现范围</h2>
+    <ul>
+      <li>新增 <code>.github/workflows/AGENTS.md</code> ，仅约束该目录下 workflow 的修改与验收。</li>
+      <li>扩展 <code>tests/test_project_instructions.py</code> ，锁定真实 workflow、匹配事件、禁止简化 smoke、验证记录和失败说明等关键条款。</li>
+      <li>不修改现有 workflow 文件，不引入新的 GitHub Action，不改变 CI 权限。</li>
+      <li>本规范与本 PR 的 unzip 修复相互印证：本 PR 已用真实 <code>.github/workflows/claude.yml</code> 运行到 Bun 解压、依赖安装和 OIDC 外部边界。</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>4. 测试结果</h2>
+    <table>
+      <thead><tr><th>验证项</th><th>命令或证据</th><th>状态</th></tr></thead>
+      <tbody>
+        <tr><td>TDD 红灯</td><td><code>python3.12 -m pytest -q tests/test_project_instructions.py</code></td><td>已确认：缺少嵌套 AGENTS 文件，<code>1 failed, 1 passed</code>。</td></tr>
+        <tr><td>TDD 绿灯</td><td>同上</td><td>通过：新增嵌套规范后 <code>2 passed</code>。</td></tr>
+        <tr><td>定向契约测试</td><td><code>python3.12 -m pytest -q tests/test_docker_stages.py tests/test_project_instructions.py</code></td><td>通过：<code>12 passed</code>。</td></tr>
+        <tr><td>真实 workflow</td><td><code>act issue_comment -W .github/workflows/claude.yml -j claude -e /private/tmp/talebook-claude-unzip-event.json -s CLAUDE_CODE_OAUTH_TOKEN=dummy --pull=false --container-architecture linux/arm64</code></td><td>通过本地边界：Bun <code>1.3.14</code> 解压成功、140 个 Action 依赖安装成功；随后按预期停在本地无法提供的 GitHub OIDC 环境变量 <code>ACTIONS_ID_TOKEN_REQUEST_URL</code>。</td></tr>
+        <tr><td>Python 格式与静态检查</td><td><code>make lint-py-fix</code>、<code>make lint-py</code></td><td>通过：96 个后端文件无需格式变更，ruff 检查通过。</td></tr>
+        <tr><td>回归测试</td><td><code>make test</code></td><td>通过：Docker 中 <code>667 passed, 2 skipped, 33 warnings</code>。</td></tr>
+        <tr><td>方案检查</td><td><code>make check-design</code></td><td>通过：53 份方案文档满足路径、状态、HTML 结构和单文件资源约束。</td></tr>
+        <tr><td>补丁检查</td><td><code>git diff --check</code></td><td>通过：补丁无空白错误。</td></tr>
+      </tbody>
+    </table>
+  </section>
+</body>
+</html>

--- a/tests/test_docker_stages.py
+++ b/tests/test_docker_stages.py
@@ -102,6 +102,10 @@ def test_dev_stage_is_a_complete_agent_development_environment():
 
     assert dev.startswith("FROM test AS dev")
     assert all(tool in dev for tool in ("git", "jq", "bubblewrap", "uidmap"))
+    assert re.search(
+        r"apt-get install -y --no-install-recommends \\\n(?:\s+\S+ \\\n)*\s+unzip \\\n",
+        dev,
+    )
     assert 'ARG CODEX_VERSION="0.144.6"' in dev
     assert 'npm install -g "@openai/codex@${CODEX_VERSION}"' in dev
     assert all(
@@ -113,6 +117,7 @@ def test_dev_stage_is_a_complete_agent_development_environment():
             "python3 -m pytest --version",
             "ruff --version",
             "bwrap --version",
+            "unzip -v",
         )
     )
 

--- a/tests/test_project_instructions.py
+++ b/tests/test_project_instructions.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 AGENTS = ROOT / "AGENTS.md"
+WORKFLOW_AGENTS = ROOT / ".github" / "workflows" / "AGENTS.md"
 
 
 def test_pull_request_description_and_design_preview_rules_are_documented():
@@ -27,3 +28,23 @@ def test_pull_request_description_and_design_preview_rules_are_documented():
         "https://raw.githack.com/talebook/talebook/18113f147aefa0ad79e8c7efd93f1c882610b3ed/"
         "design/webserver/20260721-booksource-large-json-import.active.html"
     ) in instructions
+
+
+def test_workflow_changes_require_real_local_act_validation():
+    instructions = WORKFLOW_AGENTS.read_text(encoding="utf-8")
+
+    assert all(
+        requirement in instructions
+        for requirement in (
+            "gh act",
+            "修改任何 workflow 时，必须在提交 PR 前使用本地 `act` 执行器测试",
+            "所有本地可复现的 Action bootstrap、依赖安装、脚本和步骤必须跑通",
+            "真实 workflow",
+            "匹配触发类型的事件",
+            "不得用简化 smoke workflow 替代",
+            "临时路径",
+            "实际执行命令",
+            "未执行原因和风险",
+        )
+    )
+    assert "/private/tmp" not in instructions

--- a/webserver/CLAUDE.md
+++ b/webserver/CLAUDE.md
@@ -99,12 +99,14 @@ queue.put((args, kwargs))
 ```python
 from tests.test_main import TestWithUserLogin, setUpModule as init
 
+
 def setUpModule():
     init()  # 必须调用，初始化 Tornado app 和 mock
 
+
 class TestMyFeature(TestWithUserLogin):
     def test_normal_case(self):
-        d = self.json("/api/my/endpoint")   # 发 GET 并解析 JSON
+        d = self.json("/api/my/endpoint")  # 发 GET 并解析 JSON
         self.assertEqual(d["err"], "ok")
 
     def test_post_case(self):


### PR DESCRIPTION
## 背景与目标

Claude workflow 在新的 dev job container 中执行 `oven-sh/setup-bun` 时，因镜像缺少 `unzip` 无法完成 Bun bootstrap。此 PR 为 dev 镜像补齐最小运行依赖，并新增 workflow 目录级规范，要求后续 workflow 修改必须使用真实 `act` 在本地验证本地可复现链路。

## 关键改动

- 在 Dockerfile 的 development stage 安装 `unzip`，并在构建期工具探测中执行 `unzip -v`。
- 扩展 Docker stage 契约测试，分别锁定 apt 安装项与构建期 probe，避免两项断言互相掩盖。
- 新增 `.github/workflows/AGENTS.md`，要求加载被修改的真实 workflow、使用匹配的触发事件和目标 job，不得以静态检查或简化 smoke workflow 替代真实执行。
- workflow 事件文件统一使用操作系统提供的临时路径；示例通过 `EVENT_FILE` 注入，不写死系统专用绝对路径。
- 扩展项目规范测试，锁定强制执行语义、`gh act`/`act` 入口、真实事件与临时路径可移植性。

## 实际验证结果

- `python3.12 -m pytest -q tests/test_docker_stages.py`
  - TDD 红灯：`1 failed, 9 passed`，失败项为 dev stage 缺少 `unzip`。
  - 实现后：`10 passed`。
- `python3.12 -m pytest -q tests/test_project_instructions.py`
  - TDD 红灯：`1 failed, 1 passed`，失败项为缺少嵌套 AGENTS 文件。
  - 实现后：`2 passed`。
- `python3.12 -m pytest -q tests/test_docker_stages.py tests/test_project_instructions.py`
  - `12 passed`。
- `make build-dev`
  - 通过；本地 dev 镜像摘要为 `sha256:231bf83ae3fcfcbd02b32624d230d740daa3576be4d1371f137bcb27f36de9ea`，构建期 `unzip -v` 输出 `UnZip 6.00`。
- 一次性 dev 容器工具探测
  - `/usr/bin/unzip`、Node `24.18.0`、Codex `0.144.6`、pytest `7.4.4`、ruff `0.15.22`、bubblewrap `0.11.0` 均可用。
- `act --version`
  - `act version 0.2.82`。
- `act issue_comment -W .github/workflows/claude.yml -j claude -e /private/tmp/talebook-claude-unzip-event.json -s CLAUDE_CODE_OAUTH_TOKEN=dummy --pull=false --container-architecture linux/arm64`
  - 加载并执行真实 Claude workflow；`Install Bun` 使用 `/usr/bin/unzip` 成功安装 Bun `1.3.14`，随后 140 个 Action 依赖安装成功。
  - 本地最终按预期停在 GitHub OIDC 外部边界：`ACTIONS_ID_TOKEN_REQUEST_URL` 不存在。
- `make lint-py-fix`
  - 通过；96 个文件无需格式变更。
- `make lint-py`
  - 通过。
- `make test`
  - `667 passed, 2 skipped, 33 warnings`。
- `make check-design`
  - `53 design document(s) passed`。
- `git diff --cached --check` 与 `git diff --check`
  - 通过。

## 风险与兼容性

- `unzip` 仅加入 development stage，不改变 production、builder 或 test stage 的运行时内容。
- 新增的目录级 AGENTS 规范会提高 workflow PR 的本地验收要求，这是有意的工程门禁变化。
- `act` 无法在本地完整模拟 GitHub OIDC、仓库写入、回帖和真实模型调用。本次已验证到 OIDC 边界；这些外部行为仍需真实 GitHub Actions 运行继续确认。
- 不涉及界面、布局或交互变更，无需产品截图；两份方案页已在 1440×900 和 390×844 视口完成实际渲染检查。

## 方案

### Dev 镜像补齐 Claude Action 解压依赖

- [GitHub 文件](https://github.com/talebook/talebook/blob/ca263cbfdf301a85833829c062e256b3153ed6ab/design/docker/20260723-dev-image-unzip.active.html)
- [RawGitHack 预览](https://raw.githack.com/talebook/talebook/ca263cbfdf301a85833829c062e256b3153ed6ab/design/docker/20260723-dev-image-unzip.active.html)

### Workflow 本地 act 强制验收规范

- [GitHub 文件](https://github.com/talebook/talebook/blob/ca263cbfdf301a85833829c062e256b3153ed6ab/design/project/20260724-workflow-local-act-validation.active.html)
- [RawGitHack 预览](https://raw.githack.com/talebook/talebook/ca263cbfdf301a85833829c062e256b3153ed6ab/design/project/20260724-workflow-local-act-validation.active.html)
