### PR TITLE
fix: 修复 Claude 代码评审工作流空转并补充评审结论标记

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -23,15 +23,19 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      # 评审本身用 OIDC 换取的 App token（自带 PR/issues 写权限），与此处无关；
+      # 这里的写权限是给最后一步用内置 GITHUB_TOKEN 打 reaction 用的。
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          fetch-depth: 1
+          # code-review skill 会读 git blame 与历史提交来判断改动上下文，
+          # 浅克隆会让这部分评审静默失效，因此拉取完整历史。
+          fetch-depth: 0
 
       - name: Run Claude Code Review
         id: claude-review
@@ -41,6 +45,55 @@ jobs:
           allowed_bots: 'codex-talebook[bot]'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # 传完整 PR URL，便于 skill 直接交给 gh pr view/diff 使用。
+          # slash command 后追加的正文会被一并送达（命令文件无 $ARGUMENTS 时参数自动追加，已实测）。
+          prompt: |
+            /code-review:code-review https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+
+            补充要求（优先级高于上面命令模板里的收尾格式）：
+            1. 未发现需要处理的问题时，不要发表任何评论，交由工作流打 reaction 标记即可。
+            2. 无论是否发表评论，最后都必须返回结构化结果，字段含义：
+               - reviewed：是否真正执行了评审。因 PR 已关闭、处于草稿状态或此前已评审过而跳过时为 false。
+               - issues_found：是否发表了列出问题的评审评论。
+               - summary：一句话结论。
+          # agent 模式不会注入任何默认工具（--permission-mode/--allowedTools 只在 tag 模式下设置），
+          # 不显式声明工具时 Claude 只能空转，既读不到 diff 也发不出评论。
+          # 下列工具对应 code-review skill 自身 frontmatter 的声明，外加 git 历史与子代理编排。
+          claude_args: |
+            --allowedTools "Read,Glob,Grep,Task,mcp__github_inline_comment__create_inline_comment,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*),Bash(gh pr comment:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(git log:*),Bash(git blame:*),Bash(git diff:*),Bash(git show:*)"
+            --json-schema '{"type":"object","properties":{"reviewed":{"type":"boolean"},"issues_found":{"type":"boolean"},"summary":{"type":"string"}},"required":["reviewed","issues_found"]}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
+
+      # reaction 由工作流按结构化结果判定，不依赖 Claude 自己记得去点：
+      # 输出为空  -> 评审没跑出结果，不打标记（红叉本身就是信号，避免误报“没问题”）
+      # reviewed=false -> 草稿/已关闭/已评审过，跳过
+      # issues_found -> true 打 👀，false 打 👍
+      - name: Mark review outcome on PR
+        if: steps.claude-review.outputs.structured_output != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OUTCOME: ${{ steps.claude-review.outputs.structured_output }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          reviewed=$(jq -r '.reviewed // false' <<<"$OUTCOME")
+          issues_found=$(jq -r '.issues_found // false' <<<"$OUTCOME")
+          echo "reviewed=$reviewed issues_found=$issues_found"
+
+          if [ "$reviewed" != "true" ]; then
+            echo "评审被跳过（草稿、已关闭或此前已评审），不打标记。"
+            exit 0
+          fi
+
+          if [ "$issues_found" = "true" ]; then
+            content="eyes"
+          else
+            content="+1"
+          fi
+
+          gh api --method POST \
+            "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/reactions" \
+            -f "content=${content}"
+          echo "已标记 reaction: ${content}"


### PR DESCRIPTION
## 背景与目标

Claude Code Review 工作流长期"绿色通过"但从不产出评审结论。以 [run 30791867322](https://github.com/talebook/talebook/actions/runs/30791867322/job/91616901633)（PR #930）为例，job 退出码为 0，但 SDK result 事件显示：

```json
{ "subtype": "success", "duration_ms": 15907, "num_turns": 4, "permission_denials_count": 0 }
```

`/code-review` skill 会拉起 1 个 Haiku 做资格检查、5 个并行 Sonnet 做评审、再逐条拉 Haiku 打分，不可能 4 轮 / 15.9 秒跑完。核对 PR #930 确认 `comments` 与 `reviews` 均为空。

目标：让评审真正执行并产出结论，同时让"评审通过"这件事本身可见。

## 根因

agent 模式下 claude-code-action **不注入任何默认工具**——`--permission-mode` 与 `--allowedTools` 仅在 tag 模式设置（`src/modes/tag/index.ts:175`）。原配置没有 `claude_args`，于是：

- Claude 没有 `Bash`，而 code-review skill 的 frontmatter 明确依赖 `Bash(gh pr view/diff/comment:*)`，其第 8 步要求"use the gh bash command to comment back"。既读不到 diff 也发不出评论。
- `parseAllowedTools` 返回空列表，导致 `install-mcp-server.ts:135-141` 的门槛不满足，inline comment MCP server 根本没被安装。

附带问题：`fetch-depth: 1` 使 skill 中依赖 git blame 与历史 PR 的两路评审静默失效；`actions/checkout@v4` 触发 Node 20 弃用告警。

> 排查中曾怀疑是工作流 `permissions` 为只读所致，经核对 `src/github/token.ts:69-72` 排除：OIDC 换取的 App token 默认携带 `contents/pull_requests/issues: write`，与工作流 `permissions` 块无关（该块只约束内置 `GITHUB_TOKEN`）。

## 关键改动

单文件 `.github/workflows/claude-code-review.yml` ，+58 / -5。

1. **补充 `--allowedTools`**（核心修复）：覆盖 skill frontmatter 声明的 7 个 `gh` 命令，外加 `git log/blame/diff/show`、`Task`、`Read/Glob/Grep`。
2. **`fetch-depth: 1` → `0`**：恢复依赖 git 历史的评审路径。
3. **`actions/checkout@v4` → `@v6`**：消除弃用告警，与 upstream 示例对齐。
4. **新增 `--json-schema` + reaction 标记步骤**：由工作流按结构化结论确定性地打 reaction，而非依赖 Claude 自己记得去点——后者在空转时同样不会执行，无法消除盲区。

| 状态 | 标记 |
|---|---|
| `structured_output` 为空（未跑出结果） | 不打标记 |
| `reviewed: false`（草稿/已关闭/已评审过） | 不打标记 |
| `reviewed: true, issues_found: false` | 👍 |
| `reviewed: true, issues_found: true` | 👀 |

"无 reaction"由此明确等价于"评审未正常执行"。

`permissions` 增加 `pull-requests/issues: write`，仅供新增步骤的内置 `GITHUB_TOKEN` 打 reaction 使用，评审步骤本身不受影响。

## 验证结果

已执行：

- `make check-design` → 通过，75 份方案。
- **slash command 参数行为实测**：该 command 文件无 `$ARGUMENTS` 占位符，曾怀疑 PR URL 被丢弃。建临时命令用 `claude -p` 实跑两次，URL 与追加的多行指令均完整送达，假设不成立，原 prompt 形式无误。
- **`claude_args` 过 upstream 双解析器**：`parseAllowedTools` 与 `parseSdkOptions` 均解析出 16 个工具且列表逐项一致（源码注释要求两者必须一致，否则触发 #1357 类缺陷）；`json-schema` 完整落入 extraArgs；inline-comment MCP 安装门槛满足。
- **reaction 分支逻辑干跑 4 种输入**（含字段缺失的畸形 JSON）：畸形输入保守跳过，不会误报 👍。

未执行：

- `make lint-py` / `make pytest` / `npm run lint` —— 本次仅改动 workflow YAML，未触及 Python 与前端代码，不适用。
- **端到端真实评审效果尚未验证**，原因见下。

无界面改动，故未附截图。

## 风险与兼容性

- **本 PR 自身很可能无法验证本改动。** action 在检测到 PR 含 workflow 变更时会走 `isWorkflowValidationError` 分支主动跳过（`src/github/token.ts:129-135`），日志提示"your workflow will begin working once you merge your PR"。因此真实效果需合并后由下一个 PR 确认。
- **来自 fork 的 PR 打不上 reaction**：`pull_request` 事件下 fork 的 `GITHUB_TOKEN` 强制只读，属 GitHub 机制限制。该步骤已设 `continue-on-error: true`，失败不影响 job 结论。
- `--json-schema` 与 slash command 组合为首次使用，若 Claude 未返回结构化输出，action 会告警且 `structured_output` 为空，此时不打任何 reaction，不会产生误导性标记。
- skill 模板内部存在矛盾（第 6 步"无高置信问题则不继续" vs 结尾提供的"No issues found"评论模板），已在 prompt 中显式约定无问题时不发评论，以消除该不确定性。

## 方案路径

豁免。经与维护者确认本次不创建 `design/` 方案文档，改动范围限于单个 CI 工作流配置，不涉及产品行为、API、数据结构或库表变更。
