### PR TITLE
fix(codex): 生成合规的 Issue PR 正文

### DIFF
--- a/.github/codex/prompts/comment-response.md
+++ b/.github/codex/prompts/comment-response.md
@@ -27,6 +27,7 @@
   "feature": "",
   "commit_message": "",
   "summary": "用于 GitHub 评论的简短中文答复。",
+  "pr_body": "",
   "tests": []
 }
 ```
@@ -39,6 +40,7 @@
   "feature": "short-english-kebab-case",
   "commit_message": "fix(scope): concise subject",
   "summary": "用于 GitHub 评论的简短中文摘要。",
+  "pr_body": "## 背景或目标\n说明为什么需要改动。\n\n## 关键改动\n- 说明评审者需要关注的改动。\n\n## 实际验证\n{{TEST_RESULTS}}\n\n## 风险与兼容性\n说明风险、兼容性或剩余限制。\n\n## 方案\n{{DESIGN_LINKS:design/module/yyyymmdd-feature.active.html}}\n\n## 视觉证据\n附截图 Markdown；不涉及界面或无法截图时写明原因。",
   "tests": [
     {
       "command": "本次实际运行的完整命令",
@@ -52,9 +54,14 @@
 契约规则：
 
 - `delivery` 只能是 `reply` 或 `publish`。请求已经完成且不需要仓库改动时使用 `reply`；需要发布真实仓库改动时使用 `publish`。
-- 使用 `reply` 时，`feature` 和 `commit_message` 必须为空字符串，`tests` 可以为空，并且工作树不能包含任何改动。`summary` 应直接回答维护者，不要附加伪造的测试或发布说明。
+- 使用 `reply` 时，`feature`、`commit_message` 和 `pr_body` 必须为空字符串，`tests` 可以为空，并且工作树不能包含任何改动。`summary` 应直接回答维护者，不要附加伪造的测试或发布说明。
 - 使用 `publish` 时，必须存在真实仓库改动；`feature` 必须是 3–48 个小写 ASCII 字符组成的 kebab-case。首次处理 Issue 时，选择一个稳定的英文功能名，以用于 `codex/issue-<id>-<feature>`。
 - 使用 `publish` 时，`commit_message` 必须是单行 Conventional Commit 消息，长度不得超过 120 个字符。
 - `summary` 必须是 1–1000 个字符的中文纯文本。
+- 使用 `publish` 时，`pr_body` 必须是完整的中文 Markdown PR 正文，并按示例包含六个二级标题。不要在正文中自行展开测试记录、构造 commit SHA、添加 `Closes` 语句或包裹 Codex 管理标记。
+- `pr_body` 中必须恰好包含一个 `{{TEST_RESULTS}}`。workflow 会用门禁验证过的 `tests` 替换它，确保 PR 展示的命令和结果与发布契约一致。
+- 需要方案时，`pr_body` 中必须恰好包含一个 `{{DESIGN_LINKS:design/<module>/<yyyymmdd-feature>.active.html}}`，路径指向本次有效的 ACTIVE 单文件 HTML 方案。workflow 会在提交后用完整 commit SHA 生成 GitHub 文件链接和 RawGitHack 预览链接。
+- 按仓库规范豁免方案时，用唯一的 `{{DESIGN_EXEMPTION}}` 代替方案链接占位符，并在占位符后紧接具体豁免原因。方案链接占位符与豁免占位符只能二选一。
+- `pr_body` 的“视觉证据”章节必须附带截图 Markdown；改动不涉及界面或受环境限制无法截图时，必须在该章节明确说明原因。
 - `tests` 中每条记录的 `result` 只能是 `passed`、`failed` 或 `not_run`；使用 `not_run` 时必须在 `details` 中写明中文原因。使用 `publish` 时至少包含一条本次实际验证记录，且不能存在 `failed` 结果。
 - 结果文件是 workflow 元数据，不是仓库交付内容，不得将其加入 Git。

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -653,12 +653,13 @@ jobs:
             reject "Codex 未生成 .codex-result.json。"
           elif ! jq -e '
             type == "object" and
-            (keys | sort) == ["commit_message", "delivery", "feature", "summary", "tests"] and
+            (keys | sort) == ["commit_message", "delivery", "feature", "pr_body", "summary", "tests"] and
             (.delivery == "reply" or .delivery == "publish") and
             (.feature | type == "string") and
             (.commit_message | type == "string") and
             (.summary | type == "string") and
             (.summary | length >= 1 and length <= 1000) and
+            (.pr_body | type == "string") and
             (.tests | type == "array") and
             ([.tests[] |
               type == "object" and
@@ -669,12 +670,37 @@ jobs:
             ] | all) and
             (if .delivery == "reply" then
               .feature == "" and
-              .commit_message == ""
+              .commit_message == "" and
+              .pr_body == ""
             else
               (.feature | length >= 3 and length <= 48 and test("^[a-z0-9]+(-[a-z0-9]+)*$")) and
               (.commit_message | length >= 1 and length <= 120 and (test("[\\r\\n]") | not)) and
               (.commit_message | test("^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\\([a-z0-9._/-]+\\))?!?: .+")) and
-              (.tests | length >= 1)
+              (.tests | length >= 1) and
+              (.pr_body as $body |
+                ($body | length >= 1 and length <= 50000) and
+                ([
+                  "## 背景或目标",
+                  "## 关键改动",
+                  "## 实际验证",
+                  "## 风险与兼容性",
+                  "## 方案",
+                  "## 视觉证据"
+                ] | all(. as $heading | $body | contains($heading))) and
+                ($body | contains("<!-- codex-pr-description:") | not) and
+                (($body | split("{{TEST_RESULTS") | length) == 2) and
+                (([$body | scan("\\{\\{TEST_RESULTS\\}\\}")] | length) == 1) and
+                (($body | split("{{DESIGN_") | length) == 2) and
+                (([$body | scan("\\{\\{DESIGN_LINKS:design/[a-z0-9]+(?:-[a-z0-9]+)*/[0-9]{8}-[a-z0-9]+(?:-[a-z0-9]+)*\\.active\\.html\\}\\}")] | length) as $design_link_count |
+                  ([$body | scan("\\{\\{DESIGN_EXEMPTION\\}\\}")] | length) as $design_exemption_count |
+                  (
+                    ($design_link_count == 1 and $design_exemption_count == 0) or
+                    ($design_link_count == 0 and
+                      $design_exemption_count == 1 and
+                      ($body | test("\\{\\{DESIGN_EXEMPTION\\}\\}[[:space:]]+[^[:space:]#]")))
+                  )
+                )
+              )
             end)
           ' "$RESULT_FILE" >/dev/null; then
             reject "Codex 结果不符合发布契约或 Conventional Commit 规则。"
@@ -683,6 +709,21 @@ jobs:
             delivery="$(jq -r '.delivery' "$RESULT_FILE")"
             feature="$(jq -r '.feature' "$RESULT_FILE")"
             commit_message="$(jq -r '.commit_message' "$RESULT_FILE")"
+          fi
+
+          design_path=""
+          if [ "$contract_valid" = "true" ] && [ "$delivery" = "publish" ]; then
+            design_path="$(jq -r '
+              try (
+                .pr_body
+                | capture("\\{\\{DESIGN_LINKS:(?<path>design/[a-z0-9]+(?:-[a-z0-9]+)*/[0-9]{8}-[a-z0-9]+(?:-[a-z0-9]+)*\\.active\\.html)\\}\\}")
+                | .path
+              ) catch ""
+            ' "$RESULT_FILE")"
+            if [ -n "$design_path" ] && [ ! -f "$design_path" ]; then
+              contract_valid=false
+              reject "方案文档不存在或不是文件：$design_path"
+            fi
           fi
 
           if [ -z "$reason" ] && [ "$delivery" = "publish" ] && jq -e '.tests | any(.result == "failed")' "$RESULT_FILE" >/dev/null; then
@@ -696,6 +737,11 @@ jobs:
 
           if [ -z "$reason" ] && ! git add -A; then
             reject "Git 无法暂存候选改动。"
+          fi
+
+          if [ -z "$reason" ] && [ -n "$design_path" ] && ! git cat-file -e ":$design_path" 2>/dev/null; then
+            contract_valid=false
+            reject "方案文档未包含在待发布提交中：$design_path"
           fi
 
           if [ -z "$reason" ] && [ "$delivery" = "publish" ]; then
@@ -839,18 +885,18 @@ jobs:
           echo "commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - id: create_issue_pr
-        name: Create Draft PR for issue work
+        name: Create or update Draft PR for issue work
         if: |
           steps.publish_gate.outputs.delivery == 'publish' &&
           steps.app_token.outcome == 'success' &&
           steps.context.outputs.is_pr != 'true' &&
-          steps.context.outputs.existing_issue_pr_number == '' &&
           (
             steps.publish.outcome == 'success' ||
             (
               steps.publish_gate.outputs.contract_valid == 'true' &&
               steps.publish_gate.outputs.no_changes == 'true' &&
-              steps.context.outputs.existing_issue_branch != ''
+              steps.context.outputs.existing_issue_branch != '' &&
+              steps.context.outputs.existing_issue_pr_number == ''
             )
           )
         uses: actions/github-script@v7
@@ -859,21 +905,122 @@ jobs:
           ISSUE_TITLE: ${{ steps.context.outputs.issue_title }}
           DEFAULT_BRANCH: ${{ steps.context.outputs.default_branch }}
           PUBLISH_BRANCH: ${{ steps.publish_gate.outputs.publish_branch }}
+          COMMIT_SHA: ${{ steps.publish.outputs.commit_sha || steps.context.outputs.target_sha }}
+          EXISTING_PR_NUMBER: ${{ steps.context.outputs.existing_issue_pr_number }}
+          RESULT_FILE: .codex-result.json
         with:
           github-token: ${{ steps.app_token.outputs.token }}
           script: |
-            const title = `codex: ${process.env.ISSUE_TITLE}`.slice(0, 256);
-            const result = await github.rest.pulls.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title,
-              head: process.env.PUBLISH_BRANCH,
-              base: process.env.DEFAULT_BRANCH,
-              body: `Issue #${process.env.ISSUE_NUMBER} 的自动实现。\n\nCloses #${process.env.ISSUE_NUMBER}`,
-              draft: true,
+            const fs = require("fs");
+
+            const escapeHtml = (value) => String(value)
+              .replaceAll("&", "&amp;")
+              .replaceAll("<", "&lt;")
+              .replaceAll(">", "&gt;");
+            const managedStart = "<!-- codex-pr-description:start -->";
+            const managedEnd = "<!-- codex-pr-description:end -->";
+            const mergeManagedBody = (existingBody, managedBody) => {
+              const existing = String(existingBody || "");
+              const startCount = existing.split(managedStart).length - 1;
+              const endCount = existing.split(managedEnd).length - 1;
+              if (startCount === 0 && endCount === 0) {
+                return existing.trim() ? `${existing.trim()}\n\n${managedBody}` : managedBody;
+              }
+              const startIndex = existing.indexOf(managedStart);
+              const endIndex = existing.indexOf(managedEnd);
+              if (startCount !== 1 || endCount !== 1 || endIndex <= startIndex) {
+                throw new Error("The existing PR body does not contain one valid managed description boundary pair.");
+              }
+              const before = existing.slice(0, startIndex).trimEnd();
+              const after = existing.slice(endIndex + managedEnd.length).trimStart();
+              return [before, managedBody, after].filter(Boolean).join("\n\n");
+            };
+
+            const result = JSON.parse(fs.readFileSync(process.env.RESULT_FILE, "utf8"));
+            const commitSha = String(process.env.COMMIT_SHA || "");
+            if (!/^[0-9a-f]{40}$/.test(commitSha)) {
+              throw new Error("The controlled publisher did not provide a full commit SHA for the PR body.");
+            }
+            const issueNumber = Number(process.env.ISSUE_NUMBER);
+            if (!Number.isSafeInteger(issueNumber) || issueNumber <= 0) {
+              throw new Error("The issue number is invalid.");
+            }
+
+            const testLines = result.tests.map((test) => {
+              let line = `- <code>${escapeHtml(test.command)}</code> — <strong>${escapeHtml(test.result)}</strong>`;
+              if (typeof test.details === "string" && test.details.trim()) {
+                line += ` — ${escapeHtml(test.details.trim())}`;
+              }
+              return line;
             });
