### PR TITLE
fix(ci): prepare Codex runtime before validation

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -429,6 +429,16 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Prepare Codex runtime and repository
+        if: steps.context.outputs.authorized == 'true' && steps.context.outputs.supported_target == 'true'
+        run: |
+          set -euo pipefail
+          mkdir -p "$CODEX_HOME"
+          chmod 700 "$CODEX_HOME"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git config --global --get-all safe.directory | grep -Fqx "$GITHUB_WORKSPACE"
+          git status --short
+
       - name: Verify development environment and sandbox
         if: steps.context.outputs.authorized == 'true' && steps.context.outputs.supported_target == 'true'
         run: |
@@ -443,7 +453,7 @@ jobs:
           codex --version
           bwrap --version
 
-          if codex sandbox -- /bin/true 2>/dev/null; then
+          if codex sandbox -- /bin/true; then
             echo "✅ Codex sandbox test passed"
           else
             echo "::error::Codex sandbox self-test failed"

--- a/tests/test_codex_workflow.py
+++ b/tests/test_codex_workflow.py
@@ -123,6 +123,7 @@ def test_codex_runs_in_the_dev_container_without_runtime_install_steps():
     job = codex_job()
     steps = codex_job()["steps"]
     checkout = workflow_step(name="Checkout repository")
+    prepare = workflow_step(name="Prepare Codex runtime and repository")
     verify = workflow_step(name="Verify development environment and sandbox")
     synchronize = workflow_step(name="Synchronize project dependencies")
     restore_auth = workflow_step(name="Restore Codex ChatGPT auth")
@@ -158,8 +159,29 @@ def test_codex_runs_in_the_dev_container_without_runtime_install_steps():
         )
     )
     assert synchronize["run"] == "make init\nnpm --prefix app ci\n"
-    assert steps.index(checkout) < steps.index(verify) < steps.index(synchronize) < steps.index(restore_auth)
+    assert steps.index(checkout) < steps.index(prepare) < steps.index(verify) < steps.index(synchronize) < steps.index(restore_auth)
     assert steps.index(restore_auth) < steps.index(run_codex)
+
+
+def test_codex_runtime_home_and_repository_trust_are_prepared_before_verification():
+    prepare = workflow_step(name="Prepare Codex runtime and repository")
+    verify = workflow_step(name="Verify development environment and sandbox")
+
+    assert prepare["if"] == (
+        "steps.context.outputs.authorized == 'true' && steps.context.outputs.supported_target == 'true'"
+    )
+    assert prepare["run"] == (
+        'set -euo pipefail\n'
+        'mkdir -p "$CODEX_HOME"\n'
+        'chmod 700 "$CODEX_HOME"\n'
+        'git config --global --add safe.directory "$GITHUB_WORKSPACE"\n'
+        'git config --global --get-all safe.directory | grep -Fqx "$GITHUB_WORKSPACE"\n'
+        "git status --short\n"
+    )
+    assert "safe.directory '*'" not in prepare["run"]
+    assert 'safe.directory "*"' not in prepare["run"]
+    assert "if codex sandbox -- /bin/true; then" in verify["run"]
+    assert "codex sandbox -- /bin/true 2>/dev/null" not in verify["run"]
 
 
 def test_only_repository_writers_can_trigger_the_employee():


### PR DESCRIPTION
## 背景

[Actions run 30071952310](https://github.com/talebook/talebook/actions/runs/30071952310)
包含两个独立故障：

1. workflow 导出 `CODEX_HOME=/__w/_temp/codex-home` 后，在目录创建之前执行
   `codex sandbox -- /bin/true`，sandbox 自检失败。
2. 失败兜底执行 Git 时，checkout 的临时 HOME 配置已不可见，触发
   `detected dubious ownership`。

## 关键改动

- checkout 后显式创建 `CODEX_HOME` 并收紧为 `0700`。
- 将当前 `$GITHUB_WORKSPACE` 精确加入持久 HOME 的 Git `safe.directory`，立即验证配置并执行
  `git status --short`。
- 不使用 `safe.directory '*'`，不修改镜像、root 身份、容器权限、sandbox 策略或 token 权限。
- 保留 sandbox fail-closed，同时不再丢弃 stderr。
- 增加 workflow 契约测试，锁定命令、安全边界和执行顺序。

## 已执行验证

- TDD 红灯：`python3.12 -m pytest -q tests/test_codex_workflow.py` 得到
  `2 failed, 25 passed`，失败点均为缺少 runtime 准备步骤。
- TDD 绿灯：同一命令得到 `27 passed`。
- `git diff --check`：通过。
- 本地容器诊断：
  - 不存在的 `CODEX_HOME` 可稳定复现原始 sandbox 失败。
  - 提前创建目录后，本地 arm64 dev 容器连续两次通过 sandbox 自检。
  - 异主 UID Git 仓库在精确信任前复现 `dubious ownership`，配置后通过。

## Draft 阻断项

本 PR 暂时保持 Draft：

- Docker Desktop 当前未运行，`make build-dev` 尚未完成。
- 真实 `act issue_comment -W .github/workflows/codex.yml -j codex` 尚未完成。
- 仓库全量 lint/test 尚未完成。
- WIP 方案 `design/project/20260724-codex-runtime-bootstrap.wip.html` 尚未回写并转为 ACTIVE；
  完成验证后将推送 ACTIVE 方案并补充固定 commit SHA 的 GitHub / RawGitHack 链接。

## 风险与兼容性

- 精确信任范围仅限当前工作区，不放宽其他 Git 仓库。
- GitHub 原生 amd64 runner 是最终 sandbox 验收边界；本地 QEMU 跨架构执行不能等价验证 seccomp。
- 删除新增准备步骤即可回滚，不涉及数据、镜像或密钥迁移。
