### PR TITLE
fix: 系统日志页支持级别筛选，行数调整后自动刷新

### DIFF
--- a/app/i18n/locales/en-US.json
+++ b/app/i18n/locales/en-US.json
@@ -939,11 +939,15 @@
       },
       "label": {
         "lines": "Show last N lines",
-        "file": "Log file"
+        "file": "Log file",
+        "showInfo": "Info",
+        "showWarning": "Warning",
+        "showError": "Error"
       },
       "message": {
         "noLogs": "No log content available",
-        "loadError": "Failed to load logs"
+        "loadError": "Failed to load logs",
+        "allFiltered": "No log lines match the current filter"
       }
     }
   },

--- a/app/i18n/locales/zh-CN.json
+++ b/app/i18n/locales/zh-CN.json
@@ -959,11 +959,15 @@
       },
       "label": {
         "lines": "显示最近行数",
-        "file": "日志文件"
+        "file": "日志文件",
+        "showInfo": "信息",
+        "showWarning": "警告",
+        "showError": "错误"
       },
       "message": {
         "noLogs": "暂无日志内容",
-        "loadError": "加载日志失败"
+        "loadError": "加载日志失败",
+        "allFiltered": "当前筛选条件下暂无日志内容"
       }
     }
   },

--- a/app/pages/admin/logs.vue
+++ b/app/pages/admin/logs.vue
@@ -4,7 +4,7 @@
         <v-card-title class="pl-4">
             {{ t('admin.logs.title') }}
         </v-card-title>
-        <v-card-actions class="px-4">
+        <v-card-actions class="px-4 flex-wrap">
             <v-select
                 v-model="lineCount"
                 :items="lineOptions"
@@ -13,6 +13,27 @@
                 hide-details
                 style="max-width: 160px"
                 class="mr-2"
+            />
+            <v-checkbox
+                v-model="showInfo"
+                :label="t('admin.logs.label.showInfo')"
+                density="compact"
+                hide-details
+                class="mr-2 flex-grow-0"
+            />
+            <v-checkbox
+                v-model="showWarning"
+                :label="t('admin.logs.label.showWarning')"
+                density="compact"
+                hide-details
+                class="mr-2 flex-grow-0"
+            />
+            <v-checkbox
+                v-model="showError"
+                :label="t('admin.logs.label.showError')"
+                density="compact"
+                hide-details
+                class="mr-2 flex-grow-0"
             />
             <v-spacer />
             <v-btn
@@ -51,12 +72,18 @@
                 {{ t('admin.logs.message.noLogs') }}
             </div>
             <div
+                v-else-if="!loading && filteredLines.length === 0"
+                class="text-medium-emphasis pa-2"
+            >
+                {{ t('admin.logs.message.allFiltered') }}
+            </div>
+            <div
                 v-else
                 ref="logContainer"
                 class="log-container"
             >
                 <div
-                    v-for="(entry, idx) in lines"
+                    v-for="(entry, idx) in filteredLines"
                     :key="idx"
                     :class="['log-line', entry.cls]"
                 >{{ entry.text }}</div>
@@ -66,7 +93,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted, nextTick } from 'vue';
+import { ref, computed, onMounted, nextTick, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useMainStore } from '@/stores/main';
 
@@ -82,16 +109,28 @@ const errorMsg = ref('');
 const lineCount = ref(500);
 const logContainer = ref(null);
 
+const showInfo = ref(true);
+const showWarning = ref(true);
+const showError = ref(true);
+
 const lineOptions = [100, 200, 500, 1000, 2000];
 
 const downloadUrl = '/api/admin/log/download';
 
