### PR TITLE
fix: 自动填充无法获取封面时不再放弃其余元数据更新

### DIFF
--- a/tests/test_autofill.py
+++ b/tests/test_autofill.py
@@ -63,12 +63,33 @@ class TestAutoFillKeepCover(TestWithUserLogin):
         self.assertEqual(mi.cover_data, ("jpg", b"wrong-cover"))
 
     @mock.patch.object(AutoFillService, "plugin_search_best_book_info")
-    def test_skips_update_when_no_cover_found_and_option_disabled(self, mock_search):
+    def test_updates_other_metadata_when_no_cover_found_and_option_disabled(self, mock_search):
+        # 无法获取封面时，不应放弃其余元数据（作者、简介等）的更新
         mi = self._make_mi("原书名", has_cover=False, cover_data=None)
         refer_mi = self._make_mi("错误的书名", has_cover=False, cover_data=None)
+        refer_mi.comments = "新简介"
+        refer_mi.authors = ["新作者"]
         mock_search.return_value = refer_mi
 
         with mock.patch.dict("webserver.services.autofill.CONF", {"auto_fill_keep_cover": False}):
             ok = self.service.do_fill_metadata(1, mi)
 
-        self.assertFalse(ok)
+        self.assertTrue(ok)
+        self.assertEqual(mi.comments, "新简介")
+        self.assertEqual(mi.authors, ["新作者"])
+        self.assertFalse(mi.has_cover and mi.cover_data and mi.cover_data[1])
+
+    @mock.patch.object(AutoFillService, "plugin_search_best_book_info")
+    def test_keeps_existing_cover_when_no_cover_found(self, mock_search):
+        # 书籍原本已有封面，抓取结果没有封面时，不应清空原有封面
+        mi = self._make_mi("原书名", has_cover=True, cover_data=("jpg", b"old-cover"))
+        refer_mi = self._make_mi("错误的书名", has_cover=False, cover_data=None)
+        refer_mi.comments = "新简介"
+        mock_search.return_value = refer_mi
+
+        with mock.patch.dict("webserver.services.autofill.CONF", {"auto_fill_keep_cover": False}):
+            ok = self.service.do_fill_metadata(1, mi)
+
+        self.assertTrue(ok)
+        self.assertEqual(mi.comments, "新简介")
+        self.assertEqual(mi.cover_data, ("jpg", b"old-cover"))

--- a/webserver/services/autofill.py
+++ b/webserver/services/autofill.py
@@ -110,11 +110,13 @@ class AutoFillService(AsyncService):
         keep_cover = CONF.get("auto_fill_keep_cover", False) and mi.has_cover
         refer_has_cover = bool(refer_mi.cover_data and refer_mi.cover_data[1])
 
-        if not keep_cover and not refer_has_cover:
-            logging.info(_("忽略更新书籍 id=%d : 无法获取封面"), book_id)
-            return False
+        if not refer_has_cover and not keep_cover:
+            # 未获取到封面时不应放弃其余元数据的更新，仅跳过封面字段
+            logging.warning(_("更新书籍 id=%d 的信息时无法获取封面，其余元数据将照常更新"), book_id)
 
-        if keep_cover:
+        if keep_cover or not refer_has_cover:
+            # smart_update(replace_metadata=True) 会无条件覆盖 cover_data，因此这里必须显式回填原封面，
+            # 否则封面会被清空为空值
             refer_mi.cover_data = mi.cover_data
 
         # 保留书名不修改（万一出 BUG，还能抢救一下）


### PR DESCRIPTION
## 背景

修复 #901：`do_fill_metadata` 在抓取到的参考元数据没有封面、且未开启 auto_fill_keep_cover 时，会直接 return False，导致作者/出版社/简介等其它有效信息也一并被丢弃。

## 改动

- webserver/services/autofill.py: 移除了无封面即放弃更新的提前 return，改为记录 warning 日志后继续更新其余元数据；同时显式回填书籍原有封面，避免 smart_update(replace_metadata=True) 无条件覆盖 cover_data 导致封面被清空。
- tests/test_autofill.py: 更新原有的"无封面则跳过更新"测试为验证其它字段正常更新，并新增一个书籍已有封面、抓取结果无封面时封面不被清空的用例。

## 测试

- make pytest: 710 passed, 1 skipped
- make lint-py-fix / make lint-py: 全部通过

## 方案豁免说明

本次改动是范围明确的单文件逻辑修复，不涉及 API、数据结构、配置项、权限或部署变化，按 CLAUDE.md 豁免条款视为小型缺陷修复，未创建 design 方案文档。

Generated with [Claude Code](https://claude.ai/code)