### PR TITLE
TB-17: 修复私有图书馆启动态 TypeError 与重复跳转

### DIFF
--- a/app/pages/welcome.vue
+++ b/app/pages/welcome.vue
@@ -150,7 +150,6 @@ definePageMeta({
 
 const is_err = ref(false);
 const msg = ref('');
-const welcome = ref(t('welcomePage.welcomeText'));
 const loading = ref(false);
 const invite_code = ref('');
 
@@ -167,8 +166,7 @@ const captchaVerified = ref(false);
 const captchaData = ref(null);
 const showCaptchaDialog = ref(false);
 
-// 修复1: 移除 await，正确使用 useAsyncData
-const { data: welcomeData } = useAsyncData('welcome', async () => {
+const { data: welcomeData } = await useAsyncData('welcome', async () => {
     try {
         const response = await $backend('/welcome');
         return response;
@@ -177,6 +175,8 @@ const { data: welcomeData } = useAsyncData('welcome', async () => {
         return { err: 'error', msg: '网络错误' };
     }
 });
+
+const welcome = computed(() => welcomeData.value?.welcome || t('welcomePage.welcomeText'));
 
 // 检查是否启用了验证码
 const checkCaptchaEnabled = async () => {
@@ -191,12 +191,8 @@ const checkCaptchaEnabled = async () => {
     }
 };
 
-// 修复2: 使用 watch 监听数据变化
 watch(welcomeData, (newData) => {
     if (newData) {
-        if (newData.welcome) {
-            welcome.value = newData.welcome;
-        }
         if (newData.err === 'free') {
             router.push(route.query.next || '/');
         } else if (newData.err === 'not_installed') {
@@ -323,4 +319,3 @@ useHead(() => ({
     margin-top: 100px;
 }
 </style>
-

--- a/app/plugins/talebook.js
+++ b/app/plugins/talebook.js
@@ -2,6 +2,17 @@ import { useMainStore } from '@/stores/main';
 
 export default defineNuxtPlugin((nuxtApp) => {
   const store = useMainStore();
+  const activeRedirects = new Map();
+
+  nuxtApp.$router.afterEach((to) => {
+    for (const [targetPath, reached] of activeRedirects) {
+      if (to.path === targetPath) {
+        activeRedirects.set(targetPath, true);
+      } else if (reached) {
+        activeRedirects.delete(targetPath);
+      }
+    }
+  });
 
   function showAlert(alert_type, alert_msg, alert_to) {
     store.setAlert({ type: alert_type, msg: alert_msg, to: alert_to });
@@ -13,19 +24,37 @@ export default defineNuxtPlugin((nuxtApp) => {
   }
 
   // 统一处理后端返回的控制类错误信封（未安装/未邀请/未登录/异常），触发跳转或提示。
+  function currentRoute() {
+    return nuxtApp.runWithContext(() => useRoute());
+  }
+
+  async function redirectOnce(target, logMessage) {
+    const targetPath = target.split('?')[0];
+    const route = currentRoute();
+    if (route.path === targetPath || activeRedirects.has(targetPath)) {
+      return;
+    }
+
+    activeRedirects.set(targetPath, false);
+    try {
+      if (logMessage) console.log(logMessage);
+      await nuxtApp.runWithContext(() => navigateTo(target, { redirectCode: 302 }));
+    } catch (error) {
+      activeRedirects.delete(targetPath);
+      throw error;
+    }
+  }
+
   async function handleErrorEnvelope(data) {
     if (data.err === 'not_installed') {
-      console.log('[Talebook] Redirecting to /install');
-      await nuxtApp.runWithContext(() => navigateTo('/install', { redirectCode: 302 }));
+      await redirectOnce('/install', '[Talebook] Redirecting to /install');
     } else if (data.err === 'not_invited') {
-      const route = useRoute();
+      const route = currentRoute();
       var next = route.fullPath;
       next = next ? '?next=' + next : '';
-      if (route.path !== '/welcome') {
-        await nuxtApp.runWithContext(() => navigateTo('/welcome' + next, { redirectCode: 302 }));
-      }
+      await redirectOnce('/welcome' + next);
     } else if (data.err === 'user.need_login') {
-      await nuxtApp.runWithContext(() => navigateTo('/login', { redirectCode: 302 }));
+      await redirectOnce('/login');
     } else if (data.err === 'exception') {
       store.setAlert({ type: 'error', msg: data.msg, to: null });
     }

--- a/app/stores/main.ts
+++ b/app/stores/main.ts
@@ -60,7 +60,10 @@ export const useMainStore = defineStore('main', () => {
   }
 
   function login(data: any) {
-    if (data != undefined) {
+    // 控制类错误信封（例如首次安装时的 not_installed）不包含 sys/user。
+    // 只有完整的用户信息响应才能替换初始化默认值，否则页头、页脚等计算属性
+    // 会在跳转完成前读到 undefined。
+    if (data?.sys && data?.user) {
       sys.value = data.sys
       user.value = data.user
     }

--- a/app/test/e2e/install.spec.ts
+++ b/app/test/e2e/install.spec.ts
@@ -120,12 +120,14 @@ test.describe('Private Library Access Gate', () => {
 
     test('redirects to the welcome page without corrupting bootstrap state', async ({ page }) => {
         const undefinedErrors: string[] = [];
+        const consoleErrors: string[] = [];
         const pageErrors: string[] = [];
         const welcomeRedirects: number[] = [];
 
         page.on('console', message => {
             const text = message.text();
             if (/TypeError|Cannot read properties of undefined/.test(text)) undefinedErrors.push(text);
+            if (message.type() === 'error' || /Hydration.*mismatch|Hydration completed/.test(text)) consoleErrors.push(text);
         });
         page.on('pageerror', error => pageErrors.push(error.message));
         page.on('response', response => {
@@ -142,6 +144,7 @@ test.describe('Private Library Access Gate', () => {
 
         expect(welcomeRedirects).toEqual([302]);
         expect(undefinedErrors).toEqual([]);
+        expect(consoleErrors).toEqual([]);
         expect(pageErrors).toEqual([]);
     });
 });

--- a/app/test/e2e/install.spec.ts
+++ b/app/test/e2e/install.spec.ts
@@ -13,12 +13,25 @@ test.describe('Install Flow', () => {
     });
 
     test('Redirects to install page when not installed', async ({ page }) => {
+        const installRedirects: number[] = [];
+        const undefinedErrors: string[] = [];
+        const pageErrors: string[] = [];
+
+        page.on('console', message => {
+            const text = message.text();
+            if (/TypeError|Cannot read properties of undefined/.test(text)) undefinedErrors.push(text);
+        });
+        page.on('pageerror', error => pageErrors.push(error.message));
+
     // Log network requests
         page.on('response', response => {
             if (response.url().includes('/_nuxt/')) return;
             console.log(`<< ${response.status()} ${response.url()}`);
             if (response.status() >= 300 && response.status() < 400) {
                 console.log(`   -> Redirect to ${response.headers()['location']}`);
+                if ((response.headers()['location'] || '').includes('/install')) {
+                    installRedirects.push(response.status());
+                }
             }
         });
 
@@ -33,6 +46,11 @@ test.describe('Install Flow', () => {
     
         // Check install form
         await expect(page.getByText('安装 TaleBook')).toBeVisible();
+        await page.waitForLoadState('networkidle');
+
+        expect(installRedirects).toEqual([302]);
+        expect(undefinedErrors).toEqual([]);
+        expect(pageErrors).toEqual([]);
     });
 
     test('Install redirect uses 302, not a cacheable 301', async ({ page }) => {
@@ -89,5 +107,41 @@ test.describe('Install Flow', () => {
         // Should see homepage content
         // Mock server returns static title "Talebook Mock" regardless of what we submitted
         await expect(page.getByText('Talebook Mock').first()).toBeVisible();
+    });
+});
+
+test.describe('Private Library Access Gate', () => {
+    test.beforeEach(async ({ request }) => {
+        const response = await request.post(`${mockApi}/_test/reset`, {
+            data: { installed: true, inviteMode: true, invited: false }
+        });
+        expect(response.ok()).toBeTruthy();
+    });
+
+    test('redirects to the welcome page without corrupting bootstrap state', async ({ page }) => {
+        const undefinedErrors: string[] = [];
+        const pageErrors: string[] = [];
+        const welcomeRedirects: number[] = [];
+
+        page.on('console', message => {
+            const text = message.text();
+            if (/TypeError|Cannot read properties of undefined/.test(text)) undefinedErrors.push(text);
+        });
+        page.on('pageerror', error => pageErrors.push(error.message));
+        page.on('response', response => {
+            const location = response.headers()['location'] || '';
+            if (response.status() >= 300 && response.status() < 400 && location.includes('/welcome')) {
+                welcomeRedirects.push(response.status());
+            }
+        });
+
+        await page.goto('/');
+        await expect(page).toHaveURL(/\/welcome(?:\?|$)/, { timeout: 10000 });
+        await expect(page.getByText('请输入访问码').first()).toBeVisible();
+        await page.waitForLoadState('networkidle');
+
+        expect(welcomeRedirects).toEqual([302]);
+        expect(undefinedErrors).toEqual([]);
+        expect(pageErrors).toEqual([]);
     });
 });

--- a/app/test/mock-server.js
+++ b/app/test/mock-server.js
@@ -12,6 +12,8 @@ const MOCK_DIR = path.join(__dirname, 'e2e/mocks');
 // State
 let isInstalled = true;
 let isLoggedIn = true;
+let inviteMode = false;
+let isInvited = true;
 let demoMode = false;
 let showNetworkLibrary = true;
 let users = [];
@@ -110,6 +112,12 @@ const listThemes = () => builtinThemes.map(theme => ({
   active: activeThemeName === theme.name,
 }));
 
+const accessControlEnvelope = () => {
+  if (!isInstalled) return { err: 'not_installed', msg: 'System not installed' };
+  if (inviteMode && !isInvited) return { err: 'not_invited' };
+  return null;
+};
+
 const app = createApp();
 const router = createRouter();
 
@@ -131,6 +139,8 @@ router.post('/_test/reset', eventHandler(async (event) => {
     isInstalled = true;
   }
   isLoggedIn = body?.loggedIn !== false;
+  inviteMode = !!body?.inviteMode;
+  isInvited = body?.invited !== false;
   demoMode = !!(body && body.demoMode);
   showNetworkLibrary = body?.showNetworkLibrary !== false;
   console.log('[Mock] isInstalled set to:', isInstalled);
@@ -666,7 +676,7 @@ router.get('/media/audio/:editionId/chapter/:number.mp3', eventHandler((event) =
   });
 }));
 
-router.get('/api/user/info', eventHandler(() => ({
+router.get('/api/user/info', eventHandler(() => accessControlEnvelope() || ({
   err: 'ok',
   sys: {
     title: 'Talebook Mock',
@@ -702,7 +712,7 @@ router.get('/api/captcha/config', eventHandler(() => ({
   config: { enabled: false, scenes: {} },
 })));
 
-router.get('/api/user/messages', eventHandler(() => ({
+router.get('/api/user/messages', eventHandler(() => accessControlEnvelope() || ({
   err: 'ok',
   total: 0,
   messages: []
@@ -724,10 +734,14 @@ router.get('/get/thumb_60x80/:id', eventHandler(() => (
 
 router.get('/api/index', eventHandler(() => {
   console.log('[Mock] GET /api/index, isInstalled:', isInstalled);
-  if (!isInstalled) {
-    return { err: 'not_installed', msg: 'System not installed' };
-  }
+  const accessError = accessControlEnvelope();
+  if (accessError) return accessError;
   return readJson('api_index.json') || { err: 'error', msg: 'mock not found' };
+}));
+
+router.get('/api/welcome', eventHandler(() => {
+  if (!inviteMode || isInvited) return { err: 'free', msg: 'No invitation required' };
+  return { err: 'ok', msg: '', welcome: '请输入访问码' };
 }));
 
 router.post('/api/admin/install', eventHandler(async (event) => {
@@ -1293,7 +1307,7 @@ router.get('/api/network/save/status', eventHandler(() => {
 }));
 
 // Theme API — return empty state so layout doesn't open an error dialog
-router.get('/api/themes/active', eventHandler(() => ({
+router.get('/api/themes/active', eventHandler(() => accessControlEnvelope() || ({
   err: 'ok',
   theme: listThemes().find(theme => theme.active) || null,
 })));

--- a/app/test/stores/main.nuxt.spec.ts
+++ b/app/test/stores/main.nuxt.spec.ts
@@ -1,0 +1,40 @@
+// @vitest-environment nuxt
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useMainStore } from '~/stores/main';
+
+describe('main store bootstrap state', () => {
+    beforeEach(() => {
+        setActivePinia(createPinia());
+    });
+
+    it.each(['not_installed', 'not_invited'])(
+        'preserves safe defaults when user info returns %s',
+        (err) => {
+            const store = useMainStore();
+
+            store.login({ err });
+
+            expect(store.sys).toMatchObject({
+                footer_extra_html: '',
+                friends: [],
+                show_network_library: true,
+            });
+            expect(store.user).toMatchObject({
+                is_admin: false,
+                is_login: false,
+            });
+        },
+    );
+
+    it('still accepts a complete user info response', () => {
+        const store = useMainStore();
+        const sys = { title: 'My TaleBook', friends: [] };
+        const user = { is_admin: true, is_login: true };
+
+        store.login({ err: 'ok', sys, user });
+
+        expect(store.sys).toEqual(sys);
+        expect(store.user).toEqual(user);
+    });
+});

--- a/design/app/20260811-install-bootstrap-errors.active.html
+++ b/design/app/20260811-install-bootstrap-errors.active.html
@@ -1,0 +1,93 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Talebook 安装态启动错误修复方案" />
+    <title>安装态保留安全状态并合并重复跳转 · ACTIVE</title>
+    <style>
+      :root { color-scheme: light; --bg: #f3f6fa; --panel: #fff; --ink: #203047; --muted: #59697d; --line: #d6dfeb; --accent: #b54d23; --soft: #fff1e9; --ok: #176b4a; }
+      * { box-sizing: border-box; }
+      body { margin: 0; color: var(--ink); background: var(--bg); font: 15px/1.65 system-ui, -apple-system, "Segoe UI", "PingFang SC", sans-serif; }
+      main { width: min(960px, calc(100% - 28px)); margin: 28px auto 56px; }
+      header, section { margin-bottom: 18px; padding: 24px 28px; border: 1px solid var(--line); border-radius: 18px; background: var(--panel); }
+      h1 { margin: 0 0 8px; font-size: clamp(28px, 5vw, 44px); line-height: 1.15; }
+      h2 { margin: 0 0 12px; font-size: 22px; }
+      p { margin: 0 0 10px; }
+      ul, ol { margin: 8px 0 0 20px; padding: 0; }
+      li + li { margin-top: 6px; }
+      code { padding: 2px 5px; border-radius: 5px; background: #eef2f7; font-family: ui-monospace, monospace; }
+      .meta { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 18px; }
+      .chip { padding: 5px 10px; border-radius: 999px; color: var(--muted); background: #edf2f7; font-size: 12px; font-weight: 700; }
+      .chip.status { color: var(--accent); background: var(--soft); }
+      .flow { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
+      .step { padding: 16px; border: 1px solid var(--line); border-radius: 13px; }
+      .step strong { display: block; margin-bottom: 6px; color: var(--accent); }
+      .pending { color: var(--accent); font-weight: 700; }
+      .verified { color: var(--ok); font-weight: 700; }
+      @media (max-width: 680px) { main { margin-top: 14px; } header, section { padding: 20px; } .flow { grid-template-columns: 1fr; } }
+      @media (prefers-reduced-motion: reduce) { * { scroll-behavior: auto !important; } }
+      @media print { body { background: #fff; } main { width: 100%; margin: 0; } header, section { break-inside: avoid; box-shadow: none; } }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>安装态保留安全状态并合并重复跳转</h1>
+        <p>后端尚未安装或私有图书馆尚未通过访问码时，前端应只发起一次有效导航，并在导航期间保持 Pinia 的安全默认配置，避免布局组件读取未定义字段。</p>
+        <div class="meta" aria-label="方案元信息">
+          <span class="chip status">状态：ACTIVE</span>
+          <span class="chip">创建日期：2026-08-11</span>
+          <span class="chip">所属模块：app</span>
+          <span class="chip">影响范围：启动状态、控制信封、安装与私有图书馆流程</span>
+          <span class="chip">需求来源：TB-17</span>
+        </div>
+      </header>
+
+      <section>
+        <h2>1. 原始诉求</h2>
+        <p>安装页面出现多项 <code>Cannot read properties of undefined</code>，并反复输出 <code>[Talebook] Redirecting to /install</code>；补充条件为已启用“私有图书馆”模式。</p>
+      </section>
+
+      <section>
+        <h2>2. 目标与边界</h2>
+        <ul>
+          <li><code>not_installed</code> 与 <code>not_invited</code> 响应不得把 <code>store.sys</code> 或 <code>store.user</code> 替换为 <code>undefined</code>。</li>
+          <li>同一目标的并发控制信封只触发一次导航；已经位于目标页时不再导航或打印日志。</li>
+          <li>保持后端响应结构、302 跳转语义和安装表单行为不变。</li>
+          <li>本次不重构全部启动请求，也不改变主题或消息的加载时机。</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>3. 现状与证据</h2>
+        <p><code>loadUserInfo()</code> 无条件调用 <code>login(rsp)</code>；而 <code>login()</code> 只判断响应对象存在，随后直接读取不存在的 <code>rsp.sys</code> 与 <code>rsp.user</code>。未安装时响应为 <code>not_installed</code>，私有图书馆未获访问许可时响应为 <code>not_invited</code>；布局、主题和页面请求会并发收到同类控制信封并各自调用导航。</p>
+      </section>
+
+      <section>
+        <h2>4. 方案</h2>
+        <div class="flow">
+          <div class="step"><strong>验证数据</strong>只有同时存在 <code>sys</code> 与 <code>user</code> 时才更新全局状态。</div>
+          <div class="step"><strong>合并导航</strong>按目标路径记录进行中的跳转，并跳过当前已到达的目标。</div>
+          <div class="step"><strong>真实回归</strong>让 mock 覆盖未安装态与私有图书馆访问门禁，断言各自只导航一次且无页面 TypeError。</div>
+        </div>
+      </section>
+
+      <section>
+        <h2>5. 影响与风险</h2>
+        <p>成功响应仍按原结构覆盖状态；错误响应改为保留默认值。去重只覆盖同一目标路径：到达目标后继续保留记录，离开该目标页时释放，因此后续真实状态变化仍可再次触发跳转。</p>
+      </section>
+
+      <section>
+        <h2>6. 测试结果</h2>
+        <ul class="verified">
+          <li><code>npx playwright test test/e2e/install.spec.ts --project=chromium</code>：4 项通过，覆盖安装态、302 语义、安装完成及私有图书馆访问门禁；两个异常态均无页面 TypeError。</li>
+          <li><code>npx vitest run test/stores/main.nuxt.spec.ts test/plugins/talebook.nuxt.spec.ts</code>：10 项通过；测试环境仍输出既有 Vuetify i18n 初始化警告。</li>
+          <li><code>npm run lint</code>：通过，0 error；仓库既有 193 条 warning。</li>
+          <li><code>npm run build</code>：生产构建通过；保留既有 Browserslist 数据与大 chunk 提示。</li>
+          <li><code>python3 scripts/check_design_docs.py</code>：以 ACTIVE 路径预检，102 份方案全部通过。</li>
+        </ul>
+      </section>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## 背景

安装态以及启用私有图书馆但尚未通过访问码时，启动接口会返回不含 `sys` / `user` 的控制信封。前端此前仍把它当作完整用户信息写入 Pinia，导致页头、页脚和导航读取 `undefined`；多个启动请求还会并发触发同一跳转。

Closes TB-17

## 关键改动

- 仅在响应同时包含 `sys` 与 `user` 时更新主 store，错误信封继续使用安全默认值。
- 以目标路径协调控制信封跳转，保持 SSR 的 302 语义，并合并同一目标的并发导航。
- 扩展 mock server，真实覆盖 `not_installed` 和私有图书馆 `not_invited` 两类启动状态。
- 新增 Pinia 回归测试与 Playwright 安装/私有图书馆门禁验收。

## 实际验证

- `npx playwright test test/e2e/install.spec.ts --project=chromium`：4 项通过。
- `npx vitest run test/stores/main.nuxt.spec.ts test/plugins/talebook.nuxt.spec.ts`：10 项通过；保留测试环境既有 Vuetify i18n 警告。
- `npm run lint`：通过，0 error；仓库既有 193 条 warning。
- `npm run build`：通过；保留既有 Browserslist 数据与大 chunk 提示。
- `make check-design`：102 份方案通过。

## 风险与兼容性

后端接口和 302 跳转语义不变。成功的用户信息响应仍按原逻辑覆盖状态；控制信封改为保留初始化默认值。跳转协调记录会在离开目标页后释放，不影响状态变化后的再次导航。

本次没有视觉样式变化，截图无法体现控制台 TypeError 与重复导航修复，因此以浏览器页面错误监听和重定向次数断言作为验收证据。

## 方案

- [GitHub 文件](https://github.com/talebook/talebook/blob/c76605ce23a97b7675dd48322b8b8759ded23653/design/app/20260811-install-bootstrap-errors.active.html)
- [RawGitHack 预览](https://raw.githack.com/talebook/talebook/c76605ce23a97b7675dd48322b8b8759ded23653/design/app/20260811-install-bootstrap-errors.active.html)