-const levelClass = (line) => {
-    if (/\[E\]|\[ERROR\]|ERROR/.test(line)) return 'log-error';
-    if (/\[W\]|\[WARNING\]|WARNING/.test(line)) return 'log-warning';
-    if (/\[D\]|\[DEBUG\]|DEBUG/.test(line)) return 'log-debug';
-    return 'log-info';
+// tornado 的 LogFormatter 在行首输出单字母级别，如 "[E 260101 12:00:00 module:1] message"
+const levelInfo = (line) => {
+    const trimmed = line.trimStart();
+    if (trimmed.startsWith('[E ') || /ERROR/.test(line)) return { cls: 'log-error', group: 'error' };
+    if (trimmed.startsWith('[W ') || /WARNING/.test(line)) return { cls: 'log-warning', group: 'warning' };
+    if (trimmed.startsWith('[D ') || /DEBUG/.test(line)) return { cls: 'log-debug', group: 'info' };
+    return { cls: 'log-info', group: 'info' };
 };
+
+const filteredLines = computed(() => lines.value.filter((entry) => {
+    if (entry.group === 'error') return showError.value;
+    if (entry.group === 'warning') return showWarning.value;
+    return showInfo.value;
+}));
 
 const loadLogs = async () => {
     loading.value = true;
@@ -102,7 +141,7 @@ const loadLogs = async () => {
             errorMsg.value = rsp.msg || t('admin.logs.message.loadError');
             lines.value = [];
         } else {
-            lines.value = (rsp.lines || []).map(line => ({ text: line || ' ', cls: levelClass(line) }));
+            lines.value = (rsp.lines || []).map(line => ({ text: line || ' ', ...levelInfo(line) }));
             await nextTick();
             if (logContainer.value) {
                 logContainer.value.scrollTop = logContainer.value.scrollHeight;
@@ -115,6 +154,9 @@ const loadLogs = async () => {
         loading.value = false;
     }
 };
+
+// 调节显示行数后立即生效，无需再手动点击一次刷新按钮
+watch(lineCount, loadLogs);
 
 onMounted(loadLogs);
 </script>

--- a/app/test/e2e/admin-logs.spec.ts
+++ b/app/test/e2e/admin-logs.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Admin System Logs', () => {
+    test.beforeEach(async ({ request }) => {
+        await request.post('http://127.0.0.1:8080/_test/reset', {
+            data: { installed: true }
+        });
+    });
+
+    test('level filters toggle visibility of info/warning/error lines', async ({ page }) => {
+        await page.goto('/admin/logs');
+        await expect(page.locator('.loading-page')).toBeHidden();
+
+        const infoLine = page.getByText('mock info line');
+        const warningLine = page.getByText('mock warning line');
+        const errorLine = page.getByText('mock error line');
+
+        await expect(infoLine).toBeVisible();
+        await expect(warningLine).toBeVisible();
+        await expect(errorLine).toBeVisible();
+
+        // 取消勾选“错误”后，错误行应隐藏，其余不受影响
+        await page.getByLabel('错误').uncheck();
+        await expect(errorLine).toBeHidden();
+        await expect(infoLine).toBeVisible();
+        await expect(warningLine).toBeVisible();
+
+        // 取消勾选“警告”后，警告行也应隐藏
+        await page.getByLabel('警告').uncheck();
+        await expect(warningLine).toBeHidden();
+        await expect(infoLine).toBeVisible();
+
+        // 全部取消勾选后应显示筛选提示文案
+        await page.getByLabel('信息').uncheck();
+        await expect(page.getByText('当前筛选条件下暂无日志内容')).toBeVisible();
+    });
+
+    test('changing line count reloads logs without clicking refresh', async ({ page }) => {
+        await page.goto('/admin/logs');
+        await expect(page.locator('.loading-page')).toBeHidden();
+        await expect(page.getByText('mock error line')).toBeVisible();
+
+        const reloadPromise = page.waitForResponse(resp => resp.url().includes('/api/admin/log') && resp.url().includes('lines=100'));
+        await page.getByLabel('显示最近行数').click();
+        await page.getByRole('option', { name: '100' }).click();
+        await reloadPromise;
+
+        // 未点击“刷新”按钮，日志内容也应已按新的行数重新加载
+        await expect(page.getByText('mock error line')).toBeVisible();
+    });
+});

--- a/app/test/mock-server.js
+++ b/app/test/mock-server.js
@@ -225,6 +225,22 @@ router.post('/api/admin/testmail', eventHandler(() => ({
   msg: 'Test email sent'
 })));
 
+router.get('/api/admin/log', eventHandler((event) => {
+  const query = getQuery(event);
+  const lines = Number(query.lines) || 500;
+  const allLines = [
+    '[I 260101 12:00:00 admin:1] mock info line',
+    '[W 260101 12:00:01 admin:2] mock warning line',
+    '[E 260101 12:00:02 admin:3] mock error line'
+  ];
+  return {
+    err: 'ok',
+    lines: allLines.slice(0, lines),
+    total: allLines.length,
+    file: '/data/log/talebook.log'
+  };
+}));
+
 router.get('/api/admin/trash/size', eventHandler(() => ({
   err: 'ok',
   sizes: { trash: 0, upload: 0 },


### PR DESCRIPTION
## Summary
- Add info/warning/error visibility checkboxes to the system logs admin page, and fix the underlying level-detection regex which never matched Tornado's actual log format.
- Changing the line-count selector now reloads logs automatically instead of requiring an extra click on Refresh.
- Added mock /api/admin/log route and a Playwright e2e test.

Closes #894

## Test plan
- [x] `npm run lint` passes with no new errors
- [x] Verified level-detection logic against realistic Tornado log lines via standalone script
- [ ] `npx playwright test test/e2e/admin-logs.spec.ts` - could not run in sandbox, needs confirmation in CI/local env

Generated with [Claude Code](https://claude.ai/code)