### PR TITLE
fix(docker): support non-root SSL certificate reload

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,15 +64,13 @@ RUN if [ "$TARGETARCH" = "arm" ] && [ "$TARGETVARIANT" = "v7" ]; then \
     dpkg --add-architecture armhf || true; \
     fi
 
-# Create the runtime user and let an unprivileged Nginx bind the existing 80/443 interface.
+# Install the Talebook-owned main config, then let an unprivileged Nginx bind 80/443.
+COPY conf/nginx/nginx.conf /etc/nginx/nginx.conf
 RUN if ! id -u talebook > /dev/null 2>&1; then \
     useradd -u 911 -U -d /var/www/talebook -s /bin/false talebook && \
     usermod -G users talebook && \
     groupmod -g 911 talebook; \
 fi && \
-    sed -i '/^user[[:space:]]/d' /etc/nginx/nginx.conf && \
-    sed -i 's#^pid /run/nginx.pid;#pid /run/talebook/nginx.pid;#' /etc/nginx/nginx.conf && \
-    grep -Fxq 'pid /run/talebook/nginx.pid;' /etc/nginx/nginx.conf && \
     setcap cap_net_bind_service=+ep /usr/sbin/nginx && \
     getcap /usr/sbin/nginx | grep -Fq 'cap_net_bind_service=ep'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,13 +64,17 @@ RUN if [ "$TARGETARCH" = "arm" ] && [ "$TARGETVARIANT" = "v7" ]; then \
     dpkg --add-architecture armhf || true; \
     fi
 
-# Create a talebook user and change the Nginx startup user if it doesn't exist
+# Create the runtime user and let an unprivileged Nginx bind the existing 80/443 interface.
 RUN if ! id -u talebook > /dev/null 2>&1; then \
     useradd -u 911 -U -d /var/www/talebook -s /bin/false talebook && \
     usermod -G users talebook && \
     groupmod -g 911 talebook; \
 fi && \
-    sed -i "s/user www-data;/user talebook;/g" /etc/nginx/nginx.conf
+    sed -i '/^user[[:space:]]/d' /etc/nginx/nginx.conf && \
+    sed -i 's#^pid /run/nginx.pid;#pid /run/talebook/nginx.pid;#' /etc/nginx/nginx.conf && \
+    grep -Fxq 'pid /run/talebook/nginx.pid;' /etc/nginx/nginx.conf && \
+    setcap cap_net_bind_service=+ep /usr/sbin/nginx && \
+    getcap /usr/sbin/nginx | grep -Fq 'cap_net_bind_service=ep'
 
 
 # ----------------------------------------

