### PR TITLE
fix: 搜索结果优先展示书名命中项

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -248,6 +248,17 @@ class TestAppWithoutLogin(TestApp):
         d = self.json("/api/search?name=A")
         self.assert_book_list(d, 6)
 
+    def test_search_prioritizes_title_matches(self):
+        # 书籍 3《安徒生童话》标题命中关键字；书籍 5、13 仅标签命中关键字（标题不含关键字）。
+        d = self.json("/api/search?name=" + Q("童话"))
+        self.assertEqual(d["err"], "ok")
+        ids = [book["id"] for book in d["books"]]
+        self.assertIn(3, ids)
+        self.assertIn(5, ids)
+        self.assertIn(13, ids)
+        self.assertLess(ids.index(3), ids.index(5))
+        self.assertLess(ids.index(3), ids.index(13))
+
     def test_hot(self):
         d = self.json("/api/hot")
         self.assert_book_list(d, 0)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -737,7 +737,8 @@ class TestRefer(TestWithUserLogin):
     @mock.patch("webserver.plugins.meta.calibre.CalibreMetadataApi.get_book_by_isbn")
     @mock.patch("webserver.plugins.meta.calibre.CalibreMetadataApi.get_book_by_title")
     @mock.patch("webserver.plugins.meta.tomato.TomatoNovelApi.get_book")
-    def test_refer(self, m_tomato, m_calibre_title, m_calibre_isbn, m7, m6, m5, m4, m3, m2, m1):
+    @mock.patch("webserver.plugins.meta.xhsd.XhsdBookApi.get_book")
+    def test_refer(self, m_xhsd, m_tomato, m_calibre_title, m_calibre_isbn, m7, m6, m5, m4, m3, m2, m1):
         from tests.test_baike import BAIKE_PAGE
         from tests.test_douban import DOUBAN_BOOK, DOUBAN_SEARCH
         from tests.test_youshu import YOUSHU_PAGE
@@ -754,6 +755,7 @@ class TestRefer(TestWithUserLogin):
         m_calibre_isbn.return_value = []
         m_calibre_title.return_value = []
         m_tomato.return_value = None
+        m_xhsd.return_value = None
 
         # with mock.patch("plugins.meta.baike.BaiduBaikeApi.get_book", return_value=self.fake_baidu) as m:
         # main.CONF["douban_baseurl"] = self.douban_url

--- a/webserver/handlers/book.py
+++ b/webserver/handlers/book.py
@@ -1060,7 +1060,21 @@ class SearchBook(ListHandler):
 
         title = _("搜索：%(name)s") % {"name": name}
         ids = self.cache.search(name)
+        ids = self.sort_ids_by_title_relevance(ids, name)
         return self.render_book_list([], ids=ids, title=title)
+
+    def sort_ids_by_title_relevance(self, ids, keyword):
+        """calibre 的 cache.search() 返回的是未排序的匹配集合，书名命中和简介、标签等其他字段
+        命中的结果混杂在一起。这里把书名命中的结果排到前面，同一优先级内按 id 从大到小排列。
+        """
+        keyword = (keyword or "").strip().lower()
+
+        def sort_key(book_id):
+            book_title = (self.cache.field_for("title", book_id) or "").lower()
+            title_matched = bool(keyword) and keyword in book_title
+            return (0 if title_matched else 1, -book_id)
+
+        return sorted(ids, key=sort_key)
 
 
 class HotBook(ListHandler):


### PR DESCRIPTION
## 背景

Issue #899 反馈：藏书较多时，搜索结果顺序杂乱，简介、标签等字段命中的书籍和书名命中的书籍混在一起，希望书名命中优先展示。

## 根因

`/api/search` (`SearchBook.get`) 直接使用 calibre `cache.search()` 返回的 book id 结果，而该方法官方文档明确说明返回的是未排序的匹配集合（returning a set of matched book ids），因此结果顺序本身就是任意的，并未按书名优先级排序。

## 改动

- `webserver/handlers/book.py`：新增 `SearchBook.sort_ids_by_title_relevance()`，对搜索命中的 id 按“书名是否包含关键字”排序，书名命中排在前面；同一优先级内按 id 从大到小排列，保持结果确定性。
- `tests/test_main.py`：新增 `test_search_prioritizes_title_matches`，使用测试书库中《安徒生童话》（书名命中“童话”）与另外两本仅标签命中“童话”的书籍验证排序结果。

## 测试结果

- `python3 -m pytest tests/test_main.py -k test_search -v`：2 passed
- `python3 -m pytest tests -v`：710 passed, 1 skipped
- `make lint-py-fix` + `make lint-py`：ruff 检查通过，无需改动

## 方案豁免说明

本次改动仅调整现有 `/api/search` 接口内部的结果排序逻辑，不新增接口、不涉及数据结构/权限/部署/配置变化、不跨模块，且无 UI 改动，按 CLAUDE.md 判定为可豁免创建内部方案的小型缺陷修复。

## 风险/兼容性

- 仅影响 `/api/search` 返回顺序，不改变返回字段结构，前端无需改动。
- 排序基于书名子串匹配（大小写不敏感），性能开销为对匹配结果集合做一次 field_for("title", id) 查询加排序，量级与搜索命中数量一致，可忽略不计。

Fixes #899

Generated with [Claude Code](https://claude.ai/code)