### PR TITLE
TB-17: 修复私人图书馆安装提交校验

### DIFF
--- a/app/pages/install.vue
+++ b/app/pages/install.vue
@@ -250,7 +250,7 @@ const buildUserDatabaseUrl = () => {
 const rules = {
     user: v => ( v && 20 >= v.length && v.length >= 2) || $t('install.userRule'),
     pass: v => ( v && 20 >= v.length && v.length >= 8) || $t('install.passRule'),
-    code: v => (invite.value && v && v.trim()) || $t('install.codeRule'),
+    code: v => !!(v && v.trim()) || $t('install.codeRule'),
     email: function (email) {
         var re = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
         return re.test(email) || $t('install.emailRule');

--- a/app/test/e2e/install.spec.ts
+++ b/app/test/e2e/install.spec.ts
@@ -108,6 +108,35 @@ test.describe('Install Flow', () => {
         // Mock server returns static title "Talebook Mock" regardless of what we submitted
         await expect(page.getByText('Talebook Mock').first()).toBeVisible();
     });
+
+    test('Can complete installation with private library enabled', async ({ page }) => {
+        let installPostData = '';
+        page.on('request', request => {
+            if (request.url().includes('/api/admin/install')) {
+                installPostData = request.postData() || '';
+            }
+        });
+
+        await page.goto('/install');
+
+        await page.getByLabel('网站标题').fill('Private TaleBook');
+        await page.getByLabel('管理员用户名').fill('admin');
+        await page.getByLabel('管理员登录密码').fill('password123');
+        await page.getByLabel('管理员Email').fill('admin@example.com');
+        await page.getByLabel('开启私人图书馆模式').check();
+        await page.getByLabel('访问码').fill('private-code');
+
+        await page.getByRole('button', { name: '完成设置' }).click();
+
+        await expect(page.getByText('配置写入成功')).toBeVisible({ timeout: 5000 });
+        await expect(page.getByText('API服务正常')).toBeVisible({ timeout: 10000 });
+        await expect(page).toHaveURL('/', { timeout: 15000 });
+        await expect(page.getByText('Talebook Mock').first()).toBeVisible();
+
+        const params = new URLSearchParams(installPostData);
+        expect(params.get('invite')).toBe('true');
+        expect(params.get('code')).toBe('private-code');
+    });
 });
 
 test.describe('Private Library Access Gate', () => {


### PR DESCRIPTION
Fixes TB-17\n\n## Summary\n- Fix install access-code validation so enabling private library mode can submit successfully.\n- Add an E2E regression that enables private library mode, fills the access code, confirms install completes, and asserts the install request includes invite=true and the code.\n\n## Tests\n- PLAYWRIGHT_BASE_URL=http://127.0.0.1:9000 MOCK_API_URL=http://127.0.0.1:8080 npx playwright test test/e2e/install.spec.ts --grep "private library enabled"\n- PLAYWRIGHT_BASE_URL=http://127.0.0.1:9000 MOCK_API_URL=http://127.0.0.1:8080 npx playwright test test/e2e/install.spec.ts\n- npx eslint pages/install.vue test/e2e/install.spec.ts