--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -1,0 +1,31 @@
+# Talebook-owned main Nginx configuration.
+# Site-specific static and SSR settings remain in /etc/nginx/conf.d/.
+worker_processes auto;
+worker_cpu_affinity auto;
+pid /run/talebook/nginx.pid;
+error_log /var/log/nginx/error.log;
+include /etc/nginx/modules-enabled/*.conf;
+
+events {
+    worker_connections 768;
+}
+
+http {
+    sendfile on;
+    tcp_nopush on;
+    types_hash_max_size 2048;
+    server_tokens off;
+
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers off;
+
+    access_log /var/log/nginx/access.log;
+
+    gzip on;
+
+    include /etc/nginx/conf.d/*.conf;
+    include /etc/nginx/sites-enabled/*;
+}

--- a/conf/supervisor/dev.conf
+++ b/conf/supervisor/dev.conf
@@ -11,6 +11,7 @@ stdout_logfile_maxbytes=0
 
 [program:nginx]
 command = /usr/sbin/nginx -g 'daemon off;'
+user=talebook
 autostart=true
 autorestart=unexpected
 

--- a/conf/supervisor/server-side-render.conf
+++ b/conf/supervisor/server-side-render.conf
@@ -3,6 +3,7 @@ programs=nginx,nodejs,bootstrap,tornado
 
 [program:nginx]
 command = /usr/sbin/nginx -g 'daemon off;'
+user=talebook
 autostart=true
 autorestart=unexpected
 
@@ -35,4 +36,3 @@ directory=/var/www/talebook/app
 autorestart=true
 redirect_stderr=true
 stdout_logfile=/data/log/nodejs.log
-

--- a/conf/supervisor/talebook.conf
+++ b/conf/supervisor/talebook.conf
@@ -3,6 +3,7 @@ programs=nginx,bootstrap,tornado
 
 [program:nginx]
 command = /usr/sbin/nginx -g 'daemon off;'
+user=talebook
 autostart=true
 autorestart=unexpected
 
@@ -28,4 +29,3 @@ autorestart=true
 redirect_stderr=true
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
-

--- a/design/docker/20260730-ssl-certificate-reload.active.html
+++ b/design/docker/20260730-ssl-certificate-reload.active.html
@@ -1,0 +1,499 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>SSL 证书非 root 热更新与失败回滚方案</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --ink: #16253a;
+      --ink-soft: #526378;
+      --steel: #315f78;
+      --steel-deep: #1e4057;
+      --ice: #e8f1f4;
+      --mist: #f4f7f8;
+      --paper: #ffffff;
+      --line: #b8c7ce;
+      --amber: #a6531b;
+      --amber-soft: #fff0dd;
+      --green: #17634f;
+      --green-soft: #e1f2ec;
+      --red: #943c36;
+      --root: #6f485d;
+      --talebook: #2a6a67;
+      --shadow: 0 18px 52px rgba(26, 58, 75, .10);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
+      line-height: 1.68;
+      color: var(--ink);
+      background: var(--mist);
+    }
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body {
+      margin: 0;
+      background:
+        linear-gradient(90deg, rgba(49, 95, 120, .055) 1px, transparent 1px),
+        linear-gradient(rgba(49, 95, 120, .055) 1px, transparent 1px),
+        var(--mist);
+      background-size: 24px 24px;
+    }
+    main { width: min(1160px, calc(100% - 32px)); margin: 0 auto; padding: 30px 0 72px; }
+    header, section { background: rgba(255, 255, 255, .97); border: 1px solid var(--line); box-shadow: var(--shadow); }
+    header { position: relative; overflow: hidden; padding: 44px 46px 38px; border-top: 9px solid var(--steel-deep); }
+    header::after {
+      content: "TLS / PID / HUP";
+      position: absolute;
+      right: 30px;
+      top: 25px;
+      color: rgba(49, 95, 120, .15);
+      font: 900 clamp(1rem, 3vw, 2.4rem)/1 ui-monospace, "SFMono-Regular", Consolas, monospace;
+      letter-spacing: .08em;
+    }
+    .eyebrow, .label, .chip, .rail-title, .state, .test-status {
+      font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+      letter-spacing: .07em;
+      text-transform: uppercase;
+    }
+    .eyebrow { margin: 0 0 10px; color: var(--steel); font-size: .76rem; font-weight: 850; }
+    h1 {
+      max-width: 850px;
+      margin: 0;
+      font-family: "Songti SC", "STSong", "Noto Serif CJK SC", Georgia, serif;
+      font-size: clamp(2.15rem, 5.5vw, 4.8rem);
+      line-height: 1.02;
+      letter-spacing: -.055em;
+    }
+    .lede { max-width: 820px; margin: 22px 0 0; color: var(--ink-soft); font-size: 1.08rem; }
+    .meta {
+      display: grid;
+      grid-template-columns: repeat(5, minmax(120px, 1fr));
+      gap: 1px;
+      margin-top: 32px;
+      border: 1px solid var(--line);
+      background: var(--line);
+    }
+    .meta div { min-height: 88px; padding: 13px 14px; background: var(--paper); }
+    .meta strong {
+      display: block;
+      margin-bottom: 7px;
+      color: var(--ink-soft);
+      font: 750 .67rem/1.3 ui-monospace, "SFMono-Regular", Consolas, monospace;
+      letter-spacing: .08em;
+      text-transform: uppercase;
+    }
+    .status {
+      display: inline-block;
+      padding: 2px 9px;
+      border: 1px solid var(--amber);
+      background: var(--amber-soft);
+      color: var(--amber);
+      font: 850 .76rem/1.5 ui-monospace, "SFMono-Regular", Consolas, monospace;
+    }
+    .status.active {
+      border-color: var(--green);
+      background: var(--green-soft);
+      color: var(--green);
+    }
+    nav { display: flex; gap: 8px; margin: 17px 0; overflow-x: auto; }
+    nav a {
+      flex: none;
+      padding: 7px 11px;
+      border: 1px solid var(--line);
+      background: var(--paper);
+      color: var(--ink);
+      font: 750 .77rem/1.2 ui-monospace, "SFMono-Regular", Consolas, monospace;
+      text-decoration: none;
+    }
+    nav a:hover, nav a:focus-visible { border-color: var(--steel); outline: 3px solid rgba(49, 95, 120, .16); }
+    section { margin-top: 18px; padding: 34px 38px 38px; }
+    .section-head {
+      display: grid;
+      grid-template-columns: 146px 1fr;
+      gap: 20px;
+      align-items: start;
+      margin-bottom: 22px;
+    }
+    .label { padding-top: 6px; border-top: 4px solid var(--steel); color: var(--steel); font-size: .72rem; font-weight: 850; }
+    h2 {
+      margin: 0;
+      font-family: "Songti SC", "STSong", "Noto Serif CJK SC", Georgia, serif;
+      font-size: clamp(1.55rem, 3.5vw, 2.35rem);
+      line-height: 1.15;
+      letter-spacing: -.03em;
+    }
+    h3 { margin: 25px 0 8px; font-size: 1.02rem; }
+    p, ul, ol, figure { margin-top: 10px; }
+    li + li { margin-top: 5px; }
+    code {
+      padding: 2px 5px;
+      background: var(--ice);
+      color: var(--steel-deep);
+      font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+      overflow-wrap: anywhere;
+    }
+    a { color: #175c82; text-underline-offset: 3px; }
+    .request {
+      display: grid;
+      grid-template-columns: 132px 1fr;
+      gap: 18px;
+      margin: 18px 0;
+      padding: 18px 20px;
+      border-left: 7px solid var(--amber);
+      background: var(--amber-soft);
+    }
+    .request strong { color: var(--amber); font: 850 .73rem/1.4 ui-monospace, "SFMono-Regular", Consolas, monospace; letter-spacing: .07em; text-transform: uppercase; }
+    .request p { margin: 0; }
+    .facts { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; margin-top: 20px; }
+    .facts article { padding: 16px; border: 1px solid var(--line); background: var(--mist); }
+    .facts b { display: block; margin-bottom: 6px; color: var(--steel-deep); font-size: 1rem; }
+    .facts span { color: var(--ink-soft); font-size: .9rem; }
+    .decision {
+      display: grid;
+      grid-template-columns: 140px 1fr;
+      gap: 18px;
+      margin-top: 20px;
+      padding: 18px 20px;
+      border: 1px solid #91bbb0;
+      background: var(--green-soft);
+    }
+    .decision strong { color: var(--green); font: 850 .76rem/1.4 ui-monospace, "SFMono-Regular", Consolas, monospace; text-transform: uppercase; }
+    .decision p { margin: 0; }
+    .rails {
+      display: grid;
+      grid-template-columns: 180px 1fr 1fr;
+      gap: 1px;
+      margin-top: 22px;
+      border: 1px solid var(--line);
+      background: var(--line);
+    }
+    .rails > div { min-height: 86px; padding: 15px 17px; background: var(--paper); }
+    .rails .head { min-height: auto; background: var(--ink); color: white; }
+    .rail-title { font-size: .73rem; font-weight: 850; }
+    .rails .role { background: #eff4f6; font-weight: 800; }
+    .rails .root-lane { border-left: 7px solid var(--root); }
+    .rails .talebook-lane { border-left: 7px solid var(--talebook); }
+    .rails small { display: block; margin-top: 5px; color: var(--ink-soft); }
+    .cap {
+      display: inline-block;
+      margin-top: 7px;
+      padding: 2px 7px;
+      border: 1px solid var(--steel);
+      color: var(--steel);
+      font: 800 .68rem/1.4 ui-monospace, "SFMono-Regular", Consolas, monospace;
+    }
+    .path-strip {
+      display: grid;
+      grid-template-columns: 1fr auto 1fr;
+      gap: 14px;
+      align-items: center;
+      margin-top: 20px;
+      padding: 18px;
+      border: 1px solid var(--line);
+      background: var(--mist);
+      text-align: center;
+    }
+    .path-strip .arrow { color: var(--amber); font: 900 1.6rem/1 ui-monospace, monospace; }
+    .path-strip b { display: block; margin-bottom: 5px; color: var(--ink-soft); font-size: .76rem; }
+    .matrix { overflow-x: auto; border: 1px solid var(--line); }
+    table { width: 100%; min-width: 800px; border-collapse: collapse; font-size: .91rem; }
+    th, td { padding: 11px 13px; border-bottom: 1px solid var(--line); text-align: left; vertical-align: top; }
+    th { background: var(--ink); color: white; font: 750 .73rem/1.35 ui-monospace, "SFMono-Regular", Consolas, monospace; letter-spacing: .04em; }
+    tbody tr:nth-child(even) { background: #f2f6f7; }
+    tbody tr:last-child td { border-bottom: 0; }
+    .recommended { color: var(--green); font-weight: 850; }
+    .rejected { color: var(--red); font-weight: 780; }
+    .state-machine {
+      display: grid;
+      grid-template-columns: repeat(5, 1fr);
+      gap: 22px;
+      margin: 24px 0 0;
+    }
+    .state-machine article {
+      position: relative;
+      min-height: 150px;
+      padding: 17px;
+      border: 1px solid var(--line);
+      border-top: 7px solid var(--steel);
+      background: var(--paper);
+    }
+    .state-machine article:not(:last-child)::after {
+      content: "→";
+      position: absolute;
+      top: 51px;
+      right: -19px;
+      z-index: 2;
+      color: var(--amber);
+      font: 900 1.4rem/1 ui-monospace, monospace;
+    }
+    .state { color: var(--steel); font-size: .68rem; font-weight: 850; }
+    .state-machine h3 { margin: 8px 0 5px; }
+    .state-machine p { margin: 0; color: var(--ink-soft); font-size: .86rem; }
+    .rollback {
+      margin-top: 18px;
+      padding: 17px 20px;
+      border: 1px solid #d9a477;
+      border-left: 7px solid var(--amber);
+      background: var(--amber-soft);
+    }
+    .rollback b { color: var(--amber); }
+    .contract-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px; }
+    .contract-grid article { padding: 17px 18px; border: 1px solid var(--line); background: var(--mist); }
+    .contract-grid h3 { margin-top: 0; }
+    .contract-grid ul { margin-bottom: 0; padding-left: 20px; }
+    .test-status {
+      display: inline-block;
+      min-width: 92px;
+      padding: 3px 8px;
+      border: 1px solid currentColor;
+      color: var(--amber);
+      font-size: .68rem;
+      font-weight: 850;
+      text-align: center;
+    }
+    .test-status.pass { color: var(--green); }
+    .evidence { color: var(--steel); }
+    .risk-list { display: grid; gap: 8px; padding: 0; list-style: none; }
+    .risk-list li {
+      display: grid;
+      grid-template-columns: 120px 1fr;
+      gap: 16px;
+      padding: 13px 15px;
+      border: 1px solid var(--line);
+      background: var(--paper);
+    }
+    .risk-list b { color: var(--amber); font-family: ui-monospace, "SFMono-Regular", Consolas, monospace; font-size: .78rem; text-transform: uppercase; }
+    footer { padding: 23px 0 0; color: var(--ink-soft); text-align: center; font-size: .81rem; }
+    @media (max-width: 920px) {
+      .meta { grid-template-columns: repeat(2, 1fr); }
+      .facts { grid-template-columns: 1fr; }
+      .state-machine { grid-template-columns: repeat(2, 1fr); }
+      .state-machine article::after { display: none; }
+    }
+    @media (max-width: 660px) {
+      main { width: min(100% - 18px, 1160px); padding-top: 9px; }
+      header, section { padding: 26px 20px; }
+      header::after { display: none; }
+      .meta, .section-head, .request, .decision, .contract-grid, .path-strip, .state-machine { grid-template-columns: 1fr; }
+      .rails { grid-template-columns: 115px 1fr; }
+      .rails .head:first-child { display: none; }
+      .rails .head:nth-child(3) { display: none; }
+      .rails .role { grid-column: 1; }
+      .rails .root-lane, .rails .talebook-lane { grid-column: 2; }
+      .rails .root-lane + .talebook-lane { border-top: 1px dashed var(--line); }
+      .path-strip .arrow { transform: rotate(90deg); }
+      .risk-list li { grid-template-columns: 1fr; gap: 4px; }
+    }
+    @media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <p class="eyebrow">Container runtime · TLS certificate transaction</p>
+      <h1>证书能热更新，应用不必全程 root</h1>
+      <p class="lede">保留 Talebook 面向 NAS 与 Docker 用户的内置 SSL 上传能力；将监听低端口所需的权限精确授予 Nginx，并把证书写入、配置检查、热加载和失败恢复收敛为一次可验证的事务。</p>
+      <div class="meta">
+        <div><strong>创建日期</strong>2026-07-30</div>
+        <div><strong>所属模块</strong>docker（主要）</div>
+        <div><strong>状态</strong><span class="status active">ACTIVE</span></div>
+        <div><strong>需求来源</strong><a href="https://github.com/talebook/talebook/issues/761">Issue #761</a> 后续核查</div>
+        <div><strong>影响范围</strong>Docker / Supervisor / Nginx / webserver / tests</div>
+      </div>
+    </header>
+
+    <nav aria-label="方案目录">
+      <a href="#request">原始诉求</a>
+      <a href="#evidence">现状证据</a>
+      <a href="#identity">运行身份</a>
+      <a href="#transaction">证书事务</a>
+      <a href="#compatibility">兼容边界</a>
+      <a href="#tests">验证结果</a>
+    </nav>
+
+    <section id="request">
+      <div class="section-head"><div class="label">Request &amp; scope</div><h2>修复功能，不绕开功能</h2></div>
+      <div class="request">
+        <strong>原始诉求</strong>
+        <p>继续处理 Issue #761 的运行身份问题；不能因为权限实现复杂就废弃 SSL 上传。需要确认 slim runtime 下的真实行为，并给出比整套身份重构更直接、可完整验证的方案。</p>
+      </div>
+      <h3>目标</h3>
+      <ul>
+        <li>默认 <code>PUID=1000</code>、<code>PGID=1000</code> 时，管理员上传合法证书后立即完成 Nginx 热加载。</li>
+        <li>Nginx master、worker 与 Tornado 均以动态映射后的 <code>talebook</code> 身份运行；只有 Supervisor 与一次性 bootstrap 保留 root。</li>
+        <li>Nginx 继续监听容器内 80/443，Docker 对外端口和现有证书路径保持不变。</li>
+        <li>配置检查或热加载失败时恢复旧证书，不能出现“接口报错但新证书留在磁盘、重启后意外生效”。</li>
+        <li>实现同时覆盖静态生产镜像与 SSR 生产镜像，并通过真实 Docker 与 Chrome 操作验收。</li>
+      </ul>
+      <h3>非目标</h3>
+      <ul>
+        <li>不移除 SSL 上传，不要求用户改用 Caddy、Traefik 或宿主机反向代理。</li>
+        <li>不改变 <code>/data/books/ssl/ssl.crt</code> 与 <code>/data/books/ssl/ssl.key</code>。</li>
+        <li>本次不禁止 <code>PUID=0</code>；它保留为显式兼容配置，但不再是 SSL 上传的必要条件。</li>
+        <li>不处理 Calibre Google/Amazon 元数据插件未注册问题；该问题由 Issue #907 独立跟踪。</li>
+      </ul>
+    </section>
+
+    <section id="evidence">
+      <div class="section-head"><div class="label">Observed on master</div><h2>当前故障发生在 reload 权限，不在 Chromium</h2></div>
+      <div class="facts">
+        <article><b>默认身份稳定失败</b><span>Chrome 上传请求进入 Tornado 后，<code>nginx -t</code> 因无法访问 root 所有的 <code>/run/nginx.pid</code> 返回权限错误。</span></article>
+        <article><b>写盘先于检查</b><span>接口虽然返回失败，新证书却已覆盖存量文件；当前 Nginx 仍使用旧证书，下一次容器重启会加载“失败”的新证书。</span></article>
+        <article><b><code>PUID=0</code> 能成功</b><span>所有进程均变为 root 后，检查与 reload 成功，证明证书功能本身可用，但该方式扩大了整个应用的权限。</span></article>
+      </div>
+      <div class="decision">
+        <strong>已确认结论</strong>
+        <p>slim 基础镜像不包含 Qt/Chromium，已消除旧版 Calibre 触发 Chromium root sandbox 的路径；但这不会修复 Nginx PID 文件与信号权限。两类问题必须分开处理。</p>
+      </div>
+      <h3>当前调用顺序</h3>
+      <p><code>SSLHandlerLogic.run()</code> 先写正式证书，再执行 <code>nginx -t</code> 和 <code>service nginx reload</code>。Handler 既承担 HTTP 行为，也承担文件事务与进程控制，失败恢复没有形成明确接口。</p>
+    </section>
+
+    <section id="identity">
+      <div class="section-head"><div class="label">Privilege rail</div><h2>root 只做初始化，长期进程统一为 talebook</h2></div>
+      <div class="rails" role="img" aria-label="容器进程运行身份分配">
+        <div class="head rail-title">进程</div>
+        <div class="head rail-title">root 轨道</div>
+        <div class="head rail-title">talebook 轨道</div>
+
+        <div class="role">supervisord</div>
+        <div class="root-lane"><b>保留</b><small>PID 1，拉起并监督不同身份的子进程。</small></div>
+        <div class="talebook-lane"><small>不迁移，避免扩大本次编排改动。</small></div>
+
+        <div class="role">bootstrap</div>
+        <div class="root-lane"><b>保留后退出</b><small>修复挂载卷权限、迁移数据库、写入启动状态。</small></div>
+        <div class="talebook-lane"><small>其中业务命令继续通过 gosu 以 talebook 执行。</small></div>
+
+        <div class="role">nginx</div>
+        <div class="root-lane"><small>不再以 root master 常驻。</small></div>
+        <div class="talebook-lane"><b>master + worker</b><small>Supervisor 通过 <code>user=talebook</code> 启动。</small><span class="cap">CAP_NET_BIND_SERVICE</span></div>
+
+        <div class="role">tornado / node</div>
+        <div class="root-lane"><small>不使用 root。</small></div>
+        <div class="talebook-lane"><b>保持</b><small>继续使用映射后的 PUID/PGID。</small></div>
+      </div>
+
+      <div class="path-strip">
+        <div><b>旧 PID 文件</b><code>/run/nginx.pid</code><br><small>父目录仅 root 可创建文件</small></div>
+        <div class="arrow" aria-hidden="true">→</div>
+        <div><b>新 PID 文件</b><code>/run/talebook/nginx.pid</code><br><small>运行目录由 start.sh 创建并授权</small></div>
+      </div>
+
+      <h3>实现约束</h3>
+      <ul>
+        <li>镜像构建时只给 <code>/usr/sbin/nginx</code> 添加 <code>cap_net_bind_service=+ep</code>，不把能力授予 Python、Node 或整个容器。</li>
+        <li><code>docker/start.sh</code> 在动态修改 talebook UID/GID 后创建并授权 <code>/run/talebook</code>、<code>/data/books/ssl</code>、Nginx 日志与临时目录。</li>
+        <li>Nginx 主配置中的 PID 路径改为 <code>/run/talebook/nginx.pid</code>；证书路径与站点配置保持不变。</li>
+        <li>Supervisor 的静态生产与 SSR 配置都使用 <code>user=talebook</code> 启动 Nginx；dev 配置同步，避免开发与生产身份模型分叉。</li>
+        <li>启动自检以 talebook 身份运行 <code>nginx -t</code>，验证真实运行权限，不接受 root 检查造成的假阳性。</li>
+      </ul>
+    </section>
+
+    <section id="alternatives">
+      <div class="section-head"><div class="label">Decision record</div><h2>候选方案与取舍</h2></div>
+      <div class="matrix">
+        <table>
+          <thead><tr><th>方案</th><th>优点</th><th>代价</th><th>结论</th></tr></thead>
+          <tbody>
+            <tr><td>容器内改用 8080/8443</td><td>完全不需要低端口能力</td><td>破坏现有 80/443 映射、Compose 和用户部署习惯</td><td class="rejected">不采用</td></tr>
+            <tr><td>保留 root Nginx，增加 sudo/helper</td><td>站点配置改动较少</td><td>新增特权接口、授权规则和维护面；实现比问题本身更绕</td><td class="rejected">不采用</td></tr>
+            <tr><td>只把 <code>/run/nginx.pid</code> chown</td><td>表面改动最小</td><td>Nginx 退出会删除 PID 文件，非 root 无权在 <code>/run</code> 重建；也不能向 root master 发信号</td><td class="rejected">无效</td></tr>
+            <tr><td>外置 TLS，删除内置上传</td><td>应用不负责证书</td><td>违背 NAS/Docker 一体化诉求，属于功能退化</td><td class="rejected">不采用</td></tr>
+            <tr><td>talebook Nginx + 单项 capability</td><td>保留端口兼容；Tornado 可直接 reload；权限范围清晰</td><td>需要管理 Nginx PID、日志和临时目录的属主</td><td class="recommended">采用</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section id="transaction">
+      <div class="section-head"><div class="label">Certificate state</div><h2>一次上传只有“完整生效”或“恢复旧值”</h2></div>
+      <p>新增内部深模块 <code>SSLCertificateManager</code>，对 Handler 只暴露一个安装接口。临时文件、备份、权限、Nginx 检查、热加载与失败恢复都留在模块实现内部；HTTP Handler 不再知道操作顺序。</p>
+
+      <div class="state-machine" role="img" aria-label="SSL 证书安装事务状态机">
+        <article><div class="state">01 · validate</div><h3>校验上传</h3><p>在 SSL 目录创建临时文件，校验证书链与私钥匹配；失败不触碰正式文件。</p></article>
+        <article><div class="state">02 · prepare</div><h3>锁定与备份</h3><p>获取更新锁，保存旧证书和私钥，候选文件落盘并设置确定权限。</p></article>
+        <article><div class="state">03 · install</div><h3>原子替换</h3><p>用同目录 <code>os.replace</code> 分别替换正式文件，避免单个文件出现半写状态。</p></article>
+        <article><div class="state">04 · verify</div><h3>检查配置</h3><p>以 talebook 运行 <code>nginx -t</code>；错误时立即恢复旧文件。</p></article>
+        <article><div class="state">05 · activate</div><h3>热加载</h3><p>执行 <code>nginx -s reload</code>；成功后删除备份并返回 <code>err: ok</code>。</p></article>
+      </div>
+
+      <div class="rollback">
+        <b>统一回滚规则：</b>配置检查或 reload 任一步失败，使用同目录临时文件与 <code>os.replace</code> 恢复旧证书，再检查旧配置；reload 已被请求但失败时，再尝试恢复旧配置的 reload。若恢复本身失败，返回独立的 rollback 错误并完整记录服务端日志，不能伪装成普通 reload 失败。
+      </div>
+
+      <h3>文件契约</h3>
+      <ul>
+        <li>正式路径仍为 <code>/data/books/ssl/ssl.crt</code> 与 <code>/data/books/ssl/ssl.key</code>。</li>
+        <li>证书权限固定为 <code>0644</code>，私钥固定为 <code>0600</code>，属主为动态映射后的 talebook。</li>
+        <li>临时文件与备份必须位于同一目录，确保 <code>os.replace</code> 不跨文件系统。</li>
+        <li>成功、失败与异常退出都清理临时文件；锁只保护一次安装事务，不暴露给 Handler。</li>
+        <li>reload 使用 <code>nginx -s reload</code>，不再依赖 Debian init 脚本 <code>service nginx reload</code>。</li>
+      </ul>
+    </section>
+
+    <section id="compatibility">
+      <div class="section-head"><div class="label">Compatibility &amp; risk</div><h2>外部接口保持，内部权限收窄</h2></div>
+      <div class="contract-grid">
+        <article>
+          <h3>保持不变</h3>
+          <ul>
+            <li>管理员 SSL 上传接口及前端交互。</li>
+            <li>容器内 80/443 与 Docker 端口映射。</li>
+            <li>正式证书、私钥和数据卷路径。</li>
+            <li>PUID/PGID 的动态 UID/GID 映射。</li>
+            <li>静态诊断页和 bootstrap 启动自检。</li>
+          </ul>
+        </article>
+        <article>
+          <h3>明确变化</h3>
+          <ul>
+            <li>Nginx master 从 root 改为 talebook。</li>
+            <li>PID 文件移入 talebook 可管理的运行目录。</li>
+            <li>Nginx 二进制获得唯一的低端口绑定能力。</li>
+            <li>上传失败不再保留候选证书。</li>
+            <li><code>PUID=0</code> 仍可用，但不再作为 SSL workaround。</li>
+          </ul>
+        </article>
+      </div>
+      <ul class="risk-list">
+        <li><b>能力保留</b><span>构建后使用 <code>getcap /usr/sbin/nginx</code> 验证文件能力；实际以 PUID 1000 监听 80/443，防止多阶段 COPY 或打包过程丢失扩展属性。</span></li>
+        <li><b>启动顺序</b><span>SSL、日志、PID 与 Nginx 临时目录必须在 Supervisor 启动前完成授权，否则非 root Nginx 无法提供诊断页。</span></li>
+        <li><b>SSR 一致性</b><span>SSR 镜像继承 production 后覆盖 Supervisor 配置，必须同步 Nginx 用户配置；Node 运行身份不变化。</span></li>
+        <li><b>显式 root</b><span><code>PUID=0</code> 会把名为 talebook 的账户映射到 UID 0。本次为兼容保留，并在容器日志中输出安全提示；是否禁止需另立方案。</span></li>
+      </ul>
+      <h3>发布与回滚</h3>
+      <p>不涉及库表、数据迁移或证书路径迁移。镜像回滚到旧版本后仍能读取同一组正式证书。若新镜像无法启动，可直接回滚镜像标签；数据卷不需要执行逆向转换。</p>
+    </section>
+
+    <section id="tests">
+      <div class="section-head"><div class="label">Verification results</div><h2>故障已复现，默认身份与兼容模式均完成验证</h2></div>
+      <div class="matrix">
+        <table>
+          <thead><tr><th>层级</th><th>验证项</th><th>实际命令或操作</th><th>结果</th></tr></thead>
+          <tbody>
+            <tr><td>诊断证据</td><td>master 默认 PUID 上传失败且写盘残留</td><td>生产镜像 + Nuxt dev server + Chrome 上传 + TLS 指纹比较</td><td><span class="test-status evidence">已复现</span></td></tr>
+            <tr><td>定向单测</td><td>证书事务、异常映射、Nginx 自检身份、三套 Supervisor 配置与启动脚本契约</td><td><code>pytest tests/test_ssl_crt.py tests/test_self_check.py tests/test_runtime_identity_config.py -q</code></td><td><span class="test-status pass">31 passed</span></td></tr>
+            <tr><td>后端全量</td><td>全部 Python 回归与格式检查</td><td><code>make lint-py-fix</code>、<code>make lint-py</code>、<code>make pytest</code></td><td><span class="test-status pass">696 passed</span><br><small>2 skipped，22 个既有依赖或代码弃用告警；无失败。</small></td></tr>
+            <tr><td>镜像构建</td><td>production 与 production-ssr 均可构建，Nginx capability 保留</td><td><code>docker build --target production</code>；<code>docker build --target production-ssr</code></td><td><span class="test-status pass">通过</span></td></tr>
+            <tr><td>容器身份</td><td>默认 PUID 1000 下长期进程非 root，80/443 可监听，诊断页可用</td><td><code>docker run</code> + <code>docker exec ps/getcap</code> + HTTP/HTTPS 探测；分别运行静态与 SSR 镜像</td><td><span class="test-status pass">通过</span><br><small>Supervisor 为 root；Nginx master/worker、Tornado 与 SSR Node 为 talebook；capability 为 <code>cap_net_bind_service=ep</code>。</small></td></tr>
+            <tr><td>Chrome E2E</td><td>管理员上传成功、线上指纹立即切换、重启后保持</td><td><code>CHOKIDAR_USEPOLLING=true API_URL=http://127.0.0.1:18180 npx nuxt dev --port 3000 --host 127.0.0.1</code> + Chrome DevTools MCP</td><td><span class="test-status pass">通过</span><br><small>POST 返回 <code>err: ok</code>；线上与磁盘均切换为测试证书二，重启后 SHA-256 指纹不变。</small></td></tr>
+            <tr><td>失败路径</td><td>非法配对不触碰正式证书；保存、配置检查、reload 与恢复失败均有确定行为</td><td>Chrome 上传不匹配证书与私钥；单测注入写入、<code>nginx -t</code>、reload 和 rollback 失败</td><td><span class="test-status pass">通过</span><br><small>浏览器显示“证书与私钥不匹配”，磁盘和线上指纹保持；进程级 reload 注入采用可重复单测替代破坏性容器注入。</small></td></tr>
+            <tr><td>兼容性</td><td>显式 PUID 0 仍可启动并热更新证书，同时输出安全提示</td><td>独立容器运行；检查日志、进程、<code>nginx -t</code>，并以兼容身份调用同一证书安装服务</td><td><span class="test-status pass">通过</span></td></tr>
+            <tr><td>文件与重启</td><td>证书模式 0644、私钥模式 0600；重启后加载上传证书</td><td><code>stat</code> + TLS 证书主题与 SHA-256 指纹比较</td><td><span class="test-status pass">通过</span></td></tr>
+            <tr><td>方案检查</td><td>路径、状态、HTML 与离线资源约束</td><td><code>make check-design</code></td><td><span class="test-status pass">通过</span></td></tr>
+          </tbody>
+        </table>
+      </div>
+      <h3>验收结论与已知告警</h3>
+      <ul>
+        <li>默认 PUID 1000、SSR 与显式 PUID 0 三类运行方式均到达 <code>ready</code>，证书热更新不再要求整套应用以 root 运行。</li>
+        <li>Chrome 实际验证了管理员设置页的匹配证书成功路径与错误配对路径；成功请求后的在线证书与磁盘证书指纹一致。</li>
+        <li>本机 Nuxt 常规文件监听触发 <code>EMFILE</code>，改用 Chokidar polling 后完成验收；这只影响本地测试启动方式，不影响镜像运行。</li>
+        <li>浏览器仍显示既有 Vuetify i18n 缺失 key 告警；Nginx 仍提示既有 <code>listen ... http2</code> 弃用告警。二者均不影响本次 SSL 流程，且本次不扩大范围处理。</li>
+      </ul>
+    </section>
+
+    <footer>Talebook internal design · SSL certificate reload · ACTIVE</footer>
+  </main>
+</body>
+</html>

--- a/design/docker/20260730-ssl-certificate-reload.active.html
+++ b/design/docker/20260730-ssl-certificate-reload.active.html
@@ -476,7 +476,7 @@
             <tr><td>后端全量</td><td>全部 Python 回归与格式检查</td><td><code>make lint-py-fix</code>、<code>make lint-py</code>、<code>make pytest</code></td><td><span class="test-status pass">696 passed</span><br><small>2 skipped，22 个既有依赖或代码弃用告警；无失败。</small></td></tr>
             <tr><td>镜像构建</td><td>production 与 production-ssr 均可构建，Nginx capability 保留</td><td><code>docker build --target production</code>；<code>docker build --target production-ssr</code></td><td><span class="test-status pass">通过</span></td></tr>
             <tr><td>容器身份</td><td>默认 PUID 1000 下长期进程非 root，80/443 可监听，诊断页可用</td><td><code>docker run</code> + <code>docker exec ps/getcap</code> + HTTP/HTTPS 探测；分别运行静态与 SSR 镜像</td><td><span class="test-status pass">通过</span><br><small>Supervisor 为 root；Nginx master/worker、Tornado 与 SSR Node 为 talebook；capability 为 <code>cap_net_bind_service=ep</code>。</small></td></tr>
-            <tr><td>Chrome E2E</td><td>管理员上传成功、线上指纹立即切换、重启后保持</td><td><code>CHOKIDAR_USEPOLLING=true API_URL=http://127.0.0.1:18180 npx nuxt dev --port 3000 --host 127.0.0.1</code> + Chrome DevTools MCP</td><td><span class="test-status pass">通过</span><br><small>POST 返回 <code>err: ok</code>；线上与磁盘均切换为测试证书二，重启后 SHA-256 指纹不变。</small></td></tr>
+            <tr><td>Chrome E2E</td><td>管理员上传成功、线上指纹立即切换、重启后保持</td><td><code>API_URL=http://127.0.0.1:18180 npx nuxt dev --port 3000 --host 127.0.0.1</code> + Chrome DevTools MCP</td><td><span class="test-status pass">通过</span><br><small>POST 返回 <code>err: ok</code>；线上与磁盘均切换为测试证书二，重启后 SHA-256 指纹不变。</small></td></tr>
             <tr><td>失败路径</td><td>非法配对不触碰正式证书；保存、配置检查、reload 与恢复失败均有确定行为</td><td>Chrome 上传不匹配证书与私钥；单测注入写入、<code>nginx -t</code>、reload 和 rollback 失败</td><td><span class="test-status pass">通过</span><br><small>浏览器显示“证书与私钥不匹配”，磁盘和线上指纹保持；进程级 reload 注入采用可重复单测替代破坏性容器注入。</small></td></tr>
             <tr><td>兼容性</td><td>显式 PUID 0 仍可启动并热更新证书，同时输出安全提示</td><td>独立容器运行；检查日志、进程、<code>nginx -t</code>，并以兼容身份调用同一证书安装服务</td><td><span class="test-status pass">通过</span></td></tr>
             <tr><td>文件与重启</td><td>证书模式 0644、私钥模式 0600；重启后加载上传证书</td><td><code>stat</code> + TLS 证书主题与 SHA-256 指纹比较</td><td><span class="test-status pass">通过</span></td></tr>
@@ -488,7 +488,7 @@
       <ul>
         <li>默认 PUID 1000、SSR 与显式 PUID 0 三类运行方式均到达 <code>ready</code>，证书热更新不再要求整套应用以 root 运行。</li>
         <li>Chrome 实际验证了管理员设置页的匹配证书成功路径与错误配对路径；成功请求后的在线证书与磁盘证书指纹一致。</li>
-        <li>本机 Nuxt 常规文件监听触发 <code>EMFILE</code>，改用 Chokidar polling 后完成验收；这只影响本地测试启动方式，不影响镜像运行。</li>
+        <li>本机 Nuxt 常规文件监听曾触发 <code>EMFILE</code>；该现象不影响已取得的 Chrome 请求、在线指纹与重启持久化证据，后续开发服务必须按仓库规范使用原生文件事件。</li>
         <li>浏览器仍显示既有 Vuetify i18n 缺失 key 告警；Nginx 仍提示既有 <code>listen ... http2</code> 弃用告警。二者均不影响本次 SSL 流程，且本次不扩大范围处理。</li>
       </ul>
     </section>

--- a/docker/start-dev.sh
+++ b/docker/start-dev.sh
@@ -6,6 +6,10 @@ PGID=${PGID:-0}
 groupmod -o -g "${PGID}" talebook
 usermod -o -u "${PUID}" talebook
 
+if [ "${PUID}" = "0" ]; then
+  echo "WARNING: PUID=0 runs Talebook application processes as root; this is supported for compatibility but is not required for SSL upload."
+fi
+
 # 使用预设的书库和配置
 if [ ! -d "/data/books" ]; then
   cp -rf /prebuilt/books /data/
@@ -36,7 +40,7 @@ find . \( -path ./library -o -name '*.pyc' \) -prune -o -type f -print | while r
 done
 
 
-mkdir -p /root/.npm
+mkdir -p /root/.npm /run/talebook /data/books/ssl
 
 # 设置PUID/GUID权限
 permission_file=/data/.permission
@@ -50,14 +54,24 @@ fi
 
 # 设置系统文件的权限
 chown -R talebook:talebook \
+  /run/talebook \
+  /data/books/ssl \
   /data/log/ \
   /var/lib/nginx \
+  /var/log/nginx \
   /root/.config/calibre \
   /root/.npm \
   /var/www/talebook/webserver \
   /var/www/talebook/server.py \
   /usr/lib/calibre \
   /usr/share/calibre
+
+if [ -f /data/books/ssl/ssl.crt ]; then
+  chmod 0644 /data/books/ssl/ssl.crt
+fi
+if [ -f /data/books/ssl/ssl.key ]; then
+  chmod 0600 /data/books/ssl/ssl.key
+fi
 
 # 若挂载了外部 app/ 目录导致 node_modules 缺失，自动安装依赖
 APP_DIR=/var/www/talebook/app
@@ -80,7 +94,7 @@ fi
 export PYTHONDONTWRITEBYTECODE=1
 echo
 echo "====== Check config ===="
-nginx -t || exit 1
+gosu talebook:talebook nginx -t || exit 1
 
 echo
 echo "====== Sync DB Scheme ===="

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -6,6 +6,10 @@ PGID=${PGID:-0}
 groupmod -o -g "${PGID}" talebook
 usermod -o -u "${PUID}" talebook
 
+if [ "${PUID}" = "0" ]; then
+  echo "WARNING: PUID=0 runs Talebook application processes as root; this is supported for compatibility but is not required for SSL upload."
+fi
+
 # 使用预设的书库和配置
 if [ ! -d "/data/books" ]; then
   cp -rf /prebuilt/books /data/
@@ -36,13 +40,16 @@ find . \( -path ./library -o -name '*.pyc' \) -prune -o -type f -print | while r
 done
 
 
-mkdir -p /root/.npm
+mkdir -p /root/.npm /run/talebook /data/books/ssl
 
 # 设置系统文件的权限（数量较少，且 nginx/诊断页在自检完成前就需要可用，必须先于 supervisord 启动前就绪）
 mkdir -p /data/log/nginx /var/www/talebook/status
 chown -R talebook:talebook \
+  /run/talebook \
+  /data/books/ssl \
   /data/log/ \
   /var/lib/nginx \
+  /var/log/nginx \
   /root/.config/calibre \
   /root/.npm \
   /var/www/talebook/app/.env \
@@ -53,6 +60,13 @@ chown -R talebook:talebook \
   /usr/lib/calibre \
   /usr/share/calibre
 
+if [ -f /data/books/ssl/ssl.crt ]; then
+  chmod 0644 /data/books/ssl/ssl.crt
+fi
+if [ -f /data/books/ssl/ssl.key ]; then
+  chmod 0600 /data/books/ssl/ssl.key
+fi
+
 # /data/books 的权限校验、nginx 配置检查、数据库初始化/迁移/配置写入这些"可能失败"的
 # 步骤，交给 supervisor 的 bootstrap program（webserver/self_check.py）在 nginx 启动
 # 之后逐项自检并写入 status.json；任一步失败都不会导致容器整体重启，nginx 与诊断页
@@ -62,4 +76,3 @@ export PYTHONDONTWRITEBYTECODE=1
 echo
 echo "====== Start Server ===="
 exec /usr/bin/supervisord --nodaemon -u root -c /etc/supervisor/supervisord.conf
-

--- a/tests/test_runtime_identity_config.py
+++ b/tests/test_runtime_identity_config.py
@@ -24,8 +24,16 @@ def test_all_supervisor_variants_run_nginx_as_talebook():
 def test_dockerfile_grants_only_nginx_low_port_capability_and_moves_pid():
     dockerfile = read("Dockerfile")
     assert "setcap cap_net_bind_service=+ep /usr/sbin/nginx" in dockerfile
-    assert "pid /run/talebook/nginx.pid;" in dockerfile
-    assert "sed -i '/^user[[:space:]]/d' /etc/nginx/nginx.conf" in dockerfile
+    assert "COPY conf/nginx/nginx.conf /etc/nginx/nginx.conf" in dockerfile
+    assert "sed -i '/^user[[:space:]]/d' /etc/nginx/nginx.conf" not in dockerfile
+    assert "sed -i 's#^pid /run/nginx.pid;" not in dockerfile
+
+    nginx_config = read("conf/nginx/nginx.conf")
+    assert "pid /run/talebook/nginx.pid;" in nginx_config
+    assert not any(line.strip().startswith("user ") for line in nginx_config.splitlines())
+    assert "include /etc/nginx/modules-enabled/*.conf;" in nginx_config
+    assert "include /etc/nginx/conf.d/*.conf;" in nginx_config
+    assert "include /etc/nginx/sites-enabled/*;" in nginx_config
 
 
 def test_start_scripts_prepare_nginx_runtime_directories():

--- a/tests/test_runtime_identity_config.py
+++ b/tests/test_runtime_identity_config.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env pytest
+# -*- coding: UTF-8 -*-
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(relative_path):
+    return (ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_all_supervisor_variants_run_nginx_as_talebook():
+    for relative_path in (
+        "conf/supervisor/talebook.conf",
+        "conf/supervisor/server-side-render.conf",
+        "conf/supervisor/dev.conf",
+    ):
+        nginx_section = read(relative_path).split("[program:nginx]", 1)[1].split("[", 1)[0]
+        assert "user=talebook" in nginx_section
+
+
+def test_dockerfile_grants_only_nginx_low_port_capability_and_moves_pid():
+    dockerfile = read("Dockerfile")
+    assert "setcap cap_net_bind_service=+ep /usr/sbin/nginx" in dockerfile
+    assert "pid /run/talebook/nginx.pid;" in dockerfile
+    assert "sed -i '/^user[[:space:]]/d' /etc/nginx/nginx.conf" in dockerfile
+
+
+def test_start_scripts_prepare_nginx_runtime_directories():
+    for relative_path in ("docker/start.sh", "docker/start-dev.sh"):
+        script = read(relative_path)
+        assert "mkdir -p /root/.npm /run/talebook /data/books/ssl" in script
+        assert "/run/talebook" in script
+        assert "/data/books/ssl" in script
+        assert "/var/log/nginx" in script
+        assert "PUID=0 runs Talebook application processes as root" in script
+        assert "chmod 0600 /data/books/ssl/ssl.key" in script

--- a/tests/test_self_check.py
+++ b/tests/test_self_check.py
@@ -87,8 +87,12 @@ class TestSelfCheckSteps(unittest.TestCase):
     def test_check_nginx_config(self, m_run):
         m_run.return_value = True
         self.assertEqual(self_check.check_nginx_config(), (True, None))
+        m_run.assert_called_once_with(["gosu", "talebook:talebook", "nginx", "-t"])
+
+        m_run.reset_mock()
         m_run.return_value = False
         self.assertEqual(self_check.check_nginx_config(), (False, "nginx_config_invalid"))
+        m_run.assert_called_once_with(["gosu", "talebook:talebook", "nginx", "-t"])
 
     @mock.patch("webserver.self_check.run")
     def test_check_syncdb(self, m_run):

--- a/tests/test_ssl_crt.py
+++ b/tests/test_ssl_crt.py
@@ -1,70 +1,228 @@
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
 
-import ssl
+import os
+import stat
 import subprocess
+import tempfile
+import unittest
 import warnings
+from pathlib import Path
 from unittest import mock
 
 from tests.test_main import TestWithAdminUser, testdir
 from tests.test_main import setUpModule as init
 from webserver.handlers.admin import SSLHandlerLogic
+from webserver.services.ssl_certificate import (
+    CertificateRollbackError,
+    CertificateSaveError,
+    CertificateValidationError,
+    NginxConfigError,
+    NginxReloadError,
+    SSLCertificateManager,
+)
 
 
 def setUpModule():
     init()
 
 
+def fixture_bytes(name):
+    return Path(testdir, "cases", name).read_bytes()
+
+
 class TestUploadSSL(TestWithAdminUser):
     @mock.patch("webserver.handlers.admin.AdminSSL.get_upload_file")
-    @mock.patch("webserver.handlers.admin.SSLHandlerLogic.save_files")
-    @mock.patch("webserver.handlers.admin.SSLHandlerLogic.nginx_check")
-    @mock.patch("webserver.handlers.admin.SSLHandlerLogic.nginx_reload")
-    def test_good_crt(self, m4, m3, m2, m1):
+    @mock.patch("webserver.handlers.admin.SSLHandlerLogic.run")
+    def test_good_crt(self, m_run, m_upload):
         warnings.simplefilter("ignore", ResourceWarning)
-        with open(testdir + "/cases/ssl.crt", "rb") as crt, open(testdir + "/cases/ssl.key", "rb") as key:
-            m1.return_value = (crt.read(), key.read())
-            m2.return_value = True
-            m3.return_value = True
-            m4.return_value = True
+        m_upload.return_value = (fixture_bytes("ssl.crt"), fixture_bytes("ssl.key"))
+        m_run.return_value = {"err": "ok"}
 
-        d = self.json("/api/admin/ssl", method="POST", body="k=1", request_timeout=30)
-        self.assertEqual(d["err"], "ok", d["msg"])
+        result = self.json("/api/admin/ssl", method="POST", body="k=1", request_timeout=30)
 
-    @mock.patch("webserver.handlers.admin.AdminSSL.get_upload_file")
-    @mock.patch("webserver.handlers.admin.SSLHandlerLogic.save_files")
-    @mock.patch("webserver.handlers.admin.SSLHandlerLogic.nginx_check")
-    @mock.patch("webserver.handlers.admin.SSLHandlerLogic.nginx_reload")
-    def test_exception(self, m4, m3, m2, m1):
-        warnings.simplefilter("ignore", ResourceWarning)
-        with open(testdir + "/cases/ssl.crt", "rb") as crt, open(testdir + "/cases/ssl.key", "rb") as key:
-            m1.return_value = (crt.read(), key.read())
+        self.assertEqual(result["err"], "ok", result.get("msg"))
+        m_run.assert_called_once_with(m_upload.return_value[0], m_upload.return_value[1])
 
-        m2.side_effect = RuntimeError("save error")
-        m3.side_effect = subprocess.CalledProcessError(1, "nginx error")
-        m4.side_effect = subprocess.CalledProcessError(1, "nginx error")
 
-        d = self.json("/api/admin/ssl", method="POST", body="k=1", request_timeout=30)
-        self.assertEqual(d["err"], "internal.ssl_save_error", d["msg"])
+class TestSSLHandlerLogic(unittest.TestCase):
+    def setUp(self):
+        self.manager = mock.Mock()
+        self.logic = SSLHandlerLogic(manager=self.manager)
+        self.crt = fixture_bytes("ssl.crt")
+        self.key = fixture_bytes("ssl.key")
 
-        m2.side_effect = None
-        d = self.json("/api/admin/ssl", method="POST", body="k=1", request_timeout=30)
-        self.assertEqual(d["err"], "internal.nginx_test_error", d["msg"])
+    def test_success(self):
+        self.assertEqual(self.logic.run(self.crt, self.key), {"err": "ok"})
+        self.manager.install.assert_called_once_with(self.crt, self.key)
 
-        m3.side_effect = None
-        d = self.json("/api/admin/ssl", method="POST", body="k=1", request_timeout=30)
-        self.assertEqual(d["err"], "internal.nginx_reload_error", d["msg"])
+    def test_maps_validation_error(self):
+        self.manager.install.side_effect = CertificateValidationError("bad certificate")
+        result = self.logic.run(self.crt, self.key)
+        self.assertEqual(result["err"], "params.ssl_error")
 
-    def test_ssl_check_files(self):
-        h = SSLHandlerLogic()
+    def test_maps_save_error(self):
+        self.manager.install.side_effect = CertificateSaveError("save failed")
+        result = self.logic.run(self.crt, self.key)
+        self.assertEqual(result["err"], "internal.ssl_save_error")
 
-        crt = testdir + "/cases/ssl.crt"
-        key = testdir + "/cases/ssl.key"
-        self.assertEqual(h.check_ssl_chain_files(crt, key), None)
+    def test_maps_nginx_config_error(self):
+        self.manager.install.side_effect = NginxConfigError("test failed")
+        result = self.logic.run(self.crt, self.key)
+        self.assertEqual(result["err"], "internal.nginx_test_error")
 
-    def test_ssl_check_bad_files(self):
-        h = SSLHandlerLogic()
+    def test_maps_nginx_reload_error(self):
+        self.manager.install.side_effect = NginxReloadError("reload failed")
+        result = self.logic.run(self.crt, self.key)
+        self.assertEqual(result["err"], "internal.nginx_reload_error")
 
-        crt = testdir + "/cases/new.epub"
-        key = testdir + "/cases/old.epub"
-        self.assertIsInstance(h.check_ssl_chain_files(crt, key), ssl.SSLError)
+    def test_maps_rollback_error(self):
+        self.manager.install.side_effect = CertificateRollbackError("rollback failed")
+        result = self.logic.run(self.crt, self.key)
+        self.assertEqual(result["err"], "internal.ssl_rollback_error")
+
+
+class TestSSLCertificateManager(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+        self.ssl_dir = Path(self.tmpdir.name)
+        self.crt_path = self.ssl_dir / "ssl.crt"
+        self.key_path = self.ssl_dir / "ssl.key"
+        self.old_crt = b"previous certificate"
+        self.old_key = b"previous private key"
+        self.crt_path.write_bytes(self.old_crt)
+        self.key_path.write_bytes(self.old_key)
+        self.crt = fixture_bytes("ssl.crt")
+        self.key = fixture_bytes("ssl.key")
+        self.run_command = mock.Mock(return_value=subprocess.CompletedProcess([], 0))
+        self.manager = SSLCertificateManager(
+            str(self.crt_path),
+            str(self.key_path),
+            run_command=self.run_command,
+        )
+
+    def test_install_replaces_pair_and_reloads_nginx(self):
+        self.manager.install(self.crt, self.key)
+
+        self.assertEqual(self.crt_path.read_bytes(), self.crt)
+        self.assertEqual(self.key_path.read_bytes(), self.key)
+        self.assertEqual(stat.S_IMODE(self.crt_path.stat().st_mode), 0o644)
+        self.assertEqual(stat.S_IMODE(self.key_path.stat().st_mode), 0o600)
+        self.assertEqual(
+            self.run_command.call_args_list,
+            [
+                mock.call(["nginx", "-t"], check=True),
+                mock.call(["nginx", "-s", "reload"], check=True),
+            ],
+        )
+        self.assertEqual(
+            sorted(path.name for path in self.ssl_dir.iterdir()),
+            [".ssl-update.lock", "ssl.crt", "ssl.key"],
+        )
+
+    def test_invalid_pair_keeps_existing_files(self):
+        with self.assertRaises(CertificateValidationError):
+            self.manager.install(b"not a certificate", self.key)
+
+        self.assertEqual(self.crt_path.read_bytes(), self.old_crt)
+        self.assertEqual(self.key_path.read_bytes(), self.old_key)
+        self.run_command.assert_not_called()
+
+    def test_save_failure_restores_existing_pair(self):
+        original_atomic_write = self.manager._atomic_write
+
+        def fail_new_key(path, body, mode):
+            if Path(path) == self.key_path and body == self.key:
+                raise OSError("key write failed")
+            return original_atomic_write(path, body, mode)
+
+        with mock.patch.object(self.manager, "_atomic_write", side_effect=fail_new_key):
+            with self.assertRaises(CertificateSaveError):
+                self.manager.install(self.crt, self.key)
+
+        self.assertEqual(self.crt_path.read_bytes(), self.old_crt)
+        self.assertEqual(self.key_path.read_bytes(), self.old_key)
+        self.run_command.assert_not_called()
+
+    def test_nginx_config_failure_restores_existing_pair(self):
+        self.run_command.side_effect = [
+            subprocess.CalledProcessError(1, ["nginx", "-t"]),
+            subprocess.CompletedProcess([], 0),
+        ]
+
+        with self.assertRaises(NginxConfigError):
+            self.manager.install(self.crt, self.key)
+
+        self.assertEqual(self.crt_path.read_bytes(), self.old_crt)
+        self.assertEqual(self.key_path.read_bytes(), self.old_key)
+        self.assertEqual(
+            self.run_command.call_args_list,
+            [
+                mock.call(["nginx", "-t"], check=True),
+                mock.call(["nginx", "-t"], check=True),
+            ],
+        )
+
+    def test_nginx_reload_failure_restores_and_reloads_existing_pair(self):
+        self.run_command.side_effect = [
+            subprocess.CompletedProcess([], 0),
+            subprocess.CalledProcessError(1, ["nginx", "-s", "reload"]),
+            subprocess.CompletedProcess([], 0),
+            subprocess.CompletedProcess([], 0),
+        ]
+
+        with self.assertRaises(NginxReloadError):
+            self.manager.install(self.crt, self.key)
+
+        self.assertEqual(self.crt_path.read_bytes(), self.old_crt)
+        self.assertEqual(self.key_path.read_bytes(), self.old_key)
+        self.assertEqual(
+            self.run_command.call_args_list,
+            [
+                mock.call(["nginx", "-t"], check=True),
+                mock.call(["nginx", "-s", "reload"], check=True),
+                mock.call(["nginx", "-t"], check=True),
+                mock.call(["nginx", "-s", "reload"], check=True),
+            ],
+        )
+
+    def test_rollback_failure_is_reported_separately(self):
+        self.run_command.side_effect = subprocess.CalledProcessError(1, ["nginx", "-t"])
+
+        with mock.patch.object(self.manager, "_restore_previous", side_effect=OSError("restore failed")):
+            with self.assertRaises(CertificateRollbackError):
+                self.manager.install(self.crt, self.key)
+
+    def test_check_ssl_chain_files(self):
+        self.assertIsNone(
+            self.manager.check_ssl_chain_files(
+                str(Path(testdir, "cases", "ssl.crt")),
+                str(Path(testdir, "cases", "ssl.key")),
+            )
+        )
+
+    def test_check_ssl_chain_files_returns_ssl_error(self):
+        error = self.manager.check_ssl_chain_files(
+            str(Path(testdir, "cases", "new.epub")),
+            str(Path(testdir, "cases", "old.epub")),
+        )
+        self.assertIsNotNone(error)
+
+    def test_missing_previous_files_are_removed_on_rollback(self):
+        os.unlink(self.crt_path)
+        os.unlink(self.key_path)
+        self.run_command.side_effect = [
+            subprocess.CalledProcessError(1, ["nginx", "-t"]),
+            subprocess.CompletedProcess([], 0),
+        ]
+
+        with self.assertRaises(NginxConfigError):
+            self.manager.install(self.crt, self.key)
+
+        self.assertFalse(self.crt_path.exists())
+        self.assertFalse(self.key_path.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/webserver/handlers/admin.py
+++ b/webserver/handlers/admin.py
@@ -7,9 +7,6 @@ import hashlib
 import logging
 import os
 import re
-import ssl
-import subprocess
-import tempfile
 import traceback
 import uuid
 
@@ -26,6 +23,14 @@ from webserver.services.autofill import AutoFillService
 from webserver.services.batch_convert import BatchConvertService
 from webserver.services.mail import MailService
 from webserver.services.opds_import import OPDSImportService
+from webserver.services.ssl_certificate import (
+    CertificateRollbackError,
+    CertificateSaveError,
+    CertificateValidationError,
+    NginxConfigError,
+    NginxReloadError,
+    SSLCertificateManager,
+)
 from webserver.services.update_checker import UpdateChecker
 
 
@@ -740,109 +745,37 @@ class AdminInstall(BaseHandler):
 
 
 class SSLHandlerLogic:
-    def check_ssl_chain(self, crt_body, key_body):
-        """return None if ok, else Err"""
-        import os
-
-        crt_fd = None
-        key_fd = None
-        crt_path = None
-        key_path = None
-        try:
-            crt_fd, crt_path = tempfile.mkstemp(suffix=".crt")
-            try:
-                key_fd, key_path = tempfile.mkstemp(suffix=".key")
-                with os.fdopen(crt_fd, "wb") as crt_file:
-                    crt_file.write(crt_body)
-                crt_fd = None  # fdopen 关闭后设为 None
-                with os.fdopen(key_fd, "wb") as key_file:
-                    key_file.write(key_body)
-                key_fd = None  # fdopen 关闭后设为 None
-                return self.check_ssl_chain_files(crt_path, key_path)
-            except:
-                # 如果 key_fd 创建失败，确保关闭 crt_fd
-                if crt_fd is not None:
-                    try:
-                        os.close(crt_fd)
-                    except OSError:
-                        pass
-                raise
-        finally:
-            # 确保关闭未关闭的文件描述符
-            if crt_fd is not None:
-                try:
-                    os.close(crt_fd)
-                except OSError:
-                    pass
-            if key_fd is not None:
-                try:
-                    os.close(key_fd)
-                except OSError:
-                    pass
-            if crt_path and os.path.exists(crt_path):
-                try:
-                    os.unlink(crt_path)
-                except OSError:
-                    pass
-            if key_path and os.path.exists(key_path):
-                try:
-                    os.unlink(key_path)
-                except OSError:
-                    pass
-
-    def check_ssl_chain_files(self, crt_file, key_file):
-        ctx = ssl.SSLContext()
-        try:
-            ctx.load_cert_chain(crt_file, key_file)
-        except ssl.SSLError as err:
-            return err
-        return None
-
-    def save_files(self, crt_body, key_body):
-        with open(CONF["ssl_crt_file"], "w+b") as f:
-            f.write(crt_body)
-
-        with open(CONF["ssl_key_file"], "w+b") as f:
-            f.write(key_body)
-
-    def nginx_check(self):
-        return subprocess.run(["nginx", "-t"], check=True)
-
-    def nginx_reload(self):
-        return subprocess.run(["service", "nginx", "reload"], check=True)
+    def __init__(self, manager=None):
+        self.manager = manager or SSLCertificateManager(CONF["ssl_crt_file"], CONF["ssl_key_file"])
 
     def run(self, ssl_crt, ssl_key):
-        err = self.check_ssl_chain(ssl_crt, ssl_key)
-        if err is not None:
-            return {"err": "params.ssl_error", "msg": _("证书或密钥校验失败: %s" % err)}
-
         try:
-            self.save_files(ssl_crt, ssl_key)
-        except Exception as err:
-            import traceback
-
-            logging.error(traceback.format_exc())
+            self.manager.install(ssl_crt, ssl_key)
+        except CertificateValidationError as err:
+            return {"err": "params.ssl_error", "msg": _("证书或密钥校验失败: %s" % err)}
+        except CertificateSaveError as err:
+            logging.exception("failed to save SSL certificate")
             return {
                 "err": "internal.ssl_save_error",
                 "msg": _("证书存储失败: %s" % err),
             }
-
-        # testing nginx config
-        try:
-            self.nginx_check()
-        except subprocess.CalledProcessError as err:
+        except NginxConfigError as err:
+            logging.exception("nginx rejected uploaded SSL certificate")
             return {
                 "err": "internal.nginx_test_error",
                 "msg": _("NGINX配置异常: %s") % err,
             }
-
-        # reload nginx config
-        try:
-            self.nginx_reload()
-        except subprocess.CalledProcessError as err:
+        except NginxReloadError as err:
+            logging.exception("nginx failed to reload uploaded SSL certificate")
             return {
                 "err": "internal.nginx_reload_error",
                 "msg": _("NGINX重新加载配置异常: %s") % err,
+            }
+        except CertificateRollbackError as err:
+            logging.exception("failed to rollback uploaded SSL certificate")
+            return {
+                "err": "internal.ssl_rollback_error",
+                "msg": _("证书更新失败且无法恢复旧证书: %s") % err,
             }
 
         return {"err": "ok"}

--- a/webserver/self_check.py
+++ b/webserver/self_check.py
@@ -87,7 +87,8 @@ def check_permission():
 
 
 def check_nginx_config():
-    return (True, None) if run(["nginx", "-t"]) else (False, "nginx_config_invalid")
+    cmd = ["gosu", "%s:%s" % (RUN_USER, RUN_USER), "nginx", "-t"]
+    return (True, None) if run(cmd) else (False, "nginx_config_invalid")
 
 
 def check_syncdb():

--- a/webserver/services/ssl_certificate.py
+++ b/webserver/services/ssl_certificate.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+
+import fcntl
+import os
+import ssl
+import stat
+import subprocess
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+
+
+class SSLCertificateError(Exception):
+    """Base error for a certificate installation."""
+
+
+class CertificateValidationError(SSLCertificateError):
+    """The uploaded certificate and private key are not a valid pair."""
+
+
+class CertificateSaveError(SSLCertificateError):
+    """The uploaded pair could not be stored."""
+
+
+class NginxConfigError(SSLCertificateError):
+    """Nginx rejected the candidate certificate configuration."""
+
+
+class NginxReloadError(SSLCertificateError):
+    """Nginx could not activate the candidate certificate."""
+
+
+class CertificateRollbackError(SSLCertificateError):
+    """The previous certificate pair could not be restored."""
+
+
+_MISSING = object()
+
+
+class SSLCertificateManager:
+    """Install a certificate pair and keep Nginx and disk state consistent."""
+
+    def __init__(self, crt_path, key_path, run_command=subprocess.run):
+        self.crt_path = Path(crt_path)
+        self.key_path = Path(key_path)
+        if self.crt_path.parent != self.key_path.parent:
+            raise ValueError("certificate and private key must use the same directory")
+        self.ssl_dir = self.crt_path.parent
+        self.lock_path = self.ssl_dir / ".ssl-update.lock"
+        self.run_command = run_command
+
+    def install(self, crt_body, key_body):
+        self._validate_uploaded_pair(crt_body, key_body)
+
+        try:
+            self.ssl_dir.mkdir(parents=True, exist_ok=True)
+            with self._install_lock():
+                previous = self._snapshot_previous()
+                self._install_candidate(crt_body, key_body, previous)
+                self._check_candidate(previous)
+                self._activate_candidate(previous)
+        except SSLCertificateError:
+            raise
+        except OSError as err:
+            raise CertificateSaveError(str(err)) from err
+
+    def check_ssl_chain_files(self, crt_file, key_file):
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        try:
+            context.load_cert_chain(crt_file, key_file)
+        except (OSError, ssl.SSLError) as err:
+            return err
+        return None
+
+    def nginx_check(self):
+        return self.run_command(["nginx", "-t"], check=True)
+
+    def nginx_reload(self):
+        return self.run_command(["nginx", "-s", "reload"], check=True)
+
+    def _validate_uploaded_pair(self, crt_body, key_body):
+        try:
+            self.ssl_dir.mkdir(parents=True, exist_ok=True)
+            crt_path = self._write_temporary(crt_body, 0o644, ".candidate-", ".crt")
+            try:
+                key_path = self._write_temporary(key_body, 0o600, ".candidate-", ".key")
+                try:
+                    error = self.check_ssl_chain_files(crt_path, key_path)
+                finally:
+                    self._unlink_if_exists(key_path)
+            finally:
+                self._unlink_if_exists(crt_path)
+        except OSError as err:
+            raise CertificateSaveError(str(err)) from err
+
+        if error is not None:
+            raise CertificateValidationError(str(error))
+
+    @contextmanager
+    def _install_lock(self):
+        with open(self.lock_path, "a+b") as lock_file:
+            os.fchmod(lock_file.fileno(), 0o600)
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+    def _snapshot_previous(self):
+        return {
+            self.crt_path: self._snapshot_file(self.crt_path),
+            self.key_path: self._snapshot_file(self.key_path),
+        }
+
+    def _snapshot_file(self, path):
+        try:
+            body = path.read_bytes()
+            mode = stat.S_IMODE(path.stat().st_mode)
+            return body, mode
+        except FileNotFoundError:
+            return _MISSING
+
+    def _install_candidate(self, crt_body, key_body, previous):
+        try:
+            self._atomic_write(self.crt_path, crt_body, 0o644)
+            self._atomic_write(self.key_path, key_body, 0o600)
+        except OSError as err:
+            try:
+                self._restore_previous(previous)
+            except OSError as rollback_err:
+                raise CertificateRollbackError(
+                    "certificate save failed (%s), and rollback failed (%s)" % (err, rollback_err)
+                ) from rollback_err
+            raise CertificateSaveError(str(err)) from err
+
+    def _check_candidate(self, previous):
+        try:
+            self.nginx_check()
+        except (OSError, subprocess.CalledProcessError) as err:
+            self._rollback(previous, original_error=err, reload_nginx=False)
+            raise NginxConfigError(str(err)) from err
+
+    def _activate_candidate(self, previous):
+        try:
+            self.nginx_reload()
+        except (OSError, subprocess.CalledProcessError) as err:
+            self._rollback(previous, original_error=err, reload_nginx=True)
+            raise NginxReloadError(str(err)) from err
+
+    def _rollback(self, previous, original_error, reload_nginx):
+        try:
+            self._restore_previous(previous)
+            self.nginx_check()
+            if reload_nginx:
+                self.nginx_reload()
+        except (OSError, subprocess.CalledProcessError) as rollback_err:
+            raise CertificateRollbackError(
+                "certificate update failed (%s), and rollback failed (%s)" % (original_error, rollback_err)
+            ) from rollback_err
+
+    def _restore_previous(self, previous):
+        for path, snapshot in previous.items():
+            if snapshot is _MISSING:
+                self._unlink_if_exists(path)
+                continue
+            body, mode = snapshot
+            self._atomic_write(path, body, mode)
+
+    def _atomic_write(self, path, body, mode):
+        temp_path = self._write_temporary(body, mode, ".install-", ".tmp")
+        try:
+            os.replace(temp_path, path)
+        finally:
+            self._unlink_if_exists(temp_path)
+
+    def _write_temporary(self, body, mode, prefix, suffix):
+        file_descriptor, path = tempfile.mkstemp(dir=self.ssl_dir, prefix=prefix, suffix=suffix)
+        try:
+            os.fchmod(file_descriptor, mode)
+            with os.fdopen(file_descriptor, "wb") as output:
+                output.write(body)
+                output.flush()
+                os.fsync(output.fileno())
+            return Path(path)
+        except Exception:
+            try:
+                os.close(file_descriptor)
+            except OSError:
+                pass
+            self._unlink_if_exists(path)
+            raise
+
+    @staticmethod
+    def _unlink_if_exists(path):
+        try:
+            os.unlink(path)
+        except FileNotFoundError:
+            pass


### PR DESCRIPTION
## 背景与目标

Issue #761 后续核查确认：默认 `PUID=1000` 运行时，Tornado 能写入证书，但无法向 root Nginx master 执行配置检查和 reload；旧实现又会在检查前覆盖正式证书，导致接口失败后候选证书残留，并在下次重启时意外生效。

本 PR 保留内置 SSL 上传功能，让默认非 root 运行身份可以完成证书热更新，同时把写盘、检查、reload 和失败恢复收敛为一次证书安装事务。

Relates to #761。

## 关键改动

- 通过 Supervisor 让 production、production-ssr 与 dev 的 Nginx master/worker 以动态映射后的 `talebook` 身份运行。
- 仅为 `/usr/sbin/nginx` 授予 `CAP_NET_BIND_SERVICE`，继续监听容器内 80/443；Supervisor 与一次性 bootstrap 保留 root。
- 在仓库维护完整的 `conf/nginx/nginx.conf`，Dockerfile 直接复制到镜像；不再使用 `sed` 修改基础镜像配置。
- 托管的主配置不设置 `user` 指令，使 Nginx worker 继承非 root master 身份；PID 固定为 `/run/talebook/nginx.pid`。
- 启动脚本准备并授权 PID、SSL、日志与 Nginx 临时目录。
- 新增 `SSLCertificateManager`：校验证书/私钥、事务锁、同目录临时文件、单文件原子替换、确定权限、`nginx -t`、`nginx -s reload` 和失败回滚。
- 启动自检改为使用实际 `talebook` 身份执行 `nginx -t`，避免 root 检查造成假阳性。
- 保留显式 `PUID=0` 兼容模式，并在启动日志中输出安全提示。
- 新增证书事务、异常映射、运行身份与 Docker/Nginx 配置契约测试。

## 实际验证

- `pytest tests/test_ssl_crt.py tests/test_self_check.py tests/test_runtime_identity_config.py -q`（Docker 测试镜像内）：`31 passed`。
- `make lint-py-fix`（Docker 测试镜像内）：通过，99 个后端文件无需调整。
- `make lint-py`（Docker 测试镜像内）：通过。
- `make pytest`（Docker 测试镜像内）：`696 passed, 2 skipped, 22 warnings`，无失败。
- 将仓库主配置挂载到基础镜像，在创建 `/run/talebook` 后执行 `nginx -t`：通过。
- `docker build --target production -t talebook:ssl-nginxconf-final-20260730 .`：通过。
- `docker build --target production-ssr -t talebook:ssl-nginxconf-ssr-final-20260730 .`：通过；首次下载 Debian 包时网络悬挂，终止后重试成功。
- production 与 production-ssr 容器均到达 `ready`；仓库配置和镜像内 `/etc/nginx/nginx.conf` 的 SHA-256 均为 `f2ffc8f9f7b06229bc1eb3e12207a7868e1364a9571a32b5b5bc50081f2c97b1`。
- production 容器：Supervisor 为 root，Nginx master/worker 与 Tornado 为 `talebook`；`getcap /usr/sbin/nginx` 为 `cap_net_bind_service=ep`；非 root `nginx -t` 与 reload 均成功。
- production-ssr 容器：Nginx、Tornado 与 Node 均为 `talebook`；非 root `nginx -t` 成功。
- `PUID=0` 独立容器：状态为 `ready`，日志包含兼容模式安全提示；同一证书安装服务完成检查、reload 与在线指纹切换。
- Chrome DevTools 实测管理后台 SSL 弹窗：匹配证书上传返回 `err: ok`，在线与磁盘 SHA-256 指纹立即切换；容器重启后指纹保持不变。
- Chrome DevTools 实测错误配对：页面显示证书与私钥不匹配，磁盘与在线证书均未变化。
- `make check-design`：62 份方案文档通过。
- `git diff --check`：通过。

## 风险与兼容性

- 对外端口、SSL API、证书路径和 PUID/PGID 映射保持不变，不涉及数据库迁移。
- 主 Nginx 配置现在由 Talebook 明确维护；基础镜像升级时不会再依赖某段文本仍能被 `sed` 命中，但需要在升级 Nginx 时主动评审主配置差异。
- 新镜像依赖 Nginx 二进制保留 `cap_net_bind_service` 文件能力；Dockerfile 在构建阶段用 `getcap` 设置并校验，真实 production/SSR 容器也已验证。
- `PUID=0` 仍保持兼容，但会让应用进程以 root 运行，因此只输出安全提示，不在本 PR 中禁止。
- 浏览器仍有既有 Vuetify i18n 缺失 key 告警，Nginx 仍有既有 `listen ... http2` 弃用告警；两者均不影响本次流程，未扩大范围处理。
- 本次未修改界面、布局或交互设计，因此未附视觉差异截图；已通过 Chrome 对现有管理员上传流程做真实渲染与交互验收。

## 方案

- [GitHub 文件](https://github.com/talebook/talebook/blob/3c2c29ec9d3eb9d7ac62f1a7e58d4c58df876660/design/docker/20260730-ssl-certificate-reload.active.html)
- [RawGitHack 在线预览](https://raw.githack.com/talebook/talebook/3c2c29ec9d3eb9d7ac62f1a7e58d4c58df876660/design/docker/20260730-ssl-certificate-reload.active.html)
