### PR TITLE
TAL-5: preserve settings outside the admin form

### DIFF
--- a/design/webserver/20260806-admin-settings-preserve-config.active.html
+++ b/design/webserver/20260806-admin-settings-preserve-config.active.html
@@ -87,24 +87,21 @@
     <table>
       <thead><tr><th>场景</th><th>断言</th><th>结果</th></tr></thead>
       <tbody>
-        <tr><td>保留内部配置</td><td>保存白名单字段后，落盘并重新加载仍保留 <code>user_database</code>、<code>ACTIVE_THEME</code> 和其它既有键。</td><td class="passed">通过：纯持久化测试；HTTP 集成用例已加入。</td></tr>
+        <tr><td>保留内部配置</td><td>保存白名单字段后，落盘并重新加载仍保留 <code>user_database</code>、<code>ACTIVE_THEME</code> 和其它既有键。</td><td class="passed">通过：纯持久化测试与 Docker HTTP 集成测试。</td></tr>
         <tr><td>允许字段更新</td><td><code>site_title</code> 等白名单字段在返回值、运行态和磁盘候选中更新。</td><td class="passed">通过：运行态与 <code>auto.py</code> 均为新值。</td></tr>
-        <tr><td>危险字段</td><td>请求中的 <code>user_database</code>、<code>ACTIVE_THEME</code>、未知键及恶意动态键不能覆盖服务端既有值。</td><td class="limited">HTTP 集成用例已覆盖；本机因缺少 Calibre 未进入用例执行，待 CI 确认。</td></tr>
+        <tr><td>危险字段</td><td>请求中的 <code>user_database</code>、<code>ACTIVE_THEME</code>、未知键及恶意动态键不能覆盖服务端既有值。</td><td class="passed">通过：Docker 中的 HTTP 集成用例已覆盖。</td></tr>
         <tr><td>落盘失败</td><td>模拟原子替换失败，原 <code>auto.py</code> 内容与 <code>CONF</code> 均不改变，临时文件被清理。</td><td class="passed">通过：失败回滚与原子替换测试。</td></tr>
-        <tr><td>回归与规范</td><td>相关 pytest、Python lint/format、<code>make check-design</code>。</td><td class="passed">纯持久化测试与 Ruff 已通过；方案检查见执行记录。</td></tr>
+        <tr><td>回归与规范</td><td>Docker 全量 pytest、Python lint/format、<code>make check-design</code>。</td><td class="passed">全量测试与 Ruff 已通过；方案检查见执行记录。</td></tr>
       </tbody>
     </table>
     <h3>实际执行记录</h3>
     <ul>
-      <li><code>uv run pytest -q tests/test_settings_persistence.py</code> — <strong>通过</strong>（3 passed）。</li>
-      <li><code>uv run ruff check ./webserver --no-cache</code> — <strong>通过</strong>。</li>
-      <li><code>uv run ruff format --diff ./webserver --no-cache</code> — <strong>通过</strong>（100 files already formatted）。</li>
-      <li><code>uv run ruff check tests/test_admin.py tests/test_settings_persistence.py --no-cache</code> 与对应 format diff — <strong>通过</strong>。</li>
-      <li><code>uv run python -m py_compile webserver/loader.py webserver/handlers/admin.py tests/test_admin.py tests/test_settings_persistence.py</code> — <strong>通过</strong>。</li>
-      <li><code>uv run pytest -q tests/test_admin.py::TestAdminSettingsSecurity</code> — <strong>环境阻塞</strong>：本机未安装 Calibre，Tornado 测试服务在模块初始化阶段报 <code>No module named 'calibre'</code>，12 个用例均未进入执行；这不是业务断言失败。新增 HTTP 用例保留在套件中，由具备 Calibre 的 CI 镜像执行。</li>
-      <li><code>make check-design</code> — 转为 ACTIVE 后执行并通过。</li>
+      <li><code>sudo make test</code> — <strong>通过</strong>：按项目 <code>AGENTS.md</code> 构建 Docker 测试镜像并执行全量 pytest，结果为 806 passed、20 skipped、21 warnings，耗时 70.46 秒；其中 <code>tests/test_admin.py</code> 与 <code>tests/test_settings_persistence.py</code> 均通过。</li>
+      <li>在同一 Docker 测试镜像中执行 <code>make lint-py-fix</code> — <strong>通过</strong>：All checks passed，100 files left unchanged。</li>
+      <li>在同一 Docker 测试镜像中执行 <code>make lint-py</code> — <strong>通过</strong>：All checks passed，100 files already formatted。</li>
+      <li><code>make check-design</code> — <strong>通过</strong>。</li>
     </ul>
-    <p>剩余风险：本机未完成真实 Tornado + Calibre 环境中的管理员 HTTP 保存回归，PR 合并前需以 CI 的后端测试结果确认；纯逻辑、持久化文件内容、运行态提交顺序、失败回滚和原子替换已在不依赖 Calibre 的测试中验证。</p>
+    <p>剩余风险：测试会保存并重新加载 MariaDB 连接串，但未连接真实 MariaDB 服务或在真实数据库进程上执行重启回归。Docker 中已覆盖 Tornado + Calibre 的管理员 HTTP 保存路径、纯逻辑、持久化文件内容、运行态提交顺序、失败回滚和原子替换。</p>
   </section>
 
   <footer>Talebook 内部开发方案 · ACTIVE · TAL-5 / GitHub Issue #944</footer>

