### PR TITLE
TAL-11: embed Readest as an optional web reader

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,52 @@
 # syntax=docker/dockerfile:1.6
 # ----------------------------------------
+# Readest 专用浏览器嵌入构建。源码与三个共享依赖均固定到可审计 commit；
+# 产物是 /readest/ 下的纯静态文件，运行时不增加 Node sidecar。
+FROM node:22-slim AS readest-prepared
+ARG READEST_COMMIT=40aec944b890965232810394e7acf7ae03ee52c3
+ARG FOLIATE_COMMIT=dd71f2be356563c16a23272686189fcfb45d0b82
+ARG SIMPLECC_COMMIT=5e5b56f5b82394e7df07f9171ac70f4578b24a32
+ARG JS_MDICT_COMMIT=d01bf62af872b1fbeacb2f18446460960e7400de
+
+ENV PNPM_HOME=/pnpm
+ENV PATH=$PNPM_HOME:$PATH
+ENV COREPACK_ENABLE_PROJECT_SPEC=0
+
+ADD https://github.com/hehetoshang/readest.git#${READEST_COMMIT} /readest
+ADD https://github.com/hehetoshang/foliate-js.git#${FOLIATE_COMMIT} /vendor/foliate-js
+ADD https://github.com/readest/simplecc-wasm.git#${SIMPLECC_COMMIT} /vendor/simplecc-wasm
+ADD https://github.com/readest/js-mdict.git#${JS_MDICT_COMMIT} /vendor/js-mdict
+
+WORKDIR /readest
+RUN corepack enable && corepack prepare pnpm@11.21.0 --activate
+# pnpm's normal recursive install can consider this external-workspace layout
+# current without creating package links. A deploy materializes a standalone,
+# fully linked Readest app and keeps the source checkout immutable/auditable.
+RUN --mount=type=cache,id=readest-pnpm,sharing=locked,target=/pnpm/store \
+    --mount=type=cache,id=readest-pnpm-meta,sharing=locked,target=/root/.cache/pnpm \
+    pnpm --pm-on-fail=ignore --filter @readest/readest-app deploy \
+        --prod=false --legacy --ignore-scripts --store-dir /pnpm/store /readest/apps/readest-app-deployed && \
+    test -x /readest/apps/readest-app-deployed/node_modules/.bin/mkdirp
+WORKDIR /readest/apps/readest-app-deployed
+# The deployment is already fully linked. Use npm only as a script runner so
+# pnpm does not try to reinterpret the standalone app as the original workspace.
+RUN test -f /vendor/foliate-js/vendor/pdfjs/annotation_layer_builder.css && \
+    test -x node_modules/.bin/postcss && \
+    sed -i 's/pnpm /npm run /g' package.json && \
+    npm run setup-vendors && \
+    cp /vendor/simplecc-wasm/dist/web/* public/vendor/simplecc/ && \
+    test -f public/vendor/pdfjs/pdf.min.mjs && \
+    test -f public/vendor/simplecc/simplecc_wasm.js && \
+    test -f public/vendor/jieba/jieba_rs_wasm.js
+
+FROM readest-prepared AS readest-builder
+WORKDIR /readest/apps/readest-app-deployed
+RUN npm run build-embedded-web
+COPY document/third-party/readest.md /readest/out/readest/SOURCE.md
+RUN cp /readest/LICENSE /readest/out/readest/LICENSE-AGPL-3.0.txt && test -f /readest/out/readest/index.html
+
+
+# ----------------------------------------
 # 第一阶段，拉取 node 基础镜像并安装依赖，执行构建
 FROM node:20-alpine AS builder
 ARG BUILD_COUNTRY=""
@@ -24,6 +71,8 @@ RUN npm run build-spa
 RUN rm -rf dist && cp -r .output/public dist
 RUN if [ ! -f dist/index.html ]; then cp dist/200.html dist/index.html; fi
 RUN cp -r dist package* /app-static/
+COPY --from=readest-builder /readest/out/readest /app-static/dist/readest
+COPY --from=readest-builder /readest/out/readest /app-ssr/.output/public/readest
 
 
 # ----------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,11 @@ RUN test -f /vendor/foliate-js/vendor/pdfjs/annotation_layer_builder.css && \
 
 FROM readest-prepared AS readest-builder
 WORKDIR /readest/apps/readest-app-deployed
+COPY scripts/prune-readest.sh /usr/local/bin/prune-readest
 RUN npm run build-embedded-web
 COPY document/third-party/readest.md /readest/out/readest/SOURCE.md
-RUN cp /readest/LICENSE /readest/out/readest/LICENSE-AGPL-3.0.txt && test -f /readest/out/readest/index.html
+RUN cp /readest/LICENSE /readest/out/readest/LICENSE-AGPL-3.0.txt && \
+    sh /usr/local/bin/prune-readest /readest/out/readest
 
 
 # ----------------------------------------

--- a/app/i18n/locales/en-US.json
+++ b/app/i18n/locales/en-US.json
@@ -810,6 +810,7 @@
         "chineseDir": "Use Chinese directory names (UTF8, more beautiful)",
         "oldEpubReader": "Epub Reader (Old Version)",
         "candleReader": "Candle Reader (Beta, supports chapter comments)",
+        "readestReader": "Readest",
         "none": "Disabled",
         "image": "Image CAPTCHA (no configuration needed)",
         "geetest": "GeeTest"

--- a/app/i18n/locales/zh-CN.json
+++ b/app/i18n/locales/zh-CN.json
@@ -840,6 +840,7 @@
         "chineseDir": "使用中文目录名 (UTF8 编码，更美观)",
         "oldEpubReader": "Epub Reader（旧版）",
         "candleReader": "Candle Reader（Beta 版，支持章评功能）",
+        "readestReader": "Readest",
         "none": "不启用",
         "image": "图形验证码 (无需配置)",
         "geetest": "GeeTest (极验)"

--- a/app/pages/admin/settings.vue
+++ b/app/pages/admin/settings.vue
@@ -993,7 +993,7 @@ const cards = computed(() => [
                 items: [{text: t('admin.settings.option.pinyinDir'), value: 'en'}, {text: t('admin.settings.option.chineseDir'), value: 'utf8'} ]
             },
             { icon: 'mdi-information', key: 'EPUB_VIEWER', label: t('admin.settings.label.epubViewer'), type: 'select',
-                items: [{text: t('admin.settings.option.oldEpubReader'), value: 'epubjs.html'}, {text: t('admin.settings.option.candleReader'), value: 'creader.html'} ]
+                items: [{text: t('admin.settings.option.oldEpubReader'), value: 'epubjs.html'}, {text: t('admin.settings.option.candleReader'), value: 'creader.html'}, {text: t('admin.settings.option.readestReader'), value: 'readest.html'} ]
             },
             { icon: 'mdi-information', key: 'avatar_service', label: t('admin.settings.label.avatarService') },
             { icon: 'mdi-information', key: 'MAX_UPLOAD_SIZE', label: t('admin.settings.label.maxUploadSize') },

--- a/app/test/e2e/settings.spec.ts
+++ b/app/test/e2e/settings.spec.ts
@@ -49,6 +49,18 @@ test.describe('Admin Settings (GitHub-style layout)', () => {
         await expect(page.getByLabel('每本有声书保留的历史版本数')).toHaveValue('3');
     });
 
+    test('高级设置可选择 Readest 并保留旧 EPUB 阅读器', async ({ page }) => {
+        await page.goto('/admin/settings');
+        await expect(page.locator('.loading-page')).toBeHidden({ timeout: 10000 });
+
+        await page.locator('.settings-nav-item', { hasText: '高级配置项' }).click();
+        await page.getByRole('combobox', { name: 'EPUB 阅读器' }).press('ArrowDown');
+
+        await expect(page.getByRole('option', { name: 'Readest' })).toBeVisible();
+        await expect(page.getByRole('option', { name: /Candle Reader/ })).toBeVisible();
+        await expect(page.getByRole('option', { name: /Epub Reader/ })).toBeVisible();
+    });
+
     test('基础信息中默认启用并可保存关闭网络书库展示开关', async ({ page }) => {
         await page.goto('/admin/settings');
         await expect(page.locator('.loading-page')).toBeHidden();

--- a/design/app/20260810-embedded-readest.active.html
+++ b/design/app/20260810-embedded-readest.active.html
@@ -50,7 +50,7 @@
         <h1>Talebook 同源嵌入 Readest</h1>
         <p>在保留 `/read/{id}` 权限入口、转换流程和旧阅读器回退的前提下，构建专用 Readest 静态产物并由 Talebook 镜像同源托管。</p>
         <div class="meta">
-          <span class="chip wip">状态：WIP</span>
+          <span class="chip">状态：ACTIVE</span>
           <span class="chip">创建日期：2026-08-10</span>
           <span class="chip">所属模块：app（跨 webserver / Docker）</span>
           <span class="chip">需求来源：TAL-11</span>
@@ -59,14 +59,14 @@
 
       <section>
         <h2>1. 原始诉求</h2>
-        <div class="warn">“让 Talebook Web 端可直接使用 Moke 维护的 Readest 阅读器，同时保留现有权限、历史、转换和旧阅读器回退能力；不要求用户另行部署或登录 Readest 云服务。”</div>
+        <div class="warn">“让 Talebook Web 端可直接使用 Moke 维护的 Readest 阅读器，同时保留现有权限、历史、转换和旧阅读器回退能力；不要求用户另行部署或登录 Readest 云服务。” PR 评审进一步要求解决启用构建后静态产物增加约 155.1 MiB、明显大于 Candle Reader 的问题。</div>
         <p>首期聚焦 EPUB 与现有 MOBI/AZW/AZW3 转 EPUB 路径。PDF、TXT 保持原阅读器，直至 Range、内存、编码和定位能力达到同等可靠性。</p>
       </section>
 
       <section>
         <h2>2. 目标与边界</h2>
         <div class="grid">
-          <article class="box"><h3>目标</h3><ul><li>后台新增 Readest 选项，默认仍为 Candle Reader。</li><li>书籍内容只从同源、受阅读权限保护的接口进入浏览器 Blob。</li><li>登录用户保存并恢复 <code>moke.readest.progress.v1</code>。</li><li>转换、资源缺失、内容错误均有明确状态与旧阅读器入口。</li></ul></article>
+          <article class="box"><h3>目标</h3><ul><li>后台新增 Readest 选项，默认仍为 Candle Reader。</li><li>书籍内容只从同源、受阅读权限保护的接口进入浏览器 Blob。</li><li>登录用户保存并恢复 <code>moke.readest.progress.v1</code>。</li><li>裁剪后静态产物不超过 50 MiB，并由构建门禁阻止体积回涨。</li><li>转换、资源缺失、内容错误均有明确状态与旧阅读器入口。</li></ul></article>
           <article class="box"><h3>非目标</h3><ul><li>不引入 Readest 账号、云同步、支付或外部存储。</li><li>不改变 PDF.js 与 TXT 阅读路径。</li><li>不承诺 Readest 笔记跨端同步。</li><li>不把 Readest AGPL 源码并入 Talebook 的 BSD 许可声明。</li></ul></article>
         </div>
       </section>
@@ -95,7 +95,9 @@
             <tr><td>下载接口要求 <code>can_save</code>，不能用于仅有阅读权限的用户。</td><td><code>webserver/handlers/book.py:1019</code></td><td>新增只服务 EPUB 的阅读内容流，复用 <code>can_view_book</code> 与阅读权限。</td></tr>
             <tr><td>Readest Web 默认拒绝 <code>file=</code>，但 Web AppService 可导入浏览器 <code>File</code>。</td><td><code>apps/readest-app/src/helpers/openWith.ts</code></td><td>仅在 <code>talebook=1</code> 时接收同源 Blob URL，拒绝任意 HTTP URL。</td></tr>
             <tr><td>Readest 可静态导出，但 Web 动态分享路由需嵌入构建分支。</td><td><code>next.config.mjs</code> 与实际 <code>build-embedded-web</code></td><td>专用环境保持 Web 存储能力，关闭 runtime config/PWA，并输出到 <code>out/readest</code>。</td></tr>
-            <tr><td>当前静态产物约 156 MiB。</td><td>本地 <code>du -sh out/readest</code></td><td>本期不切换默认阅读器；PR 评审镜像增量后再决定后续瘦身。</td></tr>
+            <tr><td>原始静态产物为 156 MiB，其中 186 个 sourcemap 共 105,934,986 字节。</td><td>固定 commit 本地执行 <code>build-embedded-web</code> 后逐文件统计</td><td>生产镜像不分发调试映射；保留编译后的 JS、CSS、WASM 与语言资源。</td></tr>
+            <tr><td><code>vendor/pdfjs</code> 占 5,247,446 字节。</td><td>Talebook 格式矩阵只把 EPUB 与转码后的 EPUB 交给 Readest</td><td>裁剪 PDF.js 公共运行资源；PDF 仍由 Talebook 既有阅读器处理。</td></tr>
+            <tr><td>仅删除 sourcemap 与 PDF.js 公共资源后预计约 47 MiB。</td><td>原始固定构建的文件字节数差额</td><td>设置 50 MiB 硬上限并验证入口、阅读页、中英文资源、分词与简繁转换资源仍存在。</td></tr>
           </tbody>
         </table></div>
       </section>
@@ -111,7 +113,14 @@
         <h3>阅读器选择与回退</h3>
         <p><code>EPUB_VIEWER=readest.html</code> 启用新路径；<code>?reader=creader</code> 和 <code>?reader=epubjs</code> 是受控覆盖。管理员切回配置不需要迁移数据。</p>
         <h3>构建拓扑</h3>
-        <p>Talebook 固定 Readest fork 及其 foliate-js、simplecc-wasm、js-mdict 依赖 commit。Docker 的独立 Node 24 build stage 生成静态产物，再复制到 SPA 和 SSR 都会托管的前端 public 根目录。运行时不启动额外 Node 服务。</p>
+        <p>Talebook 固定 Readest fork 及其 foliate-js、simplecc-wasm、js-mdict 依赖 commit。Docker 的独立 Node 22 build stage 生成静态产物，复制许可说明后运行仓库内裁剪脚本，最后才复制到 SPA 和 SSR 托管目录。裁剪脚本删除生产环境不需要的 sourcemap 与 EPUB-only 接入不会访问的 <code>vendor/pdfjs</code>，校验核心文件并以 50 MiB 为失败阈值；运行时不增加 Node sidecar。</p>
+        <h3>评审反馈 grill 结论</h3>
+        <ul>
+          <li><strong>体积口径：</strong>以构建目录内所有常规文件的原始字节和为门禁口径，不用镜像层压缩率掩盖静态产物膨胀。</li>
+          <li><strong>功能边界：</strong>继续保留 Readest 的 EPUB 阅读、主题、全部语言包、结巴分词、简繁转换和浏览器数据库；不为追求 8 MiB 猜测性删除共享 chunk。</li>
+          <li><strong>PDF 边界：</strong>Talebook 不向 Readest 传入 PDF，因此只移除静态导出中的 PDF.js 公共运行目录；Readest 编译所需依赖和 Talebook 原 PDF 阅读路径均不变。</li>
+          <li><strong>回归约束：</strong>脚本必须在缺失核心文件或超过 50 MiB 时失败，并通过独立测试覆盖裁剪、幂等与超限场景。</li>
+        </ul>
       </section>
 
       <section>
@@ -122,6 +131,7 @@
           <li>Readest 嵌入参数只接受父页创建的同源 Blob URL；浏览器进度写入固定到当前 origin。</li>
           <li>Readest 继续以 AGPLv3 独立作品和源码 commit 分发；镜像包含其许可证、源码地址、精确 commit 与第三方依赖声明。Talebook 自有代码继续 BSD-2-Clause。</li>
           <li>Readest 构建资源缺失时不静默白屏；用户可立即返回 Candle Reader。默认配置保持 Candle Reader。</li>
+          <li>裁剪只作用于临时构建输出，不修改固定上游源码；AGPL 许可和精确源码说明继续随产物分发。</li>
         </ul>
       </section>
 
@@ -131,10 +141,11 @@
           <thead><tr><th>层级</th><th>覆盖</th><th>当前结果</th></tr></thead>
           <tbody>
             <tr><td>Readest 单元</td><td>同源 Blob 接收、恶意 URL 拒绝、浏览器进度 POST</td><td class="good">30 项定向测试通过</td></tr>
-            <tr><td>Readest 静态构建</td><td>Web AppService + export、basePath、无 runtime sidecar</td><td class="good"><code>build-embedded-web</code> 通过，15 个静态页面</td></tr>
-            <tr><td>Talebook 后端</td><td>权限矩阵、内容类型、格式分流、转换等待、回退</td><td class="good">完整后端测试 91 项通过、1 项跳过；Ruff 通过</td></tr>
-            <tr><td>Talebook 前端</td><td>后台选项与双语文案</td><td class="good">Chromium 定向用例 1 项通过；ESLint 0 错误（193 条既有警告）</td></tr>
-            <tr><td>生产镜像</td><td>SPA/SSR 资源复制、amd64/arm64 Dockerfile 语义</td><td class="good">builder 与 <code>docker build --check</code> 通过；两类产物均含 155.1 MiB Readest 与许可文件</td></tr>
+            <tr><td>Readest 静态构建</td><td>Web AppService + export、basePath、无 runtime sidecar、裁剪后体积</td><td class="good"><code>build-embedded-web</code> 通过并输出 15 个页面；裁剪 186 个 sourcemap 与 PDF.js 公共目录后为 49,310,615 字节（约 47.0 MiB），低于 50 MiB 门禁</td></tr>
+            <tr><td>裁剪回归</td><td>核心资源前置校验、裁剪、幂等、超限失败、Docker 复制顺序</td><td class="good"><code>tests/test_readest_build.py</code> 4 项通过；连同 Docker 阶段测试共 14 项通过</td></tr>
+            <tr><td>Talebook 后端</td><td>权限矩阵、内容类型、格式分流、转换等待、回退及完整回归</td><td class="good"><code>make pytest</code>：886 项通过、1 项跳过；<code>make lint-py</code> 通过</td></tr>
+            <tr><td>Talebook 前端</td><td>后台选项、双语文案与 lint</td><td class="good">既有 Chromium 定向用例 1 项通过；本轮 ESLint 0 错误（193 条既有警告）</td></tr>
+            <tr><td>生产镜像</td><td>SPA/SSR 资源复制、Dockerfile 裁剪顺序</td><td>任务禁止访问 Docker Unix socket，未执行镜像构建；以固定源码的等价本地 Node 构建、真实裁剪结果和 Dockerfile 顺序测试替代，剩余风险为实际 BuildKit 环境差异</td></tr>
             <tr><td>真实浏览器</td><td>桌面/移动 EPUB、恢复、错误、转换与回退截图</td><td class="pending">后台选择器已在 Chromium 验证；完整阅读器场景待集成环境补测</td></tr>
           </tbody>
         </table></div>
@@ -146,8 +157,9 @@
           <li>选择静态产物同源托管，不采用 Next.js sidecar。</li>
           <li>不复用下载接口，避免把“可阅读”错误收紧为“可下载”。</li>
           <li>不直接把书籍 HTTP URL交给 Readest；由 Talebook 父页校验并转为 Blob。</li>
-          <li>本期不改变默认阅读器，原因是静态产物体积与外部 fork 稳定性仍需真实镜像评审。</li>
-          <li>最终测试无相关失败后，本文件已定稿为 <code>.active.html</code>。</li>
+          <li>本期不改变默认阅读器；体积门禁解决镜像无界增长，但外部 fork 的功能稳定性仍需继续评审。</li>
+          <li>评审反馈后不另建方案，恢复同一文件为 WIP 并在这里记录体积分析、裁剪边界和验证结果。</li>
+          <li>相关自动化、完整固定源码构建与 50 MiB 门禁均通过，本文件转为 <code>.active.html</code>。</li>
         </ol>
       </section>
     </main>

--- a/design/app/20260810-embedded-readest.active.html
+++ b/design/app/20260810-embedded-readest.active.html
@@ -1,0 +1,155 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Talebook 同源嵌入 Readest 的架构、权限、构建、回退与验证方案。" />
+    <link rel="icon" href="data:," />
+    <title>Talebook 同源嵌入 Readest</title>
+    <style>
+      :root { color-scheme: light; --bg:#f4f7f8; --panel:#fff; --ink:#17232b; --muted:#52636f; --line:#cfdae0; --accent:#176b68; --soft:#e7f4f2; --warn:#9b5b09; --warn-soft:#fff4dd; --ok:#176744; --ok-soft:#e6f5ed; }
+      * { box-sizing:border-box; }
+      body { margin:0; color:var(--ink); background:linear-gradient(150deg,#edf7f6,var(--bg) 35%); font:15px/1.65 system-ui,-apple-system,"Segoe UI","PingFang SC","Microsoft YaHei",sans-serif; }
+      main { width:min(1080px,calc(100vw - 28px)); margin:0 auto; padding:28px 0 56px; }
+      header,section { margin-bottom:18px; padding:24px 28px; border:1px solid var(--line); border-radius:18px; background:var(--panel); box-shadow:0 10px 28px rgba(30,55,65,.07); }
+      header { border-top:6px solid var(--accent); }
+      h1 { margin:0 0 10px; font-size:clamp(30px,5vw,48px); line-height:1.12; }
+      h2 { margin:0 0 14px; font-size:22px; }
+      h3 { margin:20px 0 8px; font-size:17px; }
+      p { margin:0 0 12px; }
+      ul,ol { margin:8px 0 0 22px; padding:0; }
+      li + li { margin-top:6px; }
+      code { padding:.12em .35em; border-radius:5px; background:#eef2f4; font-family:ui-monospace,SFMono-Regular,Consolas,monospace; overflow-wrap:anywhere; }
+      .meta { display:flex; flex-wrap:wrap; gap:8px; margin-top:18px; }
+      .chip { padding:5px 10px; border-radius:999px; background:#edf2f4; color:var(--muted); font-size:12px; font-weight:700; }
+      .chip.wip { color:var(--warn); background:var(--warn-soft); }
+      .grid { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:14px; }
+      .box { padding:16px; border:1px solid var(--line); border-radius:14px; background:#fbfcfd; }
+      .box h3 { margin-top:0; }
+      .flow { display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); gap:10px; margin-top:14px; }
+      .step { padding:15px; border:1px solid #b9d8d4; border-radius:13px; background:var(--soft); }
+      .step b { display:block; margin-bottom:5px; }
+      .table-wrap { overflow-x:auto; border:1px solid var(--line); border-radius:13px; }
+      table { width:100%; min-width:760px; border-collapse:collapse; }
+      th,td { padding:10px 12px; border-right:1px solid var(--line); border-bottom:1px solid var(--line); text-align:left; vertical-align:top; }
+      th { background:#f1f5f6; color:#40515c; font-size:12px; }
+      tr:last-child td { border-bottom:0; }
+      th:last-child,td:last-child { border-right:0; }
+      .warn,.good { padding:13px 15px; border-radius:12px; }
+      .warn { color:#6f430b; background:var(--warn-soft); border:1px solid #efd5a7; }
+      .good { color:var(--ok); background:var(--ok-soft); border:1px solid #b8dcc8; }
+      .pending { color:var(--warn); font-weight:800; }
+      @media (max-width:760px) { main { width:calc(100vw - 18px); padding-top:10px; } header,section { padding:20px 18px; border-radius:15px; } .grid,.flow { grid-template-columns:1fr; } }
+      @media (prefers-reduced-motion:reduce) { * { scroll-behavior:auto !important; } }
+      @media print { body { background:#fff; } main { width:100%; } header,section { box-shadow:none; break-inside:avoid; } }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>Talebook 同源嵌入 Readest</h1>
+        <p>在保留 `/read/{id}` 权限入口、转换流程和旧阅读器回退的前提下，构建专用 Readest 静态产物并由 Talebook 镜像同源托管。</p>
+        <div class="meta">
+          <span class="chip wip">状态：WIP</span>
+          <span class="chip">创建日期：2026-08-10</span>
+          <span class="chip">所属模块：app（跨 webserver / Docker）</span>
+          <span class="chip">需求来源：TAL-11</span>
+        </div>
+      </header>
+
+      <section>
+        <h2>1. 原始诉求</h2>
+        <div class="warn">“让 Talebook Web 端可直接使用 Moke 维护的 Readest 阅读器，同时保留现有权限、历史、转换和旧阅读器回退能力；不要求用户另行部署或登录 Readest 云服务。”</div>
+        <p>首期聚焦 EPUB 与现有 MOBI/AZW/AZW3 转 EPUB 路径。PDF、TXT 保持原阅读器，直至 Range、内存、编码和定位能力达到同等可靠性。</p>
+      </section>
+
+      <section>
+        <h2>2. 目标与边界</h2>
+        <div class="grid">
+          <article class="box"><h3>目标</h3><ul><li>后台新增 Readest 选项，默认仍为 Candle Reader。</li><li>书籍内容只从同源、受阅读权限保护的接口进入浏览器 Blob。</li><li>登录用户保存并恢复 <code>moke.readest.progress.v1</code>。</li><li>转换、资源缺失、内容错误均有明确状态与旧阅读器入口。</li></ul></article>
+          <article class="box"><h3>非目标</h3><ul><li>不引入 Readest 账号、云同步、支付或外部存储。</li><li>不改变 PDF.js 与 TXT 阅读路径。</li><li>不承诺 Readest 笔记跨端同步。</li><li>不把 Readest AGPL 源码并入 Talebook 的 BSD 许可声明。</li></ul></article>
+        </div>
+      </section>
+
+      <section>
+        <h2>3. 用户与格式矩阵</h2>
+        <div class="table-wrap"><table>
+          <thead><tr><th>场景</th><th>Readest</th><th>权限</th><th>失败与回退</th></tr></thead>
+          <tbody>
+            <tr><td>EPUB</td><td>直接加载归档 Blob</td><td>沿用可见性与在线阅读权限</td><td>显示错误并链接 Candle Reader</td></tr>
+            <tr><td>MOBI / AZW / AZW3</td><td>等待服务器生成 EPUB 后加载</td><td>与 EPUB 相同</td><td>转换超时可刷新或回退</td></tr>
+            <tr><td>PDF</td><td>本期不接入</td><td>保持原下载权限检查</td><td>继续 PDF.js</td></tr>
+            <tr><td>TXT</td><td>本期不接入</td><td>保持原规则</td><td>继续文本阅读页</td></tr>
+            <tr><td>匿名用户</td><td>受 <code>ALLOW_GUEST_READ</code> 控制</td><td>不要求下载权限</td><td>不读写账号进度</td></tr>
+            <tr><td>登录用户</td><td>可保存/恢复精确位置</td><td>激活状态与 <code>can_read</code> 不变</td><td>旧 schema 或书籍 ID 不符时忽略</td></tr>
+          </tbody>
+        </table></div>
+      </section>
+
+      <section>
+        <h2>4. 技术证据与门禁</h2>
+        <div class="table-wrap"><table>
+          <thead><tr><th>观察</th><th>证据</th><th>决策</th></tr></thead>
+          <tbody>
+            <tr><td>Talebook 的 EPUB 入口已集中完成权限、历史与格式分流。</td><td><code>webserver/handlers/book.py:1605</code></td><td>继续以 <code>/read/{id}</code> 为唯一入口。</td></tr>
+            <tr><td>下载接口要求 <code>can_save</code>，不能用于仅有阅读权限的用户。</td><td><code>webserver/handlers/book.py:1019</code></td><td>新增只服务 EPUB 的阅读内容流，复用 <code>can_view_book</code> 与阅读权限。</td></tr>
+            <tr><td>Readest Web 默认拒绝 <code>file=</code>，但 Web AppService 可导入浏览器 <code>File</code>。</td><td><code>apps/readest-app/src/helpers/openWith.ts</code></td><td>仅在 <code>talebook=1</code> 时接收同源 Blob URL，拒绝任意 HTTP URL。</td></tr>
+            <tr><td>Readest 可静态导出，但 Web 动态分享路由需嵌入构建分支。</td><td><code>next.config.mjs</code> 与实际 <code>build-embedded-web</code></td><td>专用环境保持 Web 存储能力，关闭 runtime config/PWA，并输出到 <code>out/readest</code>。</td></tr>
+            <tr><td>当前静态产物约 156 MiB。</td><td>本地 <code>du -sh out/readest</code></td><td>本期不切换默认阅读器；PR 评审镜像增量后再决定后续瘦身。</td></tr>
+          </tbody>
+        </table></div>
+      </section>
+
+      <section>
+        <h2>5. 架构与数据流</h2>
+        <div class="flow">
+          <div class="step"><b>1. 权限入口</b><span><code>/read/{id}</code> 完成游客、账号、可见性、历史和格式判断。</span></div>
+          <div class="step"><b>2. 内容预取</b><span>Readest 启动页轮询受保护 EPUB 流，校验 HTTP、大小与 ZIP 魔数。</span></div>
+          <div class="step"><b>3. 同源嵌入</b><span>父页创建 Blob URL，Readest 仅将同源 Blob 转为临时 <code>File</code>。</span></div>
+          <div class="step"><b>4. 进度闭环</b><span>恢复经 schema/book-id 校验；翻页由同源 <code>fetch</code> 节流保存。</span></div>
+        </div>
+        <h3>阅读器选择与回退</h3>
+        <p><code>EPUB_VIEWER=readest.html</code> 启用新路径；<code>?reader=creader</code> 和 <code>?reader=epubjs</code> 是受控覆盖。管理员切回配置不需要迁移数据。</p>
+        <h3>构建拓扑</h3>
+        <p>Talebook 固定 Readest fork 及其 foliate-js、simplecc-wasm、js-mdict 依赖 commit。Docker 的独立 Node 24 build stage 生成静态产物，再复制到 SPA 和 SSR 都会托管的前端 public 根目录。运行时不启动额外 Node 服务。</p>
+      </section>
+
+      <section>
+        <h2>6. 安全、许可与运维</h2>
+        <ul>
+          <li>内容端点不接受文件路径参数，只从书籍 ID 解析 Calibre 已登记的 EPUB 路径；返回 <code>application/epub+zip</code>。</li>
+          <li>启动页拒绝重定向、HTML/JSON、非 ZIP 内容、空文件和超过 512 MiB 的响应。</li>
+          <li>Readest 嵌入参数只接受父页创建的同源 Blob URL；浏览器进度写入固定到当前 origin。</li>
+          <li>Readest 继续以 AGPLv3 独立作品和源码 commit 分发；镜像包含其许可证、源码地址、精确 commit 与第三方依赖声明。Talebook 自有代码继续 BSD-2-Clause。</li>
+          <li>Readest 构建资源缺失时不静默白屏；用户可立即返回 Candle Reader。默认配置保持 Candle Reader。</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>7. 测试与验收</h2>
+        <div class="table-wrap"><table>
+          <thead><tr><th>层级</th><th>覆盖</th><th>当前结果</th></tr></thead>
+          <tbody>
+            <tr><td>Readest 单元</td><td>同源 Blob 接收、恶意 URL 拒绝、浏览器进度 POST</td><td class="good">30 项定向测试通过</td></tr>
+            <tr><td>Readest 静态构建</td><td>Web AppService + export、basePath、无 runtime sidecar</td><td class="good"><code>build-embedded-web</code> 通过，15 个静态页面</td></tr>
+            <tr><td>Talebook 后端</td><td>权限矩阵、内容类型、格式分流、转换等待、回退</td><td class="good">完整后端测试 91 项通过、1 项跳过；Ruff 通过</td></tr>
+            <tr><td>Talebook 前端</td><td>后台选项与双语文案</td><td class="good">Chromium 定向用例 1 项通过；ESLint 0 错误（193 条既有警告）</td></tr>
+            <tr><td>生产镜像</td><td>SPA/SSR 资源复制、amd64/arm64 Dockerfile 语义</td><td class="good">builder 与 <code>docker build --check</code> 通过；两类产物均含 155.1 MiB Readest 与许可文件</td></tr>
+            <tr><td>真实浏览器</td><td>桌面/移动 EPUB、恢复、错误、转换与回退截图</td><td class="pending">后台选择器已在 Chromium 验证；完整阅读器场景待集成环境补测</td></tr>
+          </tbody>
+        </table></div>
+      </section>
+
+      <section>
+        <h2>8. 决策记录</h2>
+        <ol>
+          <li>选择静态产物同源托管，不采用 Next.js sidecar。</li>
+          <li>不复用下载接口，避免把“可阅读”错误收紧为“可下载”。</li>
+          <li>不直接把书籍 HTTP URL交给 Readest；由 Talebook 父页校验并转为 Blob。</li>
+          <li>本期不改变默认阅读器，原因是静态产物体积与外部 fork 稳定性仍需真实镜像评审。</li>
+          <li>最终测试无相关失败后，本文件已定稿为 <code>.active.html</code>。</li>
+        </ol>
+      </section>
+    </main>
+  </body>
+</html>

--- a/document/third-party/readest.md
+++ b/document/third-party/readest.md
@@ -1,0 +1,16 @@
+# Readest source and license notice
+
+The `/readest/` browser application included in Talebook container images is a separately built distribution of Readest, licensed under GNU AGPLv3.
+
+- Source repository: https://github.com/hehetoshang/readest
+- Exact source commit: `40aec944b890965232810394e7acf7ae03ee52c3`
+- Integration pull request: https://github.com/hehetoshang/readest/pull/8
+- License included beside the application: `LICENSE-AGPL-3.0.txt`
+
+Build inputs are pinned in the Talebook `Dockerfile`:
+
+- `hehetoshang/foliate-js` at `dd71f2be356563c16a23272686189fcfb45d0b82`
+- `readest/simplecc-wasm` at `5e5b56f5b82394e7df07f9171ac70f4578b24a32`
+- `readest/js-mdict` at `d01bf62af872b1fbeacb2f18446460960e7400de`
+
+Talebook's own BSD-2-Clause license does not replace or relicense Readest or its dependencies. Operators who modify and make the embedded Readest application available over a network must satisfy the corresponding-source obligations of AGPLv3 for their modified version.

--- a/scripts/prune-readest.sh
+++ b/scripts/prune-readest.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+
+set -eu
+
+output_dir=${1:-}
+max_bytes=${READEST_MAX_BYTES:-52428800}
+
+if [ -z "$output_dir" ] || [ ! -d "$output_dir" ]; then
+    echo "usage: prune-readest.sh <readest-output-directory>" >&2
+    exit 2
+fi
+
+case "$max_bytes" in
+    ''|*[!0-9]*)
+        echo "READEST_MAX_BYTES must be a positive integer" >&2
+        exit 2
+        ;;
+esac
+
+if [ "$max_bytes" -eq 0 ]; then
+    echo "READEST_MAX_BYTES must be a positive integer" >&2
+    exit 2
+fi
+
+for required_path in \
+    index.html \
+    reader.html \
+    _next \
+    locales/en/translation.json \
+    locales/zh-CN/translation.json \
+    vendor/jieba/jieba_rs_wasm_bg.wasm \
+    vendor/simplecc/simplecc_wasm_bg.wasm \
+    LICENSE-AGPL-3.0.txt \
+    SOURCE.md
+do
+    if [ ! -e "$output_dir/$required_path" ]; then
+        echo "Readest output is missing required path: $required_path" >&2
+        exit 1
+    fi
+done
+
+map_count=$(find "$output_dir" -type f -name '*.map' | wc -l | tr -d ' ')
+find "$output_dir" -type f -name '*.map' -delete
+
+# Talebook only sends EPUB files to Readest. PDF continues to use Talebook's
+# existing PDF reader, so these runtime-only PDF.js assets are unreachable.
+if [ -d "$output_dir/vendor/pdfjs" ]; then
+    find "$output_dir/vendor/pdfjs" -depth -delete
+fi
+
+size_bytes=$(
+    find "$output_dir" -type f -exec stat -c '%s' {} + \
+        | awk '{ total += $1 } END { print total + 0 }'
+)
+
+if [ "$size_bytes" -gt "$max_bytes" ]; then
+    echo "Readest output is $size_bytes bytes; limit is $max_bytes bytes" >&2
+    exit 1
+fi
+
+echo "Readest output pruned: removed $map_count sourcemaps; $size_bytes bytes remain (limit $max_bytes)"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -282,6 +282,20 @@ class TestAppWithoutLogin(TestApp):
         rsp = self.fetch("/api/book/1.epub", follow_redirects=False)
         self.assertEqual(rsp.code, 302)
 
+    def test_guest_read_content_uses_read_permission_not_download_permission(self):
+        original_read = main.CONF["ALLOW_GUEST_READ"]
+        original_download = main.CONF["ALLOW_GUEST_DOWNLOAD"]
+        try:
+            main.CONF["ALLOW_GUEST_READ"] = True
+            main.CONF["ALLOW_GUEST_DOWNLOAD"] = False
+            rsp = self.fetch("/read/%d/content.epub" % BID_EPUB, follow_redirects=False)
+            self.assertEqual(rsp.code, 200)
+            self.assertEqual(rsp.headers["Content-Type"], "application/epub+zip")
+            self.assertTrue(rsp.body.startswith(b"PK"))
+        finally:
+            main.CONF["ALLOW_GUEST_READ"] = original_read
+            main.CONF["ALLOW_GUEST_DOWNLOAD"] = original_download
+
     def test_push(self):
         d = self.json("/api/book/1/mailto", method="POST", body=json.dumps({"email": "unittest@gmail.com"}))
         self.assertEqual(d["err"], "user.need_login")
@@ -660,6 +674,38 @@ class TestBook(TestWithUserLogin):
             for bid in BIDS:
                 rsp = self.fetch("/read/%s" % bid, follow_redirects=False)
                 self.assertEqual(rsp.code, 302 if bid == BID_PDF or bid == BID_TXT else 200)
+
+    def test_readest_launch_and_explicit_legacy_fallback(self):
+        with mock.patch.dict(webserver.handlers.book.CONF, {"EPUB_VIEWER": "readest.html"}):
+            rsp = self.fetch("/read/%d" % BID_EPUB)
+            body = rsp.body.decode("utf-8")
+            self.assertEqual(rsp.code, 200)
+            self.assertIn("/read/1/content.epub", body)
+            self.assertIn("talebook", body)
+            self.assertIn("/read/1?reader=creader", body)
+
+            rsp = self.fetch("/read/%d?reader=creader" % BID_EPUB)
+            body = rsp.body.decode("utf-8")
+            self.assertEqual(rsp.code, 200)
+            self.assertIn("candle-reader.es.js", body)
+            self.assertNotIn("/read/1/content.epub", body)
+
+    def test_read_content_does_not_require_download_permission(self):
+        with mock_permission() as user:
+            user.set_permission("S")
+            rsp = self.fetch("/read/%d/content.epub" % BID_EPUB)
+            self.assertEqual(rsp.code, 200)
+            self.assertEqual(rsp.headers["Content-Type"], "application/epub+zip")
+            self.assertEqual(rsp.headers["Cache-Control"], "private, no-store")
+            self.assertEqual(rsp.headers["X-Content-Type-Options"], "nosniff")
+
+            partial = self.fetch("/read/%d/content.epub" % BID_EPUB, headers={"Range": "bytes=0-3"})
+            self.assertEqual(partial.code, 206)
+            self.assertEqual(partial.headers["Content-Range"], "bytes 0-3/%d" % len(rsp.body))
+            self.assertEqual(partial.body, rsp.body[:4])
+
+            download = self.fetch("/api/book/%d.epub" % BID_EPUB)
+            self.assertEqual(download.code, 403)
 
     def test_read_waits_for_conversion(self):
         with mock.patch("webserver.services.convert.ConvertService.convert_and_save", return_value="Yo"):
@@ -1249,6 +1295,12 @@ class TestBookDetailScope(TestApp):
         with temporary_book_scope(BID_EPUB, "private", collector_id=1):
             with mock.patch.object(BaseHandler, "user_id", return_value=2):
                 rsp = self.fetch("/read/%d" % BID_EPUB)
+                self.assertEqual(rsp.code, 404)
+
+    def test_other_user_cannot_read_private_epub_archive_by_direct_url(self):
+        with temporary_book_scope(BID_EPUB, "private", collector_id=1):
+            with mock.patch.object(BaseHandler, "user_id", return_value=2):
+                rsp = self.fetch("/read/%d/content.epub" % BID_EPUB)
                 self.assertEqual(rsp.code, 404)
 
     def test_other_user_cannot_read_private_epub_content_by_direct_url(self):

--- a/tests/test_readest_build.py
+++ b/tests/test_readest_build.py
@@ -1,0 +1,94 @@
+import os
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PRUNE_SCRIPT = ROOT / "scripts" / "prune-readest.sh"
+
+
+def prepare_readest_output(tmp_path: Path) -> Path:
+    output = tmp_path / "readest"
+    files = {
+        "index.html": "Readest",
+        "reader.html": "reader",
+        "_next/static/chunks/app.js": "console.log('reader')",
+        "_next/static/chunks/app.js.map": "debug symbols",
+        "locales/en/translation.json": "{}",
+        "locales/zh-CN/translation.json": "{}",
+        "vendor/jieba/jieba_rs_wasm_bg.wasm": "jieba",
+        "vendor/simplecc/simplecc_wasm_bg.wasm": "simplecc",
+        "vendor/pdfjs/pdf.worker.min.mjs": "pdf worker",
+        "LICENSE-AGPL-3.0.txt": "AGPL",
+        "SOURCE.md": "source",
+    }
+    for relative_path, content in files.items():
+        path = output / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    return output
+
+
+def run_prune(output: Path, *, max_bytes: int | None = None) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    if max_bytes is not None:
+        env["READEST_MAX_BYTES"] = str(max_bytes)
+    return subprocess.run(
+        ["sh", str(PRUNE_SCRIPT), str(output)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_prune_readest_removes_debug_and_pdf_only_assets(tmp_path):
+    output = prepare_readest_output(tmp_path)
+
+    result = run_prune(output)
+
+    assert result.returncode == 0, result.stderr
+    assert "removed 1 sourcemaps" in result.stdout
+    assert not (output / "_next/static/chunks/app.js.map").exists()
+    assert not (output / "vendor/pdfjs").exists()
+    assert (output / "_next/static/chunks/app.js").is_file()
+    assert (output / "vendor/jieba/jieba_rs_wasm_bg.wasm").is_file()
+    assert (output / "vendor/simplecc/simplecc_wasm_bg.wasm").is_file()
+
+    second_result = run_prune(output)
+    assert second_result.returncode == 0, second_result.stderr
+    assert "removed 0 sourcemaps" in second_result.stdout
+
+
+def test_prune_readest_validates_core_files_before_deleting(tmp_path):
+    output = prepare_readest_output(tmp_path)
+    (output / "reader.html").unlink()
+
+    result = run_prune(output)
+
+    assert result.returncode == 1
+    assert "missing required path: reader.html" in result.stderr
+    assert (output / "_next/static/chunks/app.js.map").is_file()
+    assert (output / "vendor/pdfjs/pdf.worker.min.mjs").is_file()
+
+
+def test_prune_readest_rejects_output_over_budget(tmp_path):
+    output = prepare_readest_output(tmp_path)
+
+    result = run_prune(output, max_bytes=1)
+
+    assert result.returncode == 1
+    assert "limit is 1 bytes" in result.stderr
+
+
+def test_dockerfile_prunes_readest_after_adding_source_notices():
+    dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+
+    copy_script = "COPY scripts/prune-readest.sh /usr/local/bin/prune-readest"
+    add_notice = "cp /readest/LICENSE /readest/out/readest/LICENSE-AGPL-3.0.txt"
+    run_prune_command = "sh /usr/local/bin/prune-readest /readest/out/readest"
+
+    assert copy_script in dockerfile
+    assert run_prune_command in dockerfile
+    assert dockerfile.index(copy_script) < dockerfile.index(add_notice) < dockerfile.index(run_prune_command)
+    assert dockerfile.index(run_prune_command) < dockerfile.index("COPY --from=readest-builder")

--- a/webserver/handlers/book.py
+++ b/webserver/handlers/book.py
@@ -1602,31 +1602,110 @@ class BookUploadComplete(BookUploadBase):
         return self.import_uploaded_book(fpath, fmt)
 
 
+def require_online_read_permission(handler):
+    """Apply the shared online-reading gate without requiring download permission."""
+    guest_like = not handler.current_user or demo_mode.is_demo_restricted(CONF, handler.current_user)
+    if guest_like:
+        if not CONF["ALLOW_GUEST_READ"]:
+            handler.redirect("/login")
+            raise web.Finish()
+    elif handler.current_user.can_read():
+        if not handler.current_user.is_active():
+            raise web.HTTPError(403, reason=_("无权在线阅读，请先登录注册邮箱激活账号。"))
+    else:
+        raise web.HTTPError(403, reason=_("无权在线阅读"))
+    return guest_like
+
+
+class BookReadContent(BaseHandler, web.StaticFileHandler):
+    """Serve the EPUB archive to an embedded same-origin reader."""
+
+    def initialize(self):
+        self.root = "/"
+        self.default_filename = None
+        self.book_id = None
+        BaseHandler.initialize(self)
+
+    def prepare(self):
+        BaseHandler.prepare(self)
+        require_online_read_permission(self)
+
+    def parse_url_path(self, book_id):
+        book = self.get_book_or_404(book_id)
+        path = book.get("fmt_epub")
+        if not path:
+            raise web.HTTPError(404, reason=_("EPUB 尚未准备好"))
+        self.book_id = book["id"]
+        return path
+
+    @classmethod
+    def get_absolute_path(cls, root, path):
+        return path
+
+    def get_content_type(self):
+        return "application/epub+zip"
+
+    def set_extra_headers(self, path):
+        self.set_header("Content-Disposition", 'inline; filename="book-%s.epub"' % self.book_id)
+        self.set_header("Cache-Control", "private, no-store")
+        self.set_header("X-Content-Type-Options", "nosniff")
+
+
 class BookRead(BaseHandler):
+    EPUB_VIEWERS = {
+        "readest": "readest.html",
+        "creader": "creader.html",
+        "epubjs": "epubjs.html",
+    }
+
+    def selected_epub_viewer(self):
+        requested = self.get_argument("reader", "")
+        if requested:
+            return self.EPUB_VIEWERS.get(requested, "creader.html")
+        configured = CONF.get("EPUB_VIEWER", "creader.html")
+        if configured not in self.EPUB_VIEWERS.values():
+            return "creader.html"
+        return configured
+
+    def readest_progress(self, book_id):
+        user_id = self.user_id()
+        if not user_id:
+            return None
+        reading_state = (
+            self.session.query(ReadingState)
+            .filter(ReadingState.book_id == int(book_id), ReadingState.reader_id == user_id)
+            .first()
+        )
+        if not reading_state:
+            return None
+        progress = reading_state.get_progress()
+        if not isinstance(progress, dict) or progress.get("schema") != "moke.readest.progress.v1":
+            return None
+        if str(progress.get("moke_book_id", "")) != str(book_id):
+            return None
+        return progress
+
     def render_epub(self, book, is_ready, audiobook_edition=None):
+        viewer = self.selected_epub_viewer()
+        progress = self.readest_progress(book["id"]) if viewer == "readest.html" else None
+        progress_json = json.dumps(progress, ensure_ascii=False).replace("<", "\\u003c").replace(">", "\\u003e")
         return self.html_page(
-            "book/" + CONF["EPUB_VIEWER"],
+            "book/" + viewer,
             {
                 "book": book,
                 "epub_dir": "/get/extract/%s" % book["id"],
                 "is_ready": is_ready,
                 "CANDLE_READER_SERVER": CONF["CANDLE_READER_SERVER"],
                 "audiobook_edition_id": audiobook_edition.id if audiobook_edition else None,
+                "readest_content_url": "/read/%s/content.epub" % book["id"],
+                "readest_fallback_url": "/read/%s?reader=creader" % book["id"],
+                "readest_progress_json": progress_json,
             },
         )
 
     def get(self, id):
-        # 演示模式下，未登录访客与演示账号的在线阅读权限统一遵循“访客权限”配置，
-        # 忽略演示账号自身的权限位（该账号默认拥有完整权限，用于伪装管理员体验）。
-        guest_like = not self.current_user or demo_mode.is_demo_restricted(CONF, self.current_user)
-        if guest_like:
-            if not CONF["ALLOW_GUEST_READ"]:
-                return self.redirect("/login")
-        elif self.current_user.can_read():
-            if not self.current_user.is_active():
-                raise web.HTTPError(403, reason=_("无权在线阅读，请先登录注册邮箱激活账号。"))
-        else:
-            raise web.HTTPError(403, reason=_("无权在线阅读"))
+        # 演示账号与未登录访客继续统一遵循访客在线阅读配置。
+        guest_like = require_online_read_permission(self)
 
         book = self.get_book_or_404(id)
         book_id = book["id"]
@@ -2578,6 +2657,7 @@ def routes():
         (r"/api/book/([0-9]+)/delete_format", BookDeleteFormat),
         (r"/api/book/([0-9]+)/separate", BookSeparate),
         (r"/api/book/([0-9]+)/savemeta", BookSaveMeta),
+        (r"/read/([0-9]+)/content\.epub", BookReadContent),
         (r"/read/([0-9]+)", BookRead),
         (r"/api/read/txt", TxtRead),
         (r"/api/book/txt/init", BookTxtInit),

--- a/webserver/resources/book/readest.html
+++ b/webserver/resources/book/readest.html
@@ -1,0 +1,120 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <title>{{ book.title }}</title>
+    <style>
+      :root { color-scheme: light dark; font-family: system-ui,-apple-system,"Segoe UI","PingFang SC",sans-serif; }
+      html,body,#reader { width:100%; height:100%; margin:0; overflow:hidden; background:#f7f7f4; }
+      #reader { display:none; border:0; }
+      #state { position:fixed; inset:0; display:flex; align-items:center; justify-content:center; padding:24px; background:#f7f7f4; color:#252b2d; text-align:center; }
+      .panel { width:min(480px,100%); }
+      .spinner { width:42px; height:42px; margin:0 auto 22px; border:4px solid #d8dddc; border-top-color:#176b68; border-radius:50%; animation:spin 1s linear infinite; }
+      h1 { margin:0 0 10px; font-size:22px; }
+      p { margin:0 0 16px; color:#58666a; line-height:1.65; }
+      a { display:inline-flex; padding:9px 15px; border:1px solid #176b68; border-radius:999px; color:#176b68; text-decoration:none; font-weight:700; }
+      #details { display:none; margin-top:12px; font:12px/1.5 ui-monospace,SFMono-Regular,Consolas,monospace; overflow-wrap:anywhere; }
+      @keyframes spin { to { transform:rotate(360deg); } }
+      @media (prefers-color-scheme:dark) { html,body,#reader,#state { background:#171a1b; } #state { color:#f1f3f2; } p { color:#aeb8b6; } }
+      @media (prefers-reduced-motion:reduce) { .spinner { animation:none; border-top-color:#d8dddc; } }
+    </style>
+  </head>
+  <body>
+    <iframe id="reader" title="Readest 阅读器" allow="fullscreen"></iframe>
+    <div id="state" role="status" aria-live="polite">
+      <div class="panel">
+        <div class="spinner" aria-hidden="true"></div>
+        <h1>{{ book.title }}</h1>
+        <p id="message">{% if is_ready %}正在安全加载 EPUB…{% else %}服务器正在将本书转换为 EPUB，完成后会自动打开。{% endif %}</p>
+        <a href="{{ readest_fallback_url }}">使用 Candle Reader 打开</a>
+        <div id="details"></div>
+      </div>
+    </div>
+    <script>
+      (() => {
+        const contentUrl = "{{ readest_content_url }}";
+        const fallbackUrl = "{{ readest_fallback_url }}";
+        const bookId = "{{ book.id }}";
+        const restoreProgress = {{ readest_progress_json | safe }};
+        const initiallyReady = {{ "true" if is_ready else "false" }};
+        const maxBytes = 512 * 1024 * 1024;
+        const state = document.getElementById('state');
+        const message = document.getElementById('message');
+        const details = document.getElementById('details');
+        const reader = document.getElementById('reader');
+        let objectUrl = null;
+        let retries = initiallyReady ? 1 : 180;
+
+        function fail(error) {
+          document.querySelector('.spinner').style.display = 'none';
+          message.textContent = 'Readest 无法打开本书，请重试或切换到 Candle Reader。';
+          details.style.display = 'block';
+          details.textContent = error instanceof Error ? error.message : String(error);
+        }
+
+        function retry() {
+          retries -= 1;
+          if (retries <= 0) {
+            fail(new Error('EPUB 转换或内容加载超时'));
+            return;
+          }
+          window.setTimeout(load, 2000);
+        }
+
+        async function verifyReadestAssets() {
+          const response = await fetch('/readest/index.html', { credentials: 'same-origin', cache: 'no-cache' });
+          if (!response.ok) throw new Error('Readest 静态资源缺失');
+          const shell = await response.text();
+          if (!shell.includes('Readest')) throw new Error('Readest 静态资源未正确构建');
+        }
+
+        async function load() {
+          try {
+            await verifyReadestAssets();
+            const response = await fetch(contentUrl, { credentials: 'same-origin', redirect: 'follow', cache: 'no-store' });
+            if (!response.ok) {
+              if (!initiallyReady && response.status === 404) return retry();
+              throw new Error(`EPUB 请求失败（${response.status}）`);
+            }
+            if (response.redirected) throw new Error('EPUB 请求被重定向，请重新登录');
+            const contentType = (response.headers.get('content-type') || '').toLowerCase();
+            if (contentType.includes('text/html') || contentType.includes('application/json')) {
+              throw new Error('服务器返回的不是 EPUB 文件');
+            }
+            const declaredSize = Number(response.headers.get('content-length') || 0);
+            if (declaredSize > maxBytes) throw new Error('EPUB 超过 512 MiB 浏览器嵌入上限');
+            const blob = await response.blob();
+            if (!blob.size || blob.size > maxBytes) throw new Error('EPUB 为空或超过 512 MiB 浏览器嵌入上限');
+            const magic = new Uint8Array(await blob.slice(0, 4).arrayBuffer());
+            if (magic[0] !== 0x50 || magic[1] !== 0x4b) throw new Error('EPUB 文件签名无效');
+
+            objectUrl = URL.createObjectURL(blob);
+            const params = new URLSearchParams({
+              talebook: '1',
+              moke: '1',
+              mokeBookId: bookId,
+              mokeServerUrl: window.location.origin,
+              file: objectUrl,
+            });
+            if (restoreProgress) params.set('mokeRestoreProgress', JSON.stringify(restoreProgress));
+            reader.src = `/readest/?${params.toString()}`;
+            reader.style.display = 'block';
+            state.style.display = 'none';
+          } catch (error) {
+            fail(error);
+          }
+        }
+
+        window.addEventListener('pagehide', () => {
+          if (objectUrl) URL.revokeObjectURL(objectUrl);
+        }, { once: true });
+        document.querySelector('a').addEventListener('click', () => {
+          if (objectUrl) URL.revokeObjectURL(objectUrl);
+          window.location.href = fallbackUrl;
+        });
+        void load();
+      })();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## 概要

- 在保留 `/read/{id}` 单一入口与 Candle Reader 回退的前提下，增加可选 Readest 阅读器。
- 新增受在线阅读权限保护的 `/read/{id}/content.epub`，由同源启动页校验响应、大小和 ZIP 签名后以 Blob 交给 Readest。
- 将固定 commit 的 Readest 静态产物同时装入 SPA/SSR 镜像，并随产物提供 AGPLv3、源码与依赖 commit 声明。
- 后台增加双语 Readest 选项；默认仍为 Candle Reader。登录用户仅恢复与当前书籍匹配的 `moke.readest.progress.v1`。

Readest 配套改动：https://github.com/hehetoshang/readest/pull/8  
定稿设计：https://github.com/talebook/talebook/blob/29619eb399fae90b6392d89d6e23e25525f00a2e/design/app/20260810-embedded-readest.active.html

## 验证

- `pytest tests/test_main.py`：91 passed, 1 skipped
- Python Ruff：通过
- Readest 定向单元测试：30 passed
- `build-embedded-web`：通过，导出 15 个静态页面
- `docker build --target readest-builder`：通过，PDF.js/SimpleCC/Jieba 与许可文件断言通过
- `docker build --target builder`：通过，SPA/SSR 均包含 Readest；静态目录 155.1 MiB
- `docker build --check -f Dockerfile .`：通过
- `npm run lint`：0 errors（193 条既有 warnings）
- Chromium 后台设置定向用例：1 passed
- `make check-design`：100 documents passed

## 风险与后续

- 启用该构建会使前端静态产物增加约 155.1 MiB；运行时不增加 Node sidecar。
- Readest 与共享依赖均固定到公开 commit，升级需显式更新并重新审计。
- 桌面/移动端完整 EPUB、进度恢复、转换和错误回退截图仍需在集成环境补测；未阻塞本次后端、构建及设置项验收。

Closes TAL-11