-            core.setOutput("pull_request_number", String(result.data.number));
-            core.setOutput("pull_request_url", result.data.html_url);
+            let renderedBody = result.pr_body.replace("{{TEST_RESULTS}}", testLines.join("\n"));
+            const designMatch = renderedBody.match(
+              /\{\{DESIGN_LINKS:(design\/[a-z0-9]+(?:-[a-z0-9]+)*\/[0-9]{8}-[a-z0-9]+(?:-[a-z0-9]+)*\.active\.html)\}\}/,
+            );
+            if (designMatch) {
+              const designPath = designMatch[1];
+              const encodedPath = designPath.split("/").map(encodeURIComponent).join("/");
+              const githubUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/blob/${commitSha}/${encodedPath}`;
+              const previewUrl = `https://raw.githack.com/${context.repo.owner}/${context.repo.repo}/${commitSha}/${encodedPath}`;
+              renderedBody = renderedBody.replace(
+                designMatch[0],
+                `- [GitHub 方案文件](${githubUrl})\n- [RawGitHack 在线预览](${previewUrl})`,
+              );
+            } else {
+              renderedBody = renderedBody.replace("{{DESIGN_EXEMPTION}}", "");
+            }
+
+            const managedBody = [
+              managedStart,
+              renderedBody.trim(),
+              `Closes #${process.env.ISSUE_NUMBER}`,
+              managedEnd,
+            ].join("\n\n");
+            if (managedBody.length > 65536) {
+              throw new Error("The rendered PR body exceeds GitHub's maximum issue body length.");
+            }
+
+            const existingPrNumber = process.env.EXISTING_PR_NUMBER
+              ? Number(process.env.EXISTING_PR_NUMBER)
+              : 0;
+            let pullRequest;
+            let action;
+            if (existingPrNumber) {
+              if (!Number.isSafeInteger(existingPrNumber) || existingPrNumber <= 0) {
+                throw new Error("The existing PR number is invalid.");
+              }
+              const existingPr = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: existingPrNumber,
+              });
+              const body = mergeManagedBody(existingPr.data.body, managedBody);
+              if (body.length > 65536) {
+                throw new Error("The merged PR body exceeds GitHub's maximum issue body length.");
+              }
+              pullRequest = await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: existingPrNumber,
+                body,
+              });
+              action = "updated";
+            } else {
+              const title = `codex: ${process.env.ISSUE_TITLE}`.slice(0, 256);
+              pullRequest = await github.rest.pulls.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                head: process.env.PUBLISH_BRANCH,
+                base: process.env.DEFAULT_BRANCH,
+                body: managedBody,
+                draft: true,
+              });
+              action = "created";
+            }
+            core.setOutput("pull_request_number", String(pullRequest.data.number));
+            core.setOutput("pull_request_url", pullRequest.data.html_url);
+            core.setOutput("pull_request_action", action);
 
       - id: diff
         name: Capture Codex patch
@@ -927,6 +1074,7 @@ jobs:
           EXISTING_PR_NUMBER: ${{ steps.context.outputs.existing_issue_pr_number }}
           CREATED_PR_OUTCOME: ${{ steps.create_issue_pr.outcome }}
           CREATED_PR_URL: ${{ steps.create_issue_pr.outputs.pull_request_url }}
+          ISSUE_PR_ACTION: ${{ steps.create_issue_pr.outputs.pull_request_action }}
           CODEX_HAS_PATCH: ${{ steps.diff.outputs.has_patch }}
           CODEX_ARTIFACT_NAME: codex-patch-${{ github.run_id }}
           ISSUE_NUMBER: ${{ steps.context.outputs.issue_number }}
@@ -1022,12 +1170,12 @@ jobs:
 
               if (process.env.IS_PR !== "true") {
                 if (process.env.CREATED_PR_URL) {
-                  body += ` 已创建 Draft PR：${process.env.CREATED_PR_URL}`;
-                } else if (process.env.EXISTING_PR_NUMBER) {
-                  const prUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/pull/${process.env.EXISTING_PR_NUMBER}`;
-                  body += ` 已更新现有 Draft PR：${prUrl}`;
+                  const verb = process.env.ISSUE_PR_ACTION === "updated" ? "已更新" : "已创建";
+                  body += ` ${verb} Draft PR：${process.env.CREATED_PR_URL}`;
                 } else if (process.env.CREATED_PR_OUTCOME !== "success") {
-                  body += " 分支已推送，但 Draft PR 创建失败；请查看 workflow 日志。";
+                  body += process.env.EXISTING_PR_NUMBER
+                    ? " 提交已推送，但 Draft PR 正文更新失败；请查看 workflow 日志。"
+                    : " 分支已推送，但 Draft PR 创建失败；请查看 workflow 日志。";
                 }
               }
             } else if (process.env.CODEX_DELIVERY === "publish" && process.env.CODEX_NO_CHANGES === "true") {
@@ -1131,7 +1279,7 @@ jobs:
           if [ "$PUBLISH_OUTCOME" != "success" ]; then
             exit 1
           fi
-          if [ "$IS_PR" != "true" ] && [ -z "$EXISTING_PR_NUMBER" ] && [ "$CREATED_PR_OUTCOME" != "success" ]; then
+          if [ "$IS_PR" != "true" ] && [ "$CREATED_PR_OUTCOME" != "success" ]; then
             exit 1
           fi
 

--- a/design/project/20260803-codex-pr-description.active.html
+++ b/design/project/20260803-codex-pr-description.active.html
@@ -1,0 +1,487 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Codex PR 正文受控发布方案（已验证）</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --blueprint: #eaf3f8;
+      --paper: #f9fcfd;
+      --ink: #173044;
+      --muted: #5d7180;
+      --line: #aac3d1;
+      --cobalt: #145b86;
+      --cobalt-deep: #0c3d5c;
+      --cyan: #73bfd3;
+      --amber: #e6a53a;
+      --amber-soft: #fff2cf;
+      --green: #26715d;
+      --red: #a44742;
+      --code: #102b3c;
+      --code-ink: #d8eef6;
+    }
+
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body {
+      max-width: 1160px;
+      margin: 0 auto;
+      padding: 28px 24px 76px;
+      color: var(--ink);
+      background:
+        linear-gradient(rgba(20, 91, 134, .055) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(20, 91, 134, .055) 1px, transparent 1px),
+        var(--blueprint);
+      background-size: 28px 28px;
+      font: 16px/1.7 "PingFang SC", "Microsoft YaHei", system-ui, sans-serif;
+    }
+
+    h1, h2, h3, .eyebrow, .meta, th, .tag, .stage, .seal {
+      font-family: "Avenir Next Condensed", "Arial Narrow", "PingFang SC", sans-serif;
+    }
+    h1 {
+      max-width: 900px;
+      margin: 0;
+      font-size: clamp(42px, 7vw, 78px);
+      line-height: .96;
+      letter-spacing: -.045em;
+    }
+    h2 {
+      margin: 56px 0 17px;
+      font-size: clamp(28px, 4vw, 42px);
+      line-height: 1.08;
+      letter-spacing: -.025em;
+    }
+    h3 { margin: 0 0 9px; font-size: 20px; line-height: 1.25; }
+    p { margin: 10px 0; }
+    a { color: var(--cobalt); }
+    code {
+      padding: 2px 6px;
+      color: #12354a;
+      border: 1px solid #c0d3de;
+      border-radius: 4px;
+      background: #edf5f8;
+      font: .88em/1.5 "SFMono-Regular", Consolas, monospace;
+      overflow-wrap: anywhere;
+    }
+
+    header {
+      position: relative;
+      overflow: hidden;
+      padding: clamp(34px, 6vw, 68px);
+      color: #f4fbff;
+      background: var(--cobalt-deep);
+      border: 1px solid #082c43;
+      box-shadow: 0 22px 58px rgba(12, 61, 92, .22);
+    }
+    header::before {
+      position: absolute;
+      inset: 0 0 auto;
+      height: 9px;
+      content: "";
+      background: repeating-linear-gradient(90deg, var(--amber) 0 42px, #f7c76f 42px 48px);
+    }
+    header::after {
+      position: absolute;
+      right: -60px;
+      bottom: -80px;
+      width: 310px;
+      height: 310px;
+      content: "";
+      border: 34px solid rgba(115, 191, 211, .13);
+      border-radius: 50%;
+    }
+    .eyebrow {
+      position: relative;
+      z-index: 1;
+      margin-bottom: 17px;
+      color: #a9deeb;
+      font: 800 13px/1.2 "SFMono-Regular", Consolas, monospace;
+      letter-spacing: .14em;
+      text-transform: uppercase;
+    }
+    .thesis {
+      position: relative;
+      z-index: 1;
+      max-width: 780px;
+      margin-top: 22px;
+      color: #cfe6ef;
+      font-size: 18px;
+    }
+    .meta {
+      position: relative;
+      z-index: 1;
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 1px;
+      margin-top: 30px;
+      border: 1px solid rgba(255, 255, 255, .18);
+      background: rgba(255, 255, 255, .18);
+    }
+    .meta div { min-height: 76px; padding: 12px 14px; background: rgba(8, 43, 64, .93); }
+    .meta span { display: block; color: #8fb5c8; font-size: 11px; letter-spacing: .1em; }
+    .meta strong { display: block; margin-top: 5px; color: #fff; font-size: 15px; line-height: 1.35; }
+    .meta .status { color: #ffd88e; }
+
+    main { display: block; }
+    section {
+      margin-top: 18px;
+      padding: clamp(24px, 4vw, 42px);
+      background: rgba(249, 252, 253, .96);
+      border: 1px solid var(--line);
+      box-shadow: 0 9px 28px rgba(23, 48, 68, .06);
+    }
+    .lead {
+      padding: 18px 21px;
+      border-left: 6px solid var(--cobalt);
+      background: #fff;
+    }
+    .evidence {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 13px;
+      margin-top: 20px;
+    }
+    .evidence article, .decision, .test-item {
+      padding: 19px 20px;
+      border: 1px solid #bfd1db;
+      background: #fff;
+    }
+    .evidence strong { display: block; margin-bottom: 7px; color: var(--cobalt); }
+    .quote {
+      margin-top: 18px;
+      padding: 18px 21px;
+      color: var(--code-ink);
+      background: var(--code);
+      border-left: 6px solid var(--amber);
+      font-family: "SFMono-Regular", Consolas, monospace;
+      white-space: pre-wrap;
+    }
+
+    .manifest {
+      display: grid;
+      grid-template-columns: 1fr 88px 1.18fr;
+      align-items: stretch;
+      margin-top: 25px;
+      border: 1px solid var(--line);
+      background: var(--line);
+      gap: 1px;
+    }
+    .manifest > div { min-width: 0; padding: 25px; background: #fff; }
+    .manifest .seal {
+      display: grid;
+      place-items: center;
+      padding: 10px;
+      color: #fff;
+      background: var(--amber);
+      font-weight: 900;
+      letter-spacing: .11em;
+      text-align: center;
+      writing-mode: vertical-rl;
+    }
+    .manifest ul, .plain-list { margin: 13px 0 0; padding-left: 20px; }
+    .manifest li, .plain-list li { margin: 6px 0; }
+    .tag {
+      display: inline-block;
+      padding: 4px 8px;
+      color: var(--cobalt-deep);
+      border: 1px solid #9ebdcd;
+      background: #dff0f5;
+      font-size: 12px;
+      font-weight: 800;
+      letter-spacing: .06em;
+    }
+
+    .flow {
+      display: grid;
+      grid-template-columns: repeat(5, 1fr);
+      gap: 10px;
+      margin-top: 24px;
+    }
+    .stage {
+      position: relative;
+      min-height: 164px;
+      padding: 18px 17px;
+      color: #fff;
+      background: var(--cobalt);
+    }
+    .stage::after {
+      position: absolute;
+      top: 50%;
+      right: -10px;
+      z-index: 2;
+      width: 20px;
+      height: 2px;
+      content: "";
+      background: var(--amber);
+    }
+    .stage:last-child { background: var(--green); }
+    .stage:last-child::after { display: none; }
+    .stage small { display: block; margin-bottom: 21px; color: #bfe3ed; letter-spacing: .11em; }
+    .stage strong { display: block; font-size: 18px; line-height: 1.18; }
+    .stage span { display: block; margin-top: 10px; color: #d8edf3; font-family: "PingFang SC", sans-serif; font-size: 13px; line-height: 1.55; }
+
+    .decisions {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 12px;
+      margin-top: 20px;
+    }
+    .decision { border-top: 5px solid var(--cobalt); }
+    .decision.pending { border-top-color: var(--amber); background: var(--amber-soft); }
+    .decision.no { border-top-color: var(--red); }
+    .decision p { color: var(--muted); }
+
+    .contract {
+      overflow-x: auto;
+      margin-top: 22px;
+      padding: 20px 22px;
+      color: var(--code-ink);
+      background: var(--code);
+      border-left: 7px solid var(--cyan);
+    }
+    pre { margin: 0; font: 13px/1.62 "SFMono-Regular", Consolas, monospace; }
+
+    table { width: 100%; margin-top: 20px; border-collapse: collapse; }
+    th, td { padding: 13px 14px; border-bottom: 1px solid #c8d8e1; text-align: left; vertical-align: top; }
+    th { color: #fff; background: var(--cobalt); font-size: 13px; letter-spacing: .05em; }
+    td:first-child { width: 23%; font-weight: 700; }
+    td:nth-child(2) { width: 43%; }
+
+    .tests {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 12px;
+      margin-top: 20px;
+    }
+    .test-item { position: relative; padding-left: 48px; }
+    .test-item::before {
+      position: absolute;
+      top: 19px;
+      left: 17px;
+      content: "○";
+      color: var(--amber);
+      font-size: 22px;
+      font-weight: 900;
+    }
+    .test-item.pass::before { content: "✓"; color: var(--green); }
+    .test-item.limited::before { content: "△"; color: var(--amber); }
+    .test-item strong { display: block; }
+    .test-item span { color: var(--muted); font-size: 14px; }
+    .warning {
+      margin-top: 20px;
+      padding: 18px 20px;
+      color: #60410d;
+      border: 1px solid #e5bd72;
+      background: var(--amber-soft);
+    }
+    footer { padding: 28px 4px 0; color: var(--muted); font-size: 13px; }
+    :focus-visible { outline: 3px solid var(--amber); outline-offset: 3px; }
+
+    @media (max-width: 880px) {
+      .meta, .flow { grid-template-columns: 1fr 1fr; }
+      .stage:last-child { grid-column: 1 / -1; }
+      .stage::after { display: none; }
+      .manifest { grid-template-columns: 1fr; }
+      .manifest .seal { min-height: 46px; writing-mode: horizontal-tb; }
+    }
+    @media (max-width: 640px) {
+      body { padding: 14px 12px 48px; }
+      header, section { padding: 24px 20px; }
+      .meta, .evidence, .decisions, .tests, .flow { grid-template-columns: 1fr; }
+      .stage:last-child { grid-column: auto; }
+      table, thead, tbody, tr, th, td { display: block; }
+      thead { display: none; }
+      tr { padding: 12px 0; border-bottom: 1px solid #c8d8e1; }
+      td { width: auto !important; padding: 5px 0; border: 0; }
+      td::before { display: block; color: var(--muted); font-size: 11px; font-weight: 800; content: attr(data-label); }
+    }
+    @media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="eyebrow">Controlled publishing manifest · Issue automation</div>
+    <h1>让 PR 正文<br>经过同一道门禁</h1>
+    <p class="thesis">Codex 负责提交可校验的事实，workflow 在提交完成后用不可变 SHA 封印方案链接，再创建或更新 PR 的受控说明区。实现、验证和评审上下文不再在最后一跳丢失。</p>
+    <div class="meta">
+      <div><span>状态</span><strong class="status">ACTIVE · 已验证</strong></div>
+      <div><span>创建日期</span><strong>2026-08-03</strong></div>
+      <div><span>所属模块</span><strong>project</strong></div>
+      <div><span>需求来源</span><strong>维护者反馈 · PR #932</strong></div>
+    </div>
+  </header>
+
+  <main>
+    <h2>01 / 原始诉求与已确认事实</h2>
+    <section>
+      <div class="lead"><strong>原始诉求：</strong>修复 Codex 处理 Issue 后创建的 PR 没有遵守 <code>AGENTS.md</code> 的问题，使 PR 正文提供详细说明和 ACTIVE 方案的 GitHub、RawGitHack 固定链接。</div>
+      <div class="evidence">
+        <article>
+          <strong>规则当时已经生效</strong>
+          <p>PR #932 的基线已要求正文包含背景、关键改动、真实验证、风险或兼容性、方案路径或豁免原因；界面改动还需截图或说明无法截图的原因。</p>
+        </article>
+        <article>
+          <strong>实现阶段没有完全失守</strong>
+          <p>同一提交包含 ACTIVE 方案、组件测试和 E2E 测试，证明 Codex 已读取仓库要求；信息是在发布交接阶段丢失。</p>
+        </article>
+        <article>
+          <strong>workflow 硬编码正文</strong>
+          <p><code>create_issue_pr</code> 无条件写入“Issue 的自动实现 + Closes”，没有消费结构化摘要、测试、风险或方案路径。</p>
+        </article>
+        <article>
+          <strong>完整 SHA 只能后置生成</strong>
+          <p>Codex 被禁止自行 commit、push 或调用 GitHub API；只有受控发布步骤完成提交后，workflow 才知道可用于固定链接的最终 SHA。</p>
+        </article>
+      </div>
+      <div class="quote">当前结果：Codex 产出方案与验证 → workflow 只保留两行固定模板
+目标结果：Codex 产出完整 Markdown 模板 → workflow 校验占位符 → commit SHA 封印 → PR 正文</div>
+    </section>
+
+    <h2>02 / 目标、边界与验收口径</h2>
+    <section>
+      <div class="manifest">
+        <div>
+          <span class="tag">MODEL-SIDE</span>
+          <h3>Codex 直接提交完整正文模板</h3>
+          <ul>
+            <li>用 Markdown 自由组织背景、改动、风险和视觉证据。</li>
+            <li>在实际验证位置放置唯一的 <code>{{TEST_RESULTS}}</code>。</li>
+            <li>在方案位置放置路径占位符或方案豁免占位符。</li>
+            <li>不预先猜测 commit SHA，也不重复书写测试事实。</li>
+          </ul>
+        </div>
+        <div class="seal">COMMIT SHA 封条</div>
+        <div>
+          <span class="tag">WORKFLOW-SIDE</span>
+          <h3>受控发布器只注入远端事实</h3>
+          <ul>
+            <li>校验正文长度、必备章节和受控占位符。</li>
+            <li>把门禁确认过的 <code>tests</code> 渲染进正文。</li>
+            <li>用发布后的完整 SHA 生成 GitHub blob 与 RawGitHack 链接。</li>
+            <li>追加 <code>Closes #N</code>，再创建或更新 PR 受控区。</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="decisions">
+        <article class="decision">
+          <h3>目标：PR 正文可直接评审</h3>
+          <p>评审者不打开 workflow 日志，也能看到改动动机、范围、验证、风险、方案与视觉证据边界。</p>
+        </article>
+        <article class="decision">
+          <h3>目标：首次创建与后续提交一致</h3>
+          <p>首次 Issue 实现创建正文；已有 Codex PR 的后续发布同步更新正文和方案 SHA 链接。</p>
+        </article>
+        <article class="decision no">
+          <h3>非目标：允许模型直接操作 GitHub</h3>
+          <p>继续禁止 Codex commit、push、调用 <code>gh</code> 或 GitHub API；发布凭据和最终远端状态只由 workflow 掌握。</p>
+        </article>
+        <article class="decision no">
+          <h3>非目标：新增截图托管服务</h3>
+          <p>本次不引入图片上传或第三方托管。Codex 提供已有安全 URL；没有可发布截图时必须写明原因，正文不得静默省略视觉证据。</p>
+        </article>
+        <article class="decision">
+          <h3>已确认：维护者内容保护</h3>
+          <p>使用 HTML 注释标记 Codex 受控区。后续运行只替换这一段；无标记的现有正文在末尾追加受控区，避免覆盖人工编辑。</p>
+        </article>
+        <article class="decision">
+          <h3>已确认：严格门禁</h3>
+          <p>publish 模式缺少 <code>pr_body</code>、必备章节或占位符时拒绝发布，而不是退回两行模板；reply 模式使用空字符串。</p>
+        </article>
+      </div>
+    </section>
+
+    <h2>03 / 正文模板契约</h2>
+    <section>
+      <p>在现有 <code>.codex-result.json</code> 中只增加一个 <code>pr_body</code> 字符串。publish 模式由 Codex 直接写完整 Markdown；reply 模式必须为空字符串。workflow 不重组文案，只替换两个受控占位符并追加关闭语句。</p>
+      <div class="contract"><pre>{
+  "delivery": "publish",
+  "feature": "codex-pr-description",
+  "commit_message": "fix(codex): publish compliant PR descriptions",
+  "summary": "用于 Issue 进度评论的简短中文摘要。",
+  "pr_body": "## 背景或目标\n...\n\n## 关键改动\n...\n\n## 实际验证\n{{TEST_RESULTS}}\n\n## 风险与兼容性\n...\n\n## 方案\n{{DESIGN_LINKS:design/project/20260803-codex-pr-description.active.html}}\n\n## 视觉证据\n...",
+  "tests": [
+    {"command": "python3 -m pytest tests/test_codex_workflow.py", "result": "passed"}
+  ]
+}</pre></div>
+
+      <p>不需要方案时，把方案段改为 <code>{{DESIGN_EXEMPTION}}</code>，并紧接具体豁免原因。两个方案占位符必须恰好出现一个。正文中的截图 Markdown 或无法截图说明由 Codex 直接写入“视觉证据”章节。</p>
+
+      <table>
+        <thead><tr><th>门禁</th><th>规则</th><th>失败行为</th></tr></thead>
+        <tbody>
+          <tr><td data-label="门禁">正文完整性</td><td data-label="规则"><code>pr_body</code> 为有上限的非空字符串，并包含背景、关键改动、实际验证、风险与兼容性、方案、视觉证据六个固定二级标题。</td><td data-label="失败行为">拒绝 publish，不创建不完整 PR。</td></tr>
+          <tr><td data-label="门禁">真实测试注入</td><td data-label="规则"><code>{{TEST_RESULTS}}</code> 恰好出现一次；workflow 从已经通过 publish gate 的 <code>tests</code> 生成列表。</td><td data-label="失败行为">拒绝正文自报或遗漏验证记录。</td></tr>
+          <tr><td data-label="门禁">方案二选一</td><td data-label="规则"><code>{{DESIGN_LINKS:路径}}</code> 与 <code>{{DESIGN_EXEMPTION}}</code> 恰好出现一个；前者只允许合法且存在的 ACTIVE 文件，后者后面必须有原因。</td><td data-label="失败行为">拒绝 publish，提示方案引用不合规。</td></tr>
+          <tr><td data-label="门禁">视觉证据</td><td data-label="规则">视觉证据由正文直接表达：界面改动使用截图 Markdown，其他情况明确说明不涉及界面或无法截图原因。</td><td data-label="失败行为">固定标题使缺失内容在评审和契约测试中可见。</td></tr>
+          <tr><td data-label="门禁">正文标记</td><td data-label="规则">只接受零组或一组有序的 Codex 标记；重复、缺边界或顺序错误均不覆盖。</td><td data-label="失败行为">提交可保留，但 PR 更新失败并在进度评论中报告。</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <h2>04 / 发布流程与幂等更新</h2>
+    <section>
+      <div class="flow" role="img" aria-label="Codex PR 正文模板从生成、校验、提交、封印到创建或更新 PR 的流程">
+        <div class="stage"><small>01 · MODEL</small><strong>编写正文</strong><span>写入 pr_body、tests 和提交元数据。</span></div>
+        <div class="stage"><small>02 · GATE</small><strong>验证模板</strong><span>长度、标题、占位符、方案路径与文件。</span></div>
+        <div class="stage"><small>03 · PUBLISH</small><strong>提交并推送</strong><span>受控 App 生成最终 commit SHA。</span></div>
+        <div class="stage"><small>04 · SEAL</small><strong>替换占位符</strong><span>注入真实测试和两条不可变方案链接。</span></div>
+        <div class="stage"><small>05 · PR</small><strong>创建或更新</strong><span>替换受控区，保留人工区，保持 Draft。</span></div>
+      </div>
+
+      <table>
+        <thead><tr><th>场景</th><th>正文行为</th><th>SHA 来源</th></tr></thead>
+        <tbody>
+          <tr><td data-label="场景">首次 Issue 发布</td><td data-label="正文行为">创建 Draft PR，正文仅包含完整 Codex 受控区与 <code>Closes #N</code>。</td><td data-label="SHA 来源">本轮 publish 输出。</td></tr>
+          <tr><td data-label="场景">已有 Codex PR 后续发布</td><td data-label="正文行为">读取现有正文；替换唯一受控区，无标记则在末尾追加。</td><td data-label="SHA 来源">本轮新提交。</td></tr>
+          <tr><td data-label="场景">分支已推送但 PR 缺失</td><td data-label="正文行为">补建 Draft PR；复用已经校验的结果文件。</td><td data-label="SHA 来源">checkout 的目标提交。</td></tr>
+          <tr><td data-label="场景">标记被破坏或出现多组</td><td data-label="正文行为">拒绝覆盖并报告错误，不猜测维护者意图。</td><td data-label="SHA 来源">不适用。</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <h2>05 / 安全、兼容性与回滚</h2>
+    <section>
+      <div class="decisions">
+        <article class="decision">
+          <h3>不信任模型输出</h3>
+          <p>继续在 shell 门禁中校验严格键集合、类型、长度、固定标题和占位符。workflow 只解释自有的精确占位符，不执行正文内容，也不允许占位符路径逃逸 <code>design/</code>。</p>
+        </article>
+        <article class="decision">
+          <h3>不信任 checkout 辅助脚本</h3>
+          <p>Issue/PR 目标代码可能变化，正文渲染逻辑继续内联在受信任 workflow 版本中，不从 checkout 动态加载 JavaScript。</p>
+        </article>
+        <article class="decision">
+          <h3>兼容旧 PR</h3>
+          <p>旧正文没有标记时不删除原文，只追加受控区。新契约上线后，旧格式结果 fail closed，要求 Codex 按新 prompt 重新生成。</p>
+        </article>
+        <article class="decision">
+          <h3>回滚</h3>
+          <p>回滚 workflow、prompt 与契约测试即可停止新逻辑；已经写入 PR 的 Markdown 保持可读。受控标记只是 HTML 注释，不影响 GitHub 展示。</p>
+        </article>
+      </div>
+      <div class="warning"><strong>发布顺序约束：</strong>提交发生在 PR 更新前。如果远端提交成功但 PR API 更新失败，不能回滚已推送提交；最终状态必须明确报告“提交已发布、PR 正文更新失败”，下一次运行可重新渲染。</div>
+    </section>
+
+    <h2>06 / 测试结果</h2>
+    <section>
+      <p>核心契约、正文渲染、幂等更新、路径安全和全量项目回归均已通过。宿主机依赖不足与真实 GitHub App 凭据边界单独记录，不冒充成功。</p>
+      <div class="tests">
+        <div class="test-item pass"><strong><code>python3 -m pytest tests/test_codex_workflow.py -q</code></strong><span>PASS；43 passed in 8.84s。覆盖完整/缺失正文、固定章节、测试与方案占位符、路径穿越、ACTIVE 文件、首次创建、既有 PR 替换/追加、畸形标记和完整 SHA 双链接。</span></div>
+        <div class="test-item pass"><strong><code>make test</code></strong><span>PASS；Docker 测试镜像下 797 passed、16 skipped、20 warnings in 57.11s，包含全仓库回归。</span></div>
+        <div class="test-item pass"><strong>actionlint 1.7.12</strong><span>PASS；<code>go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -config-file .github/actionlint.yaml .github/workflows/codex.yml</code> 无输出，退出码 0。</span></div>
+        <div class="test-item pass"><strong>Python 与差异检查</strong><span>PASS；<code>make lint-py-fix</code>、<code>make lint-py</code>、<code>ruff check tests/test_codex_workflow.py</code>、<code>ruff format --check tests/test_codex_workflow.py</code> 和 <code>git diff --check</code> 全部通过。</span></div>
+        <div class="test-item pass"><strong>方案实际渲染</strong><span>PASS；本机 Chrome 分别以 1440×1100 和 390×844 视口打开单文件 HTML，桌面和移动端首屏无溢出、裁切或不可读内容。</span></div>
+        <div class="test-item limited"><strong><code>make pytest</code> 与宿主机全量 pytest</strong><span>ENVIRONMENT；Makefile 入口因 PATH 缺少 <code>pytest</code> 未启动；模块入口收集时缺 Calibre、QuickJS、<code>txt2epub_next</code> 与 Python 3.11 <code>tomllib</code>。已由 Docker <code>make test</code> 完整替代并通过。</span></div>
+        <div class="test-item limited"><strong><code>act issue_comment -W .github/workflows/codex.yml -j codex ... --pull=false</code></strong><span>BOUNDARY；act 0.2.82 成功启动真实 dev 容器、下载并执行 <code>create-github-app-token@v3</code>，随后因本地未提供生产 <code>CODEX_APP_CLIENT_ID</code>/私钥停止。真实 App Token、PR create/update 与 GitHub 评论写入必须在远端 Actions 冒烟通过后方可合并。</span></div>
+        <div class="test-item pass"><strong><code>make check-design</code></strong><span>PASS；77 design documents passed，路径、ACTIVE 状态、HTML 结构与单文件资源门禁全部通过。</span></div>
+      </div>
+    </section>
+  </main>
+
+  <footer>ACTIVE · Codex 直接输出 <code>pr_body</code>，workflow 只注入经过验证的测试、完整 SHA 方案链接和关闭语句；远端 GitHub App 冒烟仍是合并前置条件。</footer>
+</body>
+</html>

--- a/tests/test_codex_workflow.py
+++ b/tests/test_codex_workflow.py
@@ -62,11 +62,30 @@ def progress_reporter_text():
     return PROGRESS_REPORTER.read_text(encoding="utf-8")
 
 
+def publish_pr_body(*, design=True):
+    design_reference = (
+        "{{DESIGN_LINKS:design/project/20260803-codex-pr-description.active.html}}"
+        if design
+        else "{{DESIGN_EXEMPTION}} 本次仅修正不改变行为的测试说明，因此豁免方案。"
+    )
+    return "\n\n".join(
+        (
+            "## 背景或目标\n修复自动创建的 PR 丢失评审信息。",
+            "## 关键改动\n- 使用 Codex 生成的完整正文模板。",
+            "## 实际验证\n{{TEST_RESULTS}}",
+            "## 风险与兼容性\n- 保留维护者在受控区外的手写内容。",
+            f"## 方案\n{design_reference}",
+            "## 视觉证据\n本次不涉及产品界面。",
+        )
+    )
+
+
 def run_publish_gate(
     tmp_path,
     result,
     *,
     changed=False,
+    design_document="",
     publish_block_reason="",
     issue_branches=(),
     run_id="123456",
@@ -98,6 +117,10 @@ def run_publish_gate(
     ).stdout.strip()
     (tmp_path / ".git" / "info" / "exclude").write_text(".codex-result.json\n", encoding="utf-8")
     (tmp_path / ".codex-result.json").write_text(json.dumps(result, ensure_ascii=False), encoding="utf-8")
+    if design_document:
+        design_path = tmp_path / design_document
+        design_path.parent.mkdir(parents=True, exist_ok=True)
+        design_path.write_text('<!doctype html><html lang="zh-CN"><body>active</body></html>\n', encoding="utf-8")
     if changed:
         (tmp_path / "tracked.txt").write_text("changed\n", encoding="utf-8")
 
@@ -144,6 +167,7 @@ def run_response_step(
                 "feature": "",
                 "commit_message": "",
                 "summary": "已完成处理，并保留执行计划。",
+                "pr_body": "",
                 "tests": list(tests),
             },
             ensure_ascii=False,
@@ -234,6 +258,90 @@ const finish = (error) => {
         "TEST_PROGRESS_BODY": progress_body,
         "TEST_GET_COMMENT_ERROR": "true" if get_comment_error else "false",
         "TEST_UPDATE_COMMENT_ERROR": "true" if update_comment_error else "false",
+        "TEST_TRACE_FILE": str(trace_file),
+    }
+    completed = subprocess.run(
+        ["node", "-e", harness],
+        cwd=tmp_path,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return completed, json.loads(trace_file.read_text(encoding="utf-8"))
+
+
+def run_issue_pr_step(
+    tmp_path,
+    *,
+    result,
+    existing_pr_number="",
+    existing_body="",
+    commit_sha="a" * 40,
+):
+    result_file = tmp_path / ".codex-result.json"
+    result_file.write_text(json.dumps(result, ensure_ascii=False), encoding="utf-8")
+    trace_file = tmp_path / "issue-pr-trace.json"
+    issue_pr_script = workflow_step(step_id="create_issue_pr")["with"]["script"]
+    harness = (
+        """
+const harnessFs = require("fs");
+const calls = [];
+const outputs = {};
+const github = {
+  rest: {
+    pulls: {
+      get: async (args) => {
+        calls.push({name: "get", args});
+        return {data: {number: args.pull_number, body: process.env.TEST_EXISTING_BODY, html_url: "https://github.test/talebook/talebook/pull/932"}};
+      },
+      create: async (args) => {
+        calls.push({name: "create", args});
+        return {data: {number: 932, body: args.body, html_url: "https://github.test/talebook/talebook/pull/932"}};
+      },
+      update: async (args) => {
+        calls.push({name: "update", args});
+        return {data: {number: args.pull_number, body: args.body, html_url: "https://github.test/talebook/talebook/pull/932"}};
+      },
+    },
+  },
+};
+const context = {
+  serverUrl: "https://github.test",
+  repo: {owner: "talebook", repo: "talebook"},
+};
+const core = {
+  setOutput: (name, value) => { outputs[name] = value; },
+};
+const finish = (error) => {
+  harnessFs.writeFileSync(
+    process.env.TEST_TRACE_FILE,
+    JSON.stringify({calls, outputs, error: error ? error.message : ""}),
+  );
+};
+(async () => {
+"""
+        + issue_pr_script
+        + """
+})().then(
+  () => finish(null),
+  (error) => {
+    finish(error);
+    process.exitCode = 1;
+  },
+);
+"""
+    )
+    env = {
+        **os.environ,
+        "RESULT_FILE": str(result_file),
+        "ISSUE_NUMBER": "928",
+        "ISSUE_TITLE": "浅灰主题下左侧栏收缩的bug",
+        "DEFAULT_BRANCH": "master",
+        "PUBLISH_BRANCH": "codex/issue-928-light-gray-sidebar-toggle",
+        "COMMIT_SHA": commit_sha,
+        "EXISTING_PR_NUMBER": existing_pr_number,
+        "TEST_EXISTING_BODY": existing_body,
         "TEST_TRACE_FILE": str(trace_file),
     }
     completed = subprocess.run(
@@ -500,9 +608,14 @@ def test_agent_contract_distinguishes_conversational_replies_from_code_publicati
     assert "--json" in run_step["run"]
     assert "tee .codex/tmp/codex-events.jsonl" in run_step["run"]
     assert run_step["env"]["CODEX_PROGRESS_TOKEN"] == "${{ steps.interaction_token.outputs.token }}"
-    assert all(field in prompt for field in ('"delivery"', '"feature"', '"commit_message"', '"summary"', '"tests"'))
+    assert all(
+        field in prompt for field in ('"delivery"', '"feature"', '"commit_message"', '"summary"', '"pr_body"', '"tests"')
+    )
     assert '"delivery": "reply"' in prompt
     assert '"delivery": "publish"' in prompt
+    assert "{{TEST_RESULTS}}" in prompt
+    assert "{{DESIGN_LINKS:design/" in prompt
+    assert "{{DESIGN_EXEMPTION}}" in prompt
     assert '"ready_to_publish"' not in prompt
     assert "不得根据关键词预先判断" in prompt
     assert "纯问答" in prompt
@@ -554,8 +667,13 @@ def test_publish_gate_rejects_incomplete_or_unsafe_changes():
 
     assert gate["env"]["RESULT_FILE"] == ".codex-result.json"
     assert gate["env"]["PUBLISH_BLOCK_REASON"] == "${{ steps.context.outputs.publish_block_reason }}"
-    assert '(keys | sort) == ["commit_message", "delivery", "feature", "summary", "tests"]' in script
+    assert '(keys | sort) == ["commit_message", "delivery", "feature", "pr_body", "summary", "tests"]' in script
     assert '(.delivery == "reply" or .delivery == "publish")' in script
+    assert '(.pr_body | type == "string")' in script
+    assert 'split("{{TEST_RESULTS")' in script
+    assert "DESIGN_LINKS:" in script
+    assert "DESIGN_EXEMPTION" in script
+    assert "方案文档不存在或不是文件" in script
     assert 'delivery="$(jq -r \'.delivery\' "$RESULT_FILE")"' in script
     assert 'echo "delivery=$delivery" >> "$GITHUB_OUTPUT"' in script
     assert "ready_to_publish" not in script
@@ -593,6 +711,7 @@ def test_publish_gate_executes_reply_and_publish_paths_against_a_real_git_worktr
         "feature": "",
         "commit_message": "",
         "summary": "当前运行模型由工作流配置决定。",
+        "pr_body": "",
         "tests": [],
     }
     publish = {
@@ -600,6 +719,7 @@ def test_publish_gate_executes_reply_and_publish_paths_against_a_real_git_worktr
         "feature": "conversation-routing",
         "commit_message": "fix(codex): route conversational requests",
         "summary": "已修复纯问答路由。",
+        "pr_body": publish_pr_body(design=False),
         "tests": [{"command": "pytest -q tests/test_codex_workflow.py", "result": "passed"}],
     }
 
@@ -644,6 +764,76 @@ def test_publish_gate_executes_reply_and_publish_paths_against_a_real_git_worktr
     )
     assert collision_outputs["ready"] == "true"
     assert collision_outputs["publish_branch"] == "codex/issue-875-conversation-routing-123456"
+
+
+@pytest.mark.skipif(
+    any(shutil.which(command) is None for command in ("bash", "git", "jq")),
+    reason="发布门禁行为测试需要 bash、git 和 jq",
+)
+def test_publish_gate_validates_pr_body_template_and_active_design_path(tmp_path):
+    base_publish = {
+        "delivery": "publish",
+        "feature": "codex-pr-description",
+        "commit_message": "fix(codex): publish compliant PR descriptions",
+        "summary": "已补齐 PR 正文。",
+        "pr_body": publish_pr_body(),
+        "tests": [{"command": "pytest -q", "result": "passed"}],
+    }
+    design_path = "design/project/20260803-codex-pr-description.active.html"
+
+    valid_outputs = run_publish_gate(
+        tmp_path / "valid-design",
+        base_publish,
+        changed=True,
+        design_document=design_path,
+    )
+    assert valid_outputs["ready"] == "true"
+    assert valid_outputs["contract_valid"] == "true"
+
+    missing_design_outputs = run_publish_gate(tmp_path / "missing-design", base_publish, changed=True)
+    assert missing_design_outputs["ready"] == "false"
+    assert missing_design_outputs["contract_valid"] == "false"
+    assert missing_design_outputs["reason"] == f"方案文档不存在或不是文件：{design_path}"
+
+    missing_heading = {**base_publish, "pr_body": publish_pr_body().replace("## 风险与兼容性", "## 风险")}
+    missing_heading_outputs = run_publish_gate(tmp_path / "missing-heading", missing_heading, changed=True)
+    assert missing_heading_outputs["contract_valid"] == "false"
+    assert missing_heading_outputs["reason"] == "Codex 结果不符合发布契约或 Conventional Commit 规则。"
+
+    duplicate_tests = {
+        **base_publish,
+        "pr_body": publish_pr_body(design=False).replace("{{TEST_RESULTS}}", "{{TEST_RESULTS}}\n{{TEST_RESULTS}}"),
+    }
+    duplicate_outputs = run_publish_gate(tmp_path / "duplicate-tests", duplicate_tests, changed=True)
+    assert duplicate_outputs["contract_valid"] == "false"
+
+    traversal_path = {
+        **base_publish,
+        "pr_body": publish_pr_body().replace(
+            "design/project/20260803-codex-pr-description.active.html",
+            "design/../20260803-codex-pr-description.active.html",
+        ),
+    }
+    traversal_outputs = run_publish_gate(tmp_path / "traversal-path", traversal_path, changed=True)
+    assert traversal_outputs["contract_valid"] == "false"
+
+    injected_boundary = {
+        **base_publish,
+        "pr_body": publish_pr_body(design=False) + "\n<!-- codex-pr-description:start -->",
+    }
+    injected_boundary_outputs = run_publish_gate(tmp_path / "injected-boundary", injected_boundary, changed=True)
+    assert injected_boundary_outputs["contract_valid"] == "false"
+
+    invalid_reply = {
+        "delivery": "reply",
+        "feature": "",
+        "commit_message": "",
+        "summary": "只回答问题。",
+        "pr_body": "不应为 reply 生成 PR 正文。",
+        "tests": [],
+    }
+    invalid_reply_outputs = run_publish_gate(tmp_path / "reply-with-body", invalid_reply)
+    assert invalid_reply_outputs["contract_valid"] == "false"
 
 
 def test_repository_wip_gate_runs_before_no_change_classification():
@@ -718,10 +908,142 @@ def test_first_successful_issue_run_creates_one_draft_pull_request():
     assert "steps.context.outputs.existing_issue_pr_number == ''" in create_pr["if"]
     assert create_pr["with"]["github-token"] == "${{ steps.app_token.outputs.token }}"
     assert "github.rest.pulls.create" in script
+    assert "github.rest.pulls.get" in script
+    assert "github.rest.pulls.update" in script
     assert "draft: true" in script
     assert "head: process.env.PUBLISH_BRANCH" in script
     assert "base: process.env.DEFAULT_BRANCH" in script
     assert "Closes #${process.env.ISSUE_NUMBER}" in script
+    assert "<!-- codex-pr-description:start -->" in script
+    assert "<!-- codex-pr-description:end -->" in script
+    assert "raw.githack.com" in script
+
+
+@requires_node
+def test_issue_pr_body_renders_validated_tests_and_immutable_design_links(tmp_path):
+    result = {
+        "delivery": "publish",
+        "feature": "codex-pr-description",
+        "commit_message": "fix(codex): publish compliant PR descriptions",
+        "summary": "已补齐 PR 正文。",
+        "pr_body": publish_pr_body(),
+        "tests": [
+            {
+                "command": "python3 -m pytest tests/test_codex_workflow.py",
+                "result": "passed",
+                "details": "92 passed",
+            }
+        ],
+    }
+    commit_sha = "609eeda88fd2676a08eb544f8e5f88ffe4f59f07"
+
+    completed, trace = run_issue_pr_step(tmp_path, result=result, commit_sha=commit_sha)
+
+    assert completed.returncode == 0, completed.stderr
+    create = next(call for call in trace["calls"] if call["name"] == "create")
+    body = create["args"]["body"]
+    assert "## 背景或目标" in body
+    assert "<code>python3 -m pytest tests/test_codex_workflow.py</code>" in body
+    assert "<strong>passed</strong>" in body
+    assert "92 passed" in body
+    assert (
+        "https://github.test/talebook/talebook/blob/609eeda88fd2676a08eb544f8e5f88ffe4f59f07/"
+        "design/project/20260803-codex-pr-description.active.html"
+    ) in body
+    assert (
+        "https://raw.githack.com/talebook/talebook/609eeda88fd2676a08eb544f8e5f88ffe4f59f07/"
+        "design/project/20260803-codex-pr-description.active.html"
+    ) in body
+    assert "{{TEST_RESULTS}}" not in body
+    assert "{{DESIGN_LINKS:" not in body
+    assert "Closes #928" in body
+    assert body.count("<!-- codex-pr-description:start -->") == 1
+    assert body.count("<!-- codex-pr-description:end -->") == 1
+    assert trace["outputs"]["pull_request_action"] == "created"
+
+
+@requires_node
+def test_existing_issue_pr_replaces_only_the_managed_description(tmp_path):
+    result = {
+        "delivery": "publish",
+        "feature": "codex-pr-description",
+        "commit_message": "fix(codex): publish compliant PR descriptions",
+        "summary": "已更新 PR 正文。",
+        "pr_body": publish_pr_body(design=False),
+        "tests": [{"command": "pytest -q", "result": "passed"}],
+    }
+    existing_body = (
+        "维护者前言\n\n<!-- codex-pr-description:start -->\n旧的自动说明\n<!-- codex-pr-description:end -->\n\n维护者附注"
+    )
+
+    completed, trace = run_issue_pr_step(
+        tmp_path,
+        result=result,
+        existing_pr_number="932",
+        existing_body=existing_body,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert not any(call["name"] == "create" for call in trace["calls"])
+    update = next(call for call in trace["calls"] if call["name"] == "update")
+    body = update["args"]["body"]
+    assert body.startswith("维护者前言")
+    assert body.endswith("维护者附注")
+    assert "旧的自动说明" not in body
+    assert "本次仅修正不改变行为的测试说明，因此豁免方案。" in body
+    assert "{{DESIGN_EXEMPTION}}" not in body
+    assert body.count("<!-- codex-pr-description:start -->") == 1
+    assert body.count("<!-- codex-pr-description:end -->") == 1
+    assert trace["outputs"]["pull_request_action"] == "updated"
+
+
+@requires_node
+def test_existing_unmanaged_issue_pr_appends_the_managed_description(tmp_path):
+    result = {
+        "delivery": "publish",
+        "feature": "codex-pr-description",
+        "commit_message": "fix(codex): publish compliant PR descriptions",
+        "summary": "已追加 PR 正文。",
+        "pr_body": publish_pr_body(design=False),
+        "tests": [{"command": "pytest -q", "result": "passed"}],
+    }
+
+    completed, trace = run_issue_pr_step(
+        tmp_path,
+        result=result,
+        existing_pr_number="932",
+        existing_body="维护者已有的正文，不应被覆盖。",
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    update = next(call for call in trace["calls"] if call["name"] == "update")
+    body = update["args"]["body"]
+    assert body.startswith("维护者已有的正文，不应被覆盖。\n\n<!-- codex-pr-description:start -->")
+    assert "## 背景或目标" in body
+    assert trace["outputs"]["pull_request_action"] == "updated"
+
+
+@requires_node
+def test_existing_issue_pr_rejects_malformed_managed_markers(tmp_path):
+    result = {
+        "delivery": "publish",
+        "feature": "codex-pr-description",
+        "commit_message": "fix(codex): publish compliant PR descriptions",
+        "summary": "尝试更新 PR 正文。",
+        "pr_body": publish_pr_body(design=False),
+        "tests": [{"command": "pytest -q", "result": "passed"}],
+    }
+
+    completed, trace = run_issue_pr_step(
+        tmp_path,
+        result=result,
+        existing_pr_number="932",
+        existing_body="维护者正文\n<!-- codex-pr-description:start -->\n缺少结束标记",
+    )
+
+    assert completed.returncode != 0
+    assert "valid managed description boundary pair" in trace["error"]
+    assert not any(call["name"] == "update" for call in trace["calls"])
 
 
 def test_existing_issue_branch_without_a_pr_can_recover_after_a_partial_publish():
@@ -760,6 +1082,8 @@ def test_comment_reports_validated_metadata_and_remote_delivery_result():
     assert "test.result" in script
     assert "CODEX_COMMIT_SHA" in response["env"]
     assert "CREATED_PR_URL" in response["env"]
+    assert response["env"]["ISSUE_PR_ACTION"] == "${{ steps.create_issue_pr.outputs.pull_request_action }}"
+    assert "process.env.ISSUE_PR_ACTION" in script
     assert "github.rest.issues.updateComment" in script
 
 
@@ -783,6 +1107,8 @@ def test_publish_delivery_without_a_diff_only_succeeds_for_missing_pr_recovery()
     assert '未发布：${process.env.CODEX_GATE_REASON || "未产生仓库改动。"}' in response_script
     assert 'if [ "$DELIVERY" = "publish" ] && [ "$GATE_NO_CHANGES" = "true" ]; then' in final_status_script
     assert 'if [ "$CREATED_PR_OUTCOME" = "success" ]; then' in final_status_script
+    assert '[ "$IS_PR" != "true" ] && [ "$CREATED_PR_OUTCOME" != "success" ]' in final_status_script
+    assert '[ -z "$EXISTING_PR_NUMBER" ] && [ "$CREATED_PR_OUTCOME" != "success" ]' not in final_status_script
 
 
 def test_one_progress_comment_is_created_then_updated_throughout_the_run():


### PR DESCRIPTION
## 背景或目标

在 PR #932 暴露出一个发布链路缺口：Codex 处理 Issue 时，提示词只要求生成摘要和测试元数据，workflow 创建 Draft PR 时又使用固定的两行正文，因此无法落实仓库 `AGENTS.md` 对 PR 背景、关键改动、实际验证、风险兼容性以及方案链接的要求。

本次改动让 Codex 直接生成一段完整 Markdown `pr_body`，再由受信任的 workflow 注入已经校验过的测试结果、不可漂移的方案链接和 Issue 关闭语句。

## 关键改动

- 在 `.codex-result.json` 发布契约中新增字符串字段 `pr_body`；不引入多层 PR 结构体。
- 强制正文包含“背景或目标、关键改动、实际验证、风险与兼容性、方案、视觉证据”六个章节。
- 使用 `{{TEST_RESULTS}}` 注入门禁实际校验的测试记录，避免 Codex 自行宣称未执行的测试。
- 使用 `{{DESIGN_LINKS:...}}` 或带原因的 `{{DESIGN_EXEMPTION}}` 表达方案要求；提交后再以完整 commit SHA 生成 GitHub 文件链接和 RawGitHack 预览链接。
- 为自动维护的正文增加受管边界。再次处理同一 Issue 时只替换受管部分，保留维护者写在边界外的内容；异常或重复边界会 fail closed。
- 将已有 Issue PR 的正文更新纳入成功判定，并补充真实脚本行为测试及发布门禁反例测试。

## 实际验证

- `python3 -m pytest tests/test_codex_workflow.py -q` — 通过，43 passed。
- `make test` — Docker 全量测试通过，797 passed、16 skipped、20 warnings。
- `make lint-py-fix` — 通过，100 个后端文件无需修改。
- `make lint-py` — 通过。
- `ruff check tests/test_codex_workflow.py` — 通过。
- `ruff format --check tests/test_codex_workflow.py` — 通过。
- `make check-design` — 通过，77 份方案文档校验成功。
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -config-file .github/actionlint.yaml .github/workflows/codex.yml` — 通过。
- `git diff --check` — 通过。
- Chrome 实际渲染方案页面：桌面 1440×1100、移动端 390×844 均通过。

### 真实 workflow 本地执行记录

- act 版本：`act version 0.2.82`。
- 事件与 job：`issue_comment` / `codex`。
- 实际命令：`act issue_comment -W .github/workflows/codex.yml -j codex -e /private/tmp/talebook-codex-pr-description-issue-comment.json --pull=false`。
- 已到达的关键边界：启动真实开发容器、下载并加载 workflow Actions、执行 `actions/create-github-app-token@v3`。
- 本地最终结果：由于测试环境未提供生产 `CODEX_APP_CLIENT_ID` 和 App private key，在 GitHub App token 步骤按预期停止；未伪造生产密钥，也未执行真实 GitHub 写操作。
- 未执行项：`make pytest` 在宿主机找不到 `pytest` 命令；直接运行宿主机全量 pytest 又因缺少 Calibre、QuickJS、`txt2epub_next` 等运行时依赖在收集阶段停止。已使用项目规定的 Docker `make test` 完成全量替代验证。

## 风险与兼容性

- `publish` 结果新增必填 `pr_body`，旧格式结果会被门禁拒绝；同一仓库内提示词与 workflow 同步发布，因此不存在版本错配窗口。
- 自动更新仅作用于 Issue 自动化创建或识别到的 PR；直接在 PR 上调用 Codex 的既有发布路径不改变。
- GitHub App token、Draft PR 创建/更新及评论 API 无法在不使用生产凭据的本地 `act` 中完整模拟。必须在本 PR 的真实 GitHub Actions 中完成一次 Issue PR 创建/再次更新冒烟验证；在获得结果前，本 PR 保持 Draft，且该项是合并阻断项。
- 正文受 GitHub 65536 字符限制；渲染后和合并人工内容后都会再次检查长度。

## 方案

- [GitHub 方案文件](https://github.com/talebook/talebook/blob/6ff838b566dbf876e03adb5a4f99cf60b766cb12/design/project/20260803-codex-pr-description.active.html)
- [RawGitHack 在线预览](https://raw.githack.com/talebook/talebook/6ff838b566dbf876e03adb5a4f99cf60b766cb12/design/project/20260803-codex-pr-description.active.html)

## 视觉证据

本次不修改产品界面、布局或交互，因此没有产品截图。内部方案 HTML 已分别在 Chrome 桌面和移动视口完成实际渲染检查。