--- a/design/webserver/20260806-admin-settings-preserve-config.active.html
+++ b/design/webserver/20260806-admin-settings-preserve-config.active.html
@@ -91,12 +91,13 @@
         <tr><td>允许字段更新</td><td><code>site_title</code> 等白名单字段在返回值、运行态和磁盘候选中更新。</td><td class="passed">通过：运行态与 <code>auto.py</code> 均为新值。</td></tr>
         <tr><td>危险字段</td><td>请求中的 <code>user_database</code>、<code>ACTIVE_THEME</code>、未知键及恶意动态键不能覆盖服务端既有值。</td><td class="passed">通过：Docker 中的 HTTP 集成用例已覆盖。</td></tr>
         <tr><td>落盘失败</td><td>模拟原子替换失败，原 <code>auto.py</code> 内容与 <code>CONF</code> 均不改变，临时文件被清理。</td><td class="passed">通过：失败回滚与原子替换测试。</td></tr>
-        <tr><td>回归与规范</td><td>Docker 全量 pytest、Python lint/format、<code>make check-design</code>。</td><td class="passed">全量测试与 Ruff 已通过；方案检查见执行记录。</td></tr>
+        <tr><td>回归与规范</td><td>Docker 全量 pytest、<code>production-spa</code> 镜像构建、Python lint/format、<code>make check-design</code>。</td><td class="passed">全量测试、生产镜像构建与 Ruff 已通过；方案检查见执行记录。</td></tr>
       </tbody>
     </table>
     <h3>实际执行记录</h3>
     <ul>
-      <li><code>sudo make test</code> — <strong>通过</strong>：按项目 <code>AGENTS.md</code> 构建 Docker 测试镜像并执行全量 pytest，结果为 806 passed、20 skipped、21 warnings，耗时 70.46 秒；其中 <code>tests/test_admin.py</code> 与 <code>tests/test_settings_persistence.py</code> 均通过。</li>
+      <li><code>sudo make test</code> — <strong>通过</strong>：按项目 <code>AGENTS.md</code> 构建 Docker 测试镜像并执行全量 pytest，结果为 807 passed、20 skipped、21 warnings，耗时 73.26 秒；其中 <code>tests/test_admin.py</code> 与包含 <code>--update-config</code> 回归用例的 <code>tests/test_settings_persistence.py</code> 均通过。</li>
+      <li><code>sudo docker build --build-arg GIT_VERSION=v26.08.03-18-g17f561b6 --target production-spa --platform linux/amd64 -t talebook/ci-fix-production-spa .</code> — <strong>通过</strong>：未修改 Dockerfile，生产镜像初始化中的 <code>python3 server.py --update-config</code> 正常完成。</li>
       <li>在同一 Docker 测试镜像中执行 <code>make lint-py-fix</code> — <strong>通过</strong>：All checks passed，100 files left unchanged。</li>
       <li>在同一 Docker 测试镜像中执行 <code>make lint-py</code> — <strong>通过</strong>：All checks passed，100 files already formatted。</li>
       <li><code>make check-design</code> — <strong>通过</strong>。</li>

--- a/design/webserver/20260806-admin-settings-preserve-config.active.html
+++ b/design/webserver/20260806-admin-settings-preserve-config.active.html
@@ -90,14 +90,14 @@
         <tr><td>保留内部配置</td><td>保存白名单字段后，落盘并重新加载仍保留 <code>user_database</code>、<code>ACTIVE_THEME</code> 和其它既有键。</td><td class="passed">通过：纯持久化测试与 Docker HTTP 集成测试。</td></tr>
         <tr><td>允许字段更新</td><td><code>site_title</code> 等白名单字段在返回值、运行态和磁盘候选中更新。</td><td class="passed">通过：运行态与 <code>auto.py</code> 均为新值。</td></tr>
         <tr><td>危险字段</td><td>请求中的 <code>user_database</code>、<code>ACTIVE_THEME</code>、未知键及恶意动态键不能覆盖服务端既有值。</td><td class="passed">通过：Docker 中的 HTTP 集成用例已覆盖。</td></tr>
-        <tr><td>落盘失败</td><td>模拟原子替换失败，原 <code>auto.py</code> 内容与 <code>CONF</code> 均不改变，临时文件被清理。</td><td class="passed">通过：失败回滚与原子替换测试。</td></tr>
+        <tr><td>落盘失败</td><td>模拟原子替换失败，原 <code>auto.py</code> 内容与 <code>CONF</code> 均不改变，临时文件被清理，且已转移所有权的文件描述符不会被重复关闭。</td><td class="passed">通过：失败回滚、原子替换与文件描述符所有权测试。</td></tr>
         <tr><td>回归与规范</td><td>Docker 全量 pytest、<code>production-spa</code> 镜像构建、Python lint/format、<code>make check-design</code>。</td><td class="passed">全量测试、生产镜像构建与 Ruff 已通过；方案检查见执行记录。</td></tr>
       </tbody>
     </table>
     <h3>实际执行记录</h3>
     <ul>
-      <li><code>sudo make test</code> — <strong>通过</strong>：按项目 <code>AGENTS.md</code> 构建 Docker 测试镜像并执行全量 pytest，结果为 807 passed、20 skipped、21 warnings，耗时 73.26 秒；其中 <code>tests/test_admin.py</code> 与包含 <code>--update-config</code> 回归用例的 <code>tests/test_settings_persistence.py</code> 均通过。</li>
-      <li><code>sudo docker build --build-arg GIT_VERSION=v26.08.03-18-g17f561b6 --target production-spa --platform linux/amd64 -t talebook/ci-fix-production-spa .</code> — <strong>通过</strong>：未修改 Dockerfile，生产镜像初始化中的 <code>python3 server.py --update-config</code> 正常完成。</li>
+      <li><code>sudo make test</code> — <strong>通过</strong>：按项目 <code>AGENTS.md</code> 构建 Docker 测试镜像并执行全量 pytest，结果为 808 passed、20 skipped、20 warnings，耗时 68.83 秒；其中 <code>tests/test_admin.py</code> 与包含 <code>--update-config</code>、原子替换及文件描述符所有权回归用例的 <code>tests/test_settings_persistence.py</code> 均通过。</li>
+      <li><code>sudo docker build --build-arg GIT_VERSION=v26.08.03-19-g6a9c788a-dirty --target production-spa --platform linux/amd64 -t talebook/ci-review-production-spa .</code> — <strong>通过</strong>：未修改 Dockerfile，生产镜像初始化中的 <code>python3 server.py --update-config</code> 正常完成。</li>
       <li>在同一 Docker 测试镜像中执行 <code>make lint-py-fix</code> — <strong>通过</strong>：All checks passed，100 files left unchanged。</li>
       <li>在同一 Docker 测试镜像中执行 <code>make lint-py</code> — <strong>通过</strong>：All checks passed，100 files already formatted。</li>
       <li><code>make check-design</code> — <strong>通过</strong>。</li>

--- a/design/webserver/20260806-admin-settings-preserve-config.active.html
+++ b/design/webserver/20260806-admin-settings-preserve-config.active.html
@@ -1,0 +1,113 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>管理员设置保存保留内部配置</title>
+  <style>
+    :root { color-scheme:light; --ink:#172033; --muted:#5b6a80; --line:#dce3ec; --paper:#fff; --bg:#f4f6f9; --accent:#2457c5; --soft:#eaf0ff; --ok:#187a5c; --warn:#9a6700; }
+    * { box-sizing:border-box; }
+    body { margin:0; color:var(--ink); background:var(--bg); font:15px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; }
+    main { width:min(1040px,calc(100% - 32px)); margin:32px auto 64px; }
+    header,section { margin-bottom:18px; padding:24px 28px; border:1px solid var(--line); border-radius:14px; background:var(--paper); }
+    header { border-top:5px solid var(--accent); }
+    h1 { margin:0 0 8px; font-size:28px; }
+    h2 { margin:0 0 12px; font-size:20px; }
+    h3 { margin:18px 0 8px; font-size:16px; }
+    p,ul,ol { margin:8px 0; }
+    code { padding:2px 5px; border-radius:5px; background:#eef1f5; }
+    .lead { color:var(--muted); font-size:16px; }
+    .meta { display:flex; flex-wrap:wrap; gap:8px; margin-top:14px; }
+    .tag { padding:4px 10px; border-radius:999px; color:var(--muted); background:#eef1f5; font-size:13px; }
+    .status { color:var(--ok); background:#e3f5ec; font-weight:700; }
+    .callout { padding:12px 15px; border-left:4px solid var(--accent); background:var(--soft); }
+    .flow { display:grid; grid-template-columns:1fr 34px 1fr 34px 1fr 34px 1fr; align-items:center; gap:6px; margin:16px 0; }
+    .node { min-height:108px; padding:13px; border:1px solid var(--line); border-radius:10px; background:#fafbfc; }
+    .arrow { color:var(--accent); text-align:center; font-size:22px; }
+    table { width:100%; border-collapse:collapse; margin:12px 0; }
+    th,td { padding:9px 11px; border:1px solid var(--line); text-align:left; vertical-align:top; }
+    th { background:#f7f8fa; }
+    .passed { color:var(--ok); font-weight:700; }
+    .limited { color:var(--warn); font-weight:700; }
+    footer { color:var(--muted); text-align:center; font-size:13px; }
+    @media (max-width:780px) { main{width:min(100% - 20px,1040px);margin-top:10px} header,section{padding:20px} .flow{grid-template-columns:1fr} .arrow{transform:rotate(90deg)} }
+  </style>
+</head>
+<body>
+<main>
+  <header>
+    <h1>管理员设置保存保留内部配置</h1>
+    <p class="lead">修复系统配置页面只保存页面白名单字段、导致 MariaDB 连接串、已激活主题等内部配置从 <code>auto.py</code> 消失的问题，同时保持接口写入白名单，并让失败保存不提前污染运行态或留下半写文件。</p>
+    <div class="meta">
+      <span class="tag status">状态：ACTIVE</span>
+      <span class="tag">创建日期：2026-08-06</span>
+      <span class="tag">所属模块：webserver</span>
+      <span class="tag">影响范围：AdminSettings、SettingsLoader、配置落盘</span>
+      <span class="tag">需求来源：Multica TAL-5 / GitHub Issue #944</span>
+    </div>
+  </header>
+
+  <section>
+    <h2>原始诉求与复现</h2>
+    <p>管理员保存任意系统配置后，现有 MariaDB <code>user_database</code> 会在重启或重新加载时恢复为默认 SQLite；<code>ACTIVE_THEME</code> 等不由该页面编辑的配置也会丢失。接口目前新建 <code>SettingsLoader</code> 后立即 <code>clear()</code>，再仅写入请求中的白名单字段，因此生成的 <code>auto.py</code> 只剩本次页面提交内容。</p>
+    <div class="callout">基线复现：只提交 <code>site_title</code> 后，生成文件仅包含 <code>installed</code> 与 <code>site_title</code>，不再包含 <code>user_database</code> 或 <code>ACTIVE_THEME</code>。</div>
+  </section>
+
+  <section>
+    <h2>目标与边界</h2>
+    <ul>
+      <li>以当前服务端完整配置为保存候选，只覆盖明确列入页面白名单或合法 <code>SOCIAL_AUTH_*</code> 模式的请求字段。</li>
+      <li>保存后 MariaDB 连接、激活主题及其它非页面配置在运行态和重新加载后保持不变。</li>
+      <li>未知字段、非完整匹配的动态键和 Python 语法型恶意键继续被忽略，不能借“保留配置”扩大客户端可写范围。</li>
+      <li><code>auto.py</code> 使用同目录临时文件、刷新并 <code>fsync</code> 后通过 <code>os.replace</code> 原子替换；异常时清理临时文件并保留原文件。</li>
+      <li>所有持久化步骤成功后才更新 <code>CONF</code>；失败响应不能留下候选运行态。</li>
+    </ul>
+    <p><strong>非目标：</strong>不重构设置页面、不改变数据库迁移流程、不新增可编辑配置项，也不把所有任意 <code>CONF</code> 键开放给请求。</p>
+  </section>
+
+  <section>
+    <h2>方案</h2>
+    <div class="flow" aria-label="配置保存流程">
+      <div class="node"><strong>读取基线</strong><br>加载默认、<code>auto.py</code> 与本地覆盖，得到完整候选。</div>
+      <div class="arrow">→</div>
+      <div class="node"><strong>过滤覆盖</strong><br>仅把白名单字段和严格匹配的社交登录键写入候选。</div>
+      <div class="arrow">→</div>
+      <div class="node"><strong>安全落盘</strong><br>派生 Nuxt 环境文件并原子写入 <code>auto.py</code>；后一步失败时恢复前一步。</div>
+      <div class="arrow">→</div>
+      <div class="node"><strong>提交运行态</strong><br>磁盘步骤全部成功后，以完整候选更新 <code>CONF</code>。</div>
+    </div>
+    <h3>保留与授权分离</h3>
+    <p>“保留已有键”是服务端基线行为；“允许客户端修改键”仍由现有 <code>KEYS</code> 与锚定的 <code>SOCIAL_AUTH_SETTING_RE</code> 决定。请求中的 <code>user_database</code>、<code>ACTIVE_THEME</code> 或构造动态键不会进入覆盖循环，但服务端已经持有的同名配置会原样留在候选中。</p>
+    <h3>失败一致性</h3>
+    <p><code>SettingsSaverLogic</code> 不再在写盘前调用 <code>CONF.update()</code>。Nuxt 环境文件按候选配置生成并保留旧快照；随后原子写入 <code>auto.py</code>。若第二步失败，使用旧快照恢复 Nuxt 环境文件；无论哪一步失败，均不提交运行态。单个配置文件的替换使用同目录临时文件，避免跨文件系统替换和进程中断导致截断。</p>
+  </section>
+
+  <section>
+    <h2>测试与验收结果</h2>
+    <table>
+      <thead><tr><th>场景</th><th>断言</th><th>结果</th></tr></thead>
+      <tbody>
+        <tr><td>保留内部配置</td><td>保存白名单字段后，落盘并重新加载仍保留 <code>user_database</code>、<code>ACTIVE_THEME</code> 和其它既有键。</td><td class="passed">通过：纯持久化测试；HTTP 集成用例已加入。</td></tr>
+        <tr><td>允许字段更新</td><td><code>site_title</code> 等白名单字段在返回值、运行态和磁盘候选中更新。</td><td class="passed">通过：运行态与 <code>auto.py</code> 均为新值。</td></tr>
+        <tr><td>危险字段</td><td>请求中的 <code>user_database</code>、<code>ACTIVE_THEME</code>、未知键及恶意动态键不能覆盖服务端既有值。</td><td class="limited">HTTP 集成用例已覆盖；本机因缺少 Calibre 未进入用例执行，待 CI 确认。</td></tr>
+        <tr><td>落盘失败</td><td>模拟原子替换失败，原 <code>auto.py</code> 内容与 <code>CONF</code> 均不改变，临时文件被清理。</td><td class="passed">通过：失败回滚与原子替换测试。</td></tr>
+        <tr><td>回归与规范</td><td>相关 pytest、Python lint/format、<code>make check-design</code>。</td><td class="passed">纯持久化测试与 Ruff 已通过；方案检查见执行记录。</td></tr>
+      </tbody>
+    </table>
+    <h3>实际执行记录</h3>
+    <ul>
+      <li><code>uv run pytest -q tests/test_settings_persistence.py</code> — <strong>通过</strong>（3 passed）。</li>
+      <li><code>uv run ruff check ./webserver --no-cache</code> — <strong>通过</strong>。</li>
+      <li><code>uv run ruff format --diff ./webserver --no-cache</code> — <strong>通过</strong>（100 files already formatted）。</li>
+      <li><code>uv run ruff check tests/test_admin.py tests/test_settings_persistence.py --no-cache</code> 与对应 format diff — <strong>通过</strong>。</li>
+      <li><code>uv run python -m py_compile webserver/loader.py webserver/handlers/admin.py tests/test_admin.py tests/test_settings_persistence.py</code> — <strong>通过</strong>。</li>
+      <li><code>uv run pytest -q tests/test_admin.py::TestAdminSettingsSecurity</code> — <strong>环境阻塞</strong>：本机未安装 Calibre，Tornado 测试服务在模块初始化阶段报 <code>No module named 'calibre'</code>，12 个用例均未进入执行；这不是业务断言失败。新增 HTTP 用例保留在套件中，由具备 Calibre 的 CI 镜像执行。</li>
+      <li><code>make check-design</code> — 转为 ACTIVE 后执行并通过。</li>
+    </ul>
+    <p>剩余风险：本机未完成真实 Tornado + Calibre 环境中的管理员 HTTP 保存回归，PR 合并前需以 CI 的后端测试结果确认；纯逻辑、持久化文件内容、运行态提交顺序、失败回滚和原子替换已在不依赖 Calibre 的测试中验证。</p>
+  </section>
+
+  <footer>Talebook 内部开发方案 · ACTIVE · TAL-5 / GitHub Issue #944</footer>
+</main>
+</body>
+</html>

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -66,6 +66,54 @@ class TestAdminSettingsSecurity(TestWithAdminUser):
         finally:
             conf["SHOW_NETWORK_LIBRARY"] = previous_show_network_library
 
+    def test_settings_update_preserves_internal_settings(self):
+        """页面保存只覆盖白名单字段，数据库、主题和其它内部配置应保留"""
+        conf = loader.get_settings()
+        tracked = {
+            "site_title": conf.get("site_title"),
+            "user_database": conf.get("user_database"),
+            "ACTIVE_THEME": conf.get("ACTIVE_THEME"),
+            "INTERNAL_ONLY_TEST_VALUE": conf.get("INTERNAL_ONLY_TEST_VALUE"),
+        }
+        had_internal_value = "INTERNAL_ONLY_TEST_VALUE" in conf
+        try:
+            conf["user_database"] = "mysql+pymysql://talebook:secret@db.example.com/books"
+            conf["ACTIVE_THEME"] = "graphite"
+            conf["INTERNAL_ONLY_TEST_VALUE"] = "keep-me"
+            with tempfile.TemporaryDirectory() as tmpdir:
+                with mock.patch("webserver.loader.SettingsLoader.set_store_path", return_value=tmpdir):
+                    req = json.dumps(
+                        {
+                            "site_title": "Updated title",
+                            "user_database": "sqlite:////tmp/attacker.db",
+                            "ACTIVE_THEME": "attacker-theme",
+                            "INTERNAL_ONLY_TEST_VALUE": "replace-me",
+                        }
+                    )
+                    d = self.json("/api/admin/settings", method="POST", body=req)
+
+                path = os.path.join(tmpdir, "auto.py")
+                namespace = {}
+                with open(path, encoding="utf-8") as f:
+                    exec(compile(f.read(), path, "exec"), namespace)
+                saved = namespace["settings"]
+
+            self.assertEqual(d["err"], "ok")
+            self.assertEqual(d["rsp"]["site_title"], "Updated title")
+            self.assertEqual(saved["site_title"], "Updated title")
+            self.assertEqual(saved["user_database"], "mysql+pymysql://talebook:secret@db.example.com/books")
+            self.assertEqual(saved["ACTIVE_THEME"], "graphite")
+            self.assertEqual(saved["INTERNAL_ONLY_TEST_VALUE"], "keep-me")
+            self.assertEqual(d["rsp"]["user_database"], saved["user_database"])
+            self.assertEqual(d["rsp"]["ACTIVE_THEME"], "graphite")
+            self.assertEqual(d["rsp"]["INTERNAL_ONLY_TEST_VALUE"], "keep-me")
+        finally:
+            for key, value in tracked.items():
+                if key == "INTERNAL_ONLY_TEST_VALUE" and not had_internal_value:
+                    conf.pop(key, None)
+                else:
+                    conf[key] = value
+
     def test_settings_update_chunk_upload_settings(self):
         """管理员可以开关分片上传功能并自定义分片阈值/分片大小"""
         conf = loader.get_settings()

--- a/tests/test_settings_persistence.py
+++ b/tests/test_settings_persistence.py
@@ -4,7 +4,7 @@
 import os
 from unittest import mock
 
-from webserver import loader
+from webserver import loader, main
 from webserver.handlers import admin
 
 
@@ -84,3 +84,20 @@ def test_settings_dumpfile_replace_failure_is_atomic(tmp_path):
     assert path.read_text(encoding="utf-8") == "original config\n"
     assert sorted(item.name for item in tmp_path.iterdir()) == ["auto.py"]
     assert remove.called
+
+
+def test_update_config_passes_current_settings_to_nuxt_writer():
+    previous_update_config = main.options.update_config
+    main.options.update_config = True
+    try:
+        with mock.patch.object(admin.SettingsSaverLogic, "update_nuxtjs_env") as update_nuxtjs_env:
+            try:
+                main.make_app()
+            except SystemExit as exc:
+                assert exc.code == 0
+            else:
+                raise AssertionError("--update-config must exit after updating the Nuxt environment")
+    finally:
+        main.options.update_config = previous_update_config
+
+    update_nuxtjs_env.assert_called_once_with(main.CONF)

--- a/tests/test_settings_persistence.py
+++ b/tests/test_settings_persistence.py
@@ -74,16 +74,34 @@ def test_settings_dumpfile_replace_failure_is_atomic(tmp_path):
     with mock.patch.object(settings, "set_store_path", return_value=str(tmp_path)):
         with mock.patch("webserver.loader.os.replace", side_effect=OSError("replace failed")):
             with mock.patch("webserver.loader.os.remove", wraps=os.remove) as remove:
-                try:
-                    settings.dumpfile()
-                except OSError:
-                    pass
-                else:
-                    raise AssertionError("replace failure must be propagated")
+                with mock.patch("webserver.loader.os.close", wraps=os.close) as close:
+                    try:
+                        settings.dumpfile()
+                    except OSError:
+                        pass
+                    else:
+                        raise AssertionError("replace failure must be propagated")
 
     assert path.read_text(encoding="utf-8") == "original config\n"
     assert sorted(item.name for item in tmp_path.iterdir()) == ["auto.py"]
     assert remove.called
+    close.assert_not_called()
+
+
+def test_atomic_write_closes_descriptor_when_fdopen_fails(tmp_path):
+    path = tmp_path / "auto.py"
+
+    with mock.patch("webserver.loader.os.fdopen", side_effect=OSError("fdopen failed")):
+        with mock.patch("webserver.loader.os.close", wraps=os.close) as close:
+            try:
+                loader.atomic_write_text(str(path), "new config\n")
+            except OSError:
+                pass
+            else:
+                raise AssertionError("fdopen failure must be propagated")
+
+    assert sorted(item.name for item in tmp_path.iterdir()) == []
+    close.assert_called_once()
 
 
 def test_update_config_passes_current_settings_to_nuxt_writer():

--- a/tests/test_settings_persistence.py
+++ b/tests/test_settings_persistence.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+
+import os
+from unittest import mock
+
+from webserver import loader
+from webserver.handlers import admin
+
+
+def _candidate(nuxt_env_path):
+    return {
+        "installed": True,
+        "site_title": "Original title",
+        "google_analytics_id": "",
+        "nuxt_env_path": str(nuxt_env_path),
+        "user_database": "mysql+pymysql://talebook:secret@db.example.com/books",
+        "ACTIVE_THEME": "graphite",
+        "INTERNAL_ONLY_TEST_VALUE": "keep-me",
+    }
+
+
+def test_settings_saver_persists_complete_candidate(tmp_path):
+    conf = _candidate(tmp_path / ".env")
+    args = loader.SettingsLoader()
+    args.clear()
+    args.update(conf)
+    args["site_title"] = "Updated title"
+
+    with mock.patch.object(admin, "CONF", conf):
+        with mock.patch.object(args, "set_store_path", return_value=str(tmp_path)):
+            result = admin.SettingsSaverLogic().save_extra_settings(args)
+
+    namespace = {}
+    path = tmp_path / "auto.py"
+    exec(compile(path.read_text(encoding="utf-8"), str(path), "exec"), namespace)
+    saved = namespace["settings"]
+
+    assert result["err"] == "ok"
+    assert conf["site_title"] == "Updated title"
+    assert saved["site_title"] == "Updated title"
+    assert saved["user_database"] == "mysql+pymysql://talebook:secret@db.example.com/books"
+    assert saved["ACTIVE_THEME"] == "graphite"
+    assert saved["INTERNAL_ONLY_TEST_VALUE"] == "keep-me"
+
+
+def test_settings_saver_failure_keeps_runtime_and_disk_config(tmp_path):
+    conf = _candidate(tmp_path / ".env")
+    args = loader.SettingsLoader()
+    args.clear()
+    args.update(conf)
+    args["site_title"] = "Must not be committed"
+    auto_path = tmp_path / "auto.py"
+    auto_path.write_text("original auto config\n", encoding="utf-8")
+    (tmp_path / ".env").write_text("original nuxt config\n", encoding="utf-8")
+
+    with mock.patch.object(admin, "CONF", conf):
+        with mock.patch.object(args, "dumpfile", side_effect=OSError("disk full")):
+            result = admin.SettingsSaverLogic().save_extra_settings(args)
+
+    assert result["err"] == "file.permission"
+    assert conf["site_title"] == "Original title"
+    assert auto_path.read_text(encoding="utf-8") == "original auto config\n"
+    assert (tmp_path / ".env").read_text(encoding="utf-8") == "original nuxt config\n"
+
+
+def test_settings_dumpfile_replace_failure_is_atomic(tmp_path):
+    settings = loader.SettingsLoader()
+    settings.clear()
+    settings["site_title"] = "new title"
+    path = tmp_path / "auto.py"
+    path.write_text("original config\n", encoding="utf-8")
+
+    with mock.patch.object(settings, "set_store_path", return_value=str(tmp_path)):
+        with mock.patch("webserver.loader.os.replace", side_effect=OSError("replace failed")):
+            with mock.patch("webserver.loader.os.remove", wraps=os.remove) as remove:
+                try:
+                    settings.dumpfile()
+                except OSError:
+                    pass
+                else:
+                    raise AssertionError("replace failure must be propagated")
+
+    assert path.read_text(encoding="utf-8") == "original config\n"
+    assert sorted(item.name for item in tmp_path.iterdir()) == ["auto.py"]
+    assert remove.called

--- a/webserver/handlers/admin.py
+++ b/webserver/handlers/admin.py
@@ -275,7 +275,7 @@ class AdminOwnerMode(BaseHandler):
 
 
 class SettingsSaverLogic:
-    def update_nuxtjs_env(self):
+    def update_nuxtjs_env(self, settings):
         # update nuxtjs .env file
         nuxtjs_env = """
 TITLE="%(site_title)s"
@@ -283,15 +283,35 @@ TITLE_TEMPLATE="%%s | %(site_title)s"
 GOOGLE_ANALYTICS_ID=%(google_analytics_id)s
 
 """
-        with open(CONF["nuxt_env_path"], "w") as f:
-            f.write(nuxtjs_env % CONF)
+        loader.atomic_write_text(settings["nuxt_env_path"], nuxtjs_env % settings)
+
+    @staticmethod
+    def _read_nuxtjs_env(path):
+        try:
+            with open(path, encoding="utf-8") as f:
+                return f.read()
+        except FileNotFoundError:
+            return None
+
+    @staticmethod
+    def _restore_nuxtjs_env(path, previous):
+        if previous is None:
+            try:
+                os.remove(path)
+            except FileNotFoundError:
+                pass
+            return
+        loader.atomic_write_text(path, previous)
 
     def save_extra_settings(self, args):
-        if args != CONF:
-            CONF.update(args)
+        args["installed"] = True
+        candidate = dict(CONF)
+        candidate.update(args)
+        nuxt_env_path = candidate["nuxt_env_path"]
 
         try:
-            self.update_nuxtjs_env()
+            previous_nuxtjs_env = self._read_nuxtjs_env(nuxt_env_path)
+            self.update_nuxtjs_env(candidate)
         except:
             logging.error(traceback.format_exc())
             return {
@@ -299,19 +319,22 @@ GOOGLE_ANALYTICS_ID=%(google_analytics_id)s
                 "msg": _("更新nuxtjs配置文件失败！请确保文件的权限为可写入！"),
             }
 
-        # don't update running environment for now
-        args["installed"] = True
         try:
             args.dumpfile()
         except:
             logging.error(traceback.format_exc())
+            try:
+                self._restore_nuxtjs_env(nuxt_env_path, previous_nuxtjs_env)
+            except:
+                logging.error("failed to roll back nuxtjs config:\n%s", traceback.format_exc())
             return {
                 "err": "file.permission",
                 "msg": _("更新磁盘配置文件失败！请确保配置文件的权限为可写入！"),
             }
 
-        # ok, it's safe to update current environment
-        CONF["installed"] = True
+        # Both files are durable now; only then expose the candidate to the running process.
+        if args != CONF:
+            CONF.update(args)
         return {"err": "ok", "rsp": args}
 
 
@@ -498,7 +521,7 @@ class AdminSettings(BaseHandler):
         ]
 
         args = loader.SettingsLoader()
-        args.clear()
+        args.update(CONF)
 
         for key, val in data.items():
             if SOCIAL_AUTH_SETTING_RE.match(key):

--- a/webserver/loader.py
+++ b/webserver/loader.py
@@ -16,21 +16,24 @@ def atomic_write_text(path, text):
     fd, temp_path = tempfile.mkstemp(dir=directory, prefix=".%s." % filename, suffix=".tmp")
     try:
         try:
-            mode = stat.S_IMODE(os.stat(path).st_mode)
-        except FileNotFoundError:
-            mode = 0o644
-        os.fchmod(fd, mode)
-        with os.fdopen(fd, "w", encoding="utf-8") as output:
+            try:
+                mode = stat.S_IMODE(os.stat(path).st_mode)
+            except FileNotFoundError:
+                mode = 0o644
+            os.fchmod(fd, mode)
+            output = os.fdopen(fd, "w", encoding="utf-8")
+        except Exception:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+            raise
+
+        with output:
             output.write(text)
             output.flush()
             os.fsync(output.fileno())
         os.replace(temp_path, path)
-    except Exception:
-        try:
-            os.close(fd)
-        except OSError:
-            pass
-        raise
     finally:
         try:
             os.remove(temp_path)

--- a/webserver/loader.py
+++ b/webserver/loader.py
@@ -4,8 +4,38 @@
 import json
 import logging
 import os
+import stat
 import sys
+import tempfile
 import traceback
+
+
+def atomic_write_text(path, text):
+    directory = os.path.dirname(path)
+    filename = os.path.basename(path)
+    fd, temp_path = tempfile.mkstemp(dir=directory, prefix=".%s." % filename, suffix=".tmp")
+    try:
+        try:
+            mode = stat.S_IMODE(os.stat(path).st_mode)
+        except FileNotFoundError:
+            mode = 0o644
+        os.fchmod(fd, mode)
+        with os.fdopen(fd, "w", encoding="utf-8") as output:
+            output.write(text)
+            output.flush()
+            os.fsync(output.fileno())
+        os.replace(temp_path, path)
+    except Exception:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        raise
+    finally:
+        try:
+            os.remove(temp_path)
+        except OSError:
+            pass
 
 
 class SettingsLoader(dict):
@@ -69,8 +99,7 @@ settings = {
         py = os.path.join(d, filename)
         pyc = os.path.join(d, filename + "c")
         logging.error("saving settings file: %s" % py)
-        with open(py, "w") as f:
-            f.write(code)
+        atomic_write_text(py, code)
         try:
             os.remove(pyc)
         except:

--- a/webserver/main.py
+++ b/webserver/main.py
@@ -202,7 +202,7 @@ def make_app():
         from webserver.handlers.admin import SettingsSaverLogic
 
         logic = SettingsSaverLogic()
-        logic.update_nuxtjs_env()
+        logic.update_nuxtjs_env(CONF)
         logging.info("done")
         sys.exit(0)
 


### PR DESCRIPTION
## 背景与根因

Closes TAL-5
Closes #944

管理员在“系统配置”页面保存任意字段时，保存逻辑会先清空新加载的配置，再只写回页面白名单字段。这样生成的 `auto.py` 会删除 `user_database`、`ACTIVE_THEME` 等非页面配置；重启或重新加载后，MariaDB 连接会回退到默认 SQLite，主题和其它内部设置也会丢失。

## 关键改动

- 以当前完整服务端配置构造保存候选，只用现有白名单和严格匹配的 `SOCIAL_AUTH_*_(KEY|SECRET)` 请求字段覆盖候选。
- 保持客户端写入权限不变：`user_database`、`ACTIVE_THEME`、未知字段及恶意动态键均不能通过该接口改写。
- 将运行态 `CONF` 更新推迟到 Nuxt 派生配置和 `auto.py` 都成功落盘之后；`auto.py` 写入失败时恢复 Nuxt 配置。
- 使用同目录临时文件、flush/fsync 和 `os.replace` 原子替换配置文件，保留既有文件权限并在失败时清理临时文件。
- 明确 `os.fdopen` 成功后的文件描述符所有权，避免写入或替换失败时重复关闭已释放且可能被其它线程复用的描述符。
- 修复生产镜像 `server.py --update-config` 路径的 Python 调用契约：显式向 Nuxt 配置写入器传入当前完整 `CONF`，不修改 Dockerfile 或 CI 调用。
- 增加 HTTP 级保留/授权边界、完整候选、失败回滚、原子替换、文件描述符所有权及 `--update-config` 回归测试。

## 用户与兼容性影响

- 保存系统配置后，既有 MariaDB、激活主题及其它非页面配置会继续保留。
- 页面白名单字段仍可正常更新，接口没有新增可写配置项。
- 配置文件会保存完整的当前服务端候选，而不是只保存本次请求中的页面字段；这是避免非页面配置丢失的预期变化。
- 未改动设置页面、数据库迁移流程、配置字段定义、Dockerfile 或 GitHub Actions 工作流。

## 实际验证

- `sudo make test` — 按项目 `AGENTS.md` 构建 Docker 测试镜像并执行全量 pytest：808 passed、20 skipped、20 warnings，68.83 秒；`tests/test_admin.py` 和包含 `--update-config`、原子替换及文件描述符所有权回归用例的 `tests/test_settings_persistence.py` 均通过。
- `sudo docker build --build-arg GIT_VERSION=v26.08.03-19-g6a9c788a-dirty --target production-spa --platform linux/amd64 -t talebook/ci-review-production-spa .` — 通过；生产镜像初始化中的 `python3 server.py --update-config` 正常完成。
- 在同一 Docker 测试镜像中执行 `make lint-py-fix` — 通过（All checks passed，100 files left unchanged）。
- 在同一 Docker 测试镜像中执行 `make lint-py` — 通过（All checks passed，100 files already formatted）。
- `ruff check tests/test_settings_persistence.py --no-cache` 与对应 format check — 通过。
- `make check-design` — 88 design document(s) passed。

## 剩余风险

测试会保存并重新加载 MariaDB 连接串，但未连接真实 MariaDB 服务或在真实数据库进程上执行重启回归。Docker 中已覆盖 Tornado + Calibre 的管理员 HTTP 保存路径、生产镜像 `--update-config` 初始化、纯逻辑、持久化文件内容、运行态提交顺序、失败回滚、原子替换和文件描述符异常路径。

## 方案文档

- [GitHub 文件](https://github.com/talebook/talebook/blob/d75e72bacc9fc460176340b7cb947e04c6a9a1b4/design/webserver/20260806-admin-settings-preserve-config.active.html)
- [RawGitHack 预览](https://raw.githack.com/talebook/talebook/d75e72bacc9fc460176340b7cb947e04c6a9a1b4/design/webserver/20260806-admin-settings-preserve-config.active.html)
