### PR TITLE
fix(app): 修复用户中心表格列宽压缩导致详情列逐字换行

### DIFF
--- a/app/pages/admin/users.vue
+++ b/app/pages/admin/users.vue
@@ -563,16 +563,16 @@ const guestPermissionList = computed(() => [
 ]);
 
 const headers = computed(() => [
-    { title: 'ID', key: 'id', sortable: true },
-    { title: t('admin.users.label.username'), key: 'username', sortable: true },
-    { title: t('admin.users.label.nickname'), key: 'name', sortable: false },
-    { title: 'Email', key: 'email', sortable: true },
-    { title: t('admin.users.label.registrationPlatform'), key: 'provider', sortable: false },
-    { title: t('admin.users.label.registrationTime'), key: 'create_time', sortable: true },
-    { title: t('admin.users.label.loginTime'), key: 'access_time', sortable: true },
-    { title: t('admin.users.label.loginIp'), key: 'login_ip', sortable: false },
-    { title: t('admin.users.label.detail'), key: 'detail', sortable: false },
-    { title: t('admin.users.label.action'), key: 'actions', sortable: false },
+    { title: 'ID', key: 'id', sortable: true, width: 70, nowrap: true },
+    { title: t('admin.users.label.username'), key: 'username', sortable: true, width: 120, nowrap: true },
+    { title: t('admin.users.label.nickname'), key: 'name', sortable: false, width: 100, nowrap: true },
+    { title: 'Email', key: 'email', sortable: true, width: 180, nowrap: true },
+    { title: t('admin.users.label.registrationPlatform'), key: 'provider', sortable: false, width: 100, nowrap: true },
+    { title: t('admin.users.label.registrationTime'), key: 'create_time', sortable: true, width: 175, nowrap: true },
+    { title: t('admin.users.label.loginTime'), key: 'access_time', sortable: true, width: 175, nowrap: true },
+    { title: t('admin.users.label.loginIp'), key: 'login_ip', sortable: false, width: 130, nowrap: true },
+    { title: t('admin.users.label.detail'), key: 'detail', sortable: false, width: 260 },
+    { title: t('admin.users.label.action'), key: 'actions', sortable: false, width: 110, nowrap: true },
 ]);
 
 const permissions = computed(() => [
@@ -817,5 +817,15 @@ useHead(() => ({
 
 :deep(.v-data-table-footer__items-per-page .v-field) {
     min-width: 100px;
+}
+
+/*
+ * 强制表格使用固定列宽布局。
+ * 默认的 table-layout: auto 会按内容自动分配列宽，而“详情”列内容不含空格，
+ * 浏览器可在任意字符间换行，导致该列在空间不足时被压缩到单字宽度，
+ * 其余内容被迫逐字换行、纵向堆叠。固定列宽后改为在 .v-table__wrapper 上出现横向滚动条。
+ */
+:deep(.v-table__wrapper > table) {
+    table-layout: fixed;
 }
 </style>

--- a/app/test/e2e/admin.spec.ts
+++ b/app/test/e2e/admin.spec.ts
@@ -49,6 +49,25 @@ test.describe('Admin Pages', () => {
         await expect(page.getByText('扫描书籍')).toBeVisible();
     });
 
+    test('Users table "detail" column keeps a reasonable width (regression for #917)', async ({ page }) => {
+        // 回归保护：详情列没有空格可换行的中文文案，若表格列宽未固定，
+        // 该列会被压缩到单字宽度，内容逐字换行纵向堆叠，撑爆整行高度。
+        await page.setViewportSize({ width: 1280, height: 800 });
+        const usersPromise = page.waitForResponse(resp => resp.url().includes('/api/admin/users'));
+        await page.goto('/admin/users');
+        await usersPromise;
+        await expect(page.locator('.loading-page')).toBeHidden();
+
+        const detailCell = page.locator('tbody tr').first().locator('td').filter({ hasText: '阅读了' });
+        await expect(detailCell).toBeVisible();
+        const box = await detailCell.boundingBox();
+        expect(box.width).toBeGreaterThan(100);
+
+        // 行高也应保持在合理范围内，而不是被压垮的单字列撑到几百像素
+        const rowBox = await page.locator('tbody tr').first().boundingBox();
+        expect(rowBox.height).toBeLessThan(200);
+    });
+
     test('Settings page interactions', async ({ page }) => {
         await page.setViewportSize({ width: 1280, height: 1024 });
         await page.goto('/admin/settings');

--- a/app/test/mock-server.js
+++ b/app/test/mock-server.js
@@ -262,7 +262,13 @@ app.use('/api/admin/users', eventHandler((event) => {
             is_active: true,
             access_time: '2023-01-01 12:00:00',
             create_time: '2023-01-01 12:00:00',
-            extra: { login_ip: '127.0.0.1' },
+            extra: {
+              login_ip: '127.0.0.1',
+              visit_history: Array(10).fill('mock-book-id'),
+              read_history: Array(1).fill('mock-book-id'),
+              download_history: Array(3).fill('mock-book-id'),
+              upload_history: Array(24).fill('mock-book-id')
+            },
             can_login: true,
             can_upload: true,
             can_read: true


### PR DESCRIPTION
## Summary
- 用户中心（/admin/users）表格的详情列内容是不含空格的中文文案，浏览器可在任意字符间换行；默认 table-layout: auto 下这是表格里唯一可压缩到最小的列，一旦整行内容宽度超出容器就会被挤压到单字宽度，导致文字逐字换行、纵向堆叠成一长条（见 issue #917 截图）。
- 为所有列显式设置 width（短字段如 ID/用户名/Email/时间/IP/操作额外加 nowrap，超出时省略号截断），并将表格设为 table-layout: fixed，空间不足时改为在 .v-table__wrapper 上出现横向滚动条。

## Test plan
- [x] npx eslint pages/admin/users.vue test/e2e/admin.spec.ts test/mock-server.js -- 通过（测试文件命中 ignore 规则，仅警告，无 error）
- [x] npx playwright test test/e2e/admin.spec.ts -- 4/4 通过，新增回归用例 Users table "detail" column keeps a reasonable width (regression for #917)；临时回退本次修复后重跑，确认该用例会失败（列宽 88px < 100px 断言），验证测试确实覆盖了本次 bug
- [x] npx playwright test（全量）-- 38 passed；另有 9 个失败用例（admin-themes / book-detail / sidebar / webdav-readme），均为本次未改动页面，且改动范围仅限 app/pages/admin/users.vue、app/test/e2e/admin.spec.ts、app/test/mock-server.js（git diff --stat 已确认），判断为环境中已存在的无关失败
- [x] npx vitest run test/components/ -- 37 tests passed；另有 2 个测试文件因 #build/i18n-options.mjs 缺失（未执行 nuxt prepare）无法加载，与本次改动无关

方案豁免说明：本次改动是纯前端表格列宽/布局的缺陷修复，不涉及新功能、API、数据结构、权限、部署或跨模块变更，且改动范围小、无架构复杂度，按仓库规范可豁免内部方案文档。

Fixes #917

Generated with [Claude Code](https://claude.ai/code)
