### PR TITLE
TB-37: publish images to GHCR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ on:
 
 env:
   REGISTRY: docker.io
+  GHCR_REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
 permissions:
@@ -56,6 +57,7 @@ jobs:
               - 'requirements-test.txt'
               - 'docker-compose.yml'
               - 'docker-compose.dev.yml'
+              - '.github/workflows/build.yml'
 
       - name: Decide Docker build
         id: decide
@@ -145,16 +147,30 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.GHCR_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Set build outputs
         id: out
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             echo "value=type=image,push=false" >> $GITHUB_OUTPUT
           else
-            echo "value=type=image,name=${REGISTRY}/${IMAGE_NAME},push-by-digest=true,name-canonical=true,push=true" >> $GITHUB_OUTPUT
+            {
+              echo "value<<EOF"
+              echo "type=image,name=${REGISTRY}/${IMAGE_NAME},push-by-digest=true,name-canonical=true,push=true"
+              echo "type=image,name=${GHCR_REGISTRY}/${IMAGE_NAME},push-by-digest=true,name-canonical=true,push=true"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
           fi
         env:
           REGISTRY: ${{ env.REGISTRY }}
+          GHCR_REGISTRY: ${{ env.GHCR_REGISTRY }}
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
 
       - name: Build SPA
@@ -192,7 +208,9 @@ jobs:
           platforms: linux/amd64
           provenance: false
           push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev
+            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}:dev
           labels: org.opencontainers.image.revision=${{ github.sha }}
           cache-from: type=gha,scope=dev-linux-amd64
           cache-to: type=gha,scope=dev-linux-amd64,mode=max
@@ -241,57 +259,70 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      # SPA 镜像：talebook/talebook:latest / <ver> / master / <branch>，
-      # 以及 calibre-webserver:latest / master（仅 talebook/talebook 仓库）
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.GHCR_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # SPA 镜像：两个 registry 中的 talebook/talebook:latest / <ver> / master / <branch>，
+      # 以及 Docker Hub 的 calibre-webserver:latest / master（仅 talebook/talebook 仓库）
       - name: Create SPA manifest
         run: |
-          IMAGE="${REGISTRY}/${IMAGE_NAME}"
-          TAGS=()
-          if [[ $GITHUB_REF == refs/tags/* ]]; then
-            TAGS+=("-t" "${IMAGE}:latest" "-t" "${IMAGE}:${GITHUB_REF_NAME}")
-          fi
-          if [[ "$GITHUB_REF" == "refs/heads/master" ]]; then
-            TAGS+=("-t" "${IMAGE}:master")
-          fi
-          if [[ "$GITHUB_REF" == refs/heads/dev/* || "$GITHUB_REF" == refs/heads/claude/* || "$GITHUB_REF" == refs/heads/codex/* ]]; then
-            TAGS+=("-t" "${IMAGE}:${SAFE_REF_NAME}")
-          fi
-          if [[ "$GITHUB_REPOSITORY" == "talebook/talebook" ]]; then
+          for TARGET_REGISTRY in "$REGISTRY" "$GHCR_REGISTRY"; do
+            IMAGE="${TARGET_REGISTRY}/${IMAGE_NAME}"
+            TAGS=()
             if [[ $GITHUB_REF == refs/tags/* ]]; then
-              TAGS+=("-t" "${REGISTRY}/talebook/calibre-webserver:latest")
+              TAGS+=("-t" "${IMAGE}:latest" "-t" "${IMAGE}:${GITHUB_REF_NAME}")
             fi
             if [[ "$GITHUB_REF" == "refs/heads/master" ]]; then
-              TAGS+=("-t" "${REGISTRY}/talebook/calibre-webserver:master")
+              TAGS+=("-t" "${IMAGE}:master")
             fi
-          fi
-          if [[ ${#TAGS[@]} -eq 0 ]]; then echo "No SPA tags for this ref, skip."; exit 0; fi
-          SRCS=()
-          for f in /tmp/digests/spa/*; do SRCS+=("${IMAGE}@$(cat "$f")"); done
-          docker buildx imagetools create "${TAGS[@]}" "${SRCS[@]}"
+            if [[ "$GITHUB_REF" == refs/heads/dev/* || "$GITHUB_REF" == refs/heads/claude/* || "$GITHUB_REF" == refs/heads/codex/* ]]; then
+              TAGS+=("-t" "${IMAGE}:${SAFE_REF_NAME}")
+            fi
+            if [[ "$TARGET_REGISTRY" == "$REGISTRY" && "$GITHUB_REPOSITORY" == "talebook/talebook" ]]; then
+              if [[ $GITHUB_REF == refs/tags/* ]]; then
+                TAGS+=("-t" "${REGISTRY}/talebook/calibre-webserver:latest")
+              fi
+              if [[ "$GITHUB_REF" == "refs/heads/master" ]]; then
+                TAGS+=("-t" "${REGISTRY}/talebook/calibre-webserver:master")
+              fi
+            fi
+            if [[ ${#TAGS[@]} -eq 0 ]]; then continue; fi
+            SRCS=()
+            for f in /tmp/digests/spa/*; do SRCS+=("${IMAGE}@$(cat "$f")"); done
+            docker buildx imagetools create "${TAGS[@]}" "${SRCS[@]}"
+          done
         env:
           REGISTRY: ${{ env.REGISTRY }}
+          GHCR_REGISTRY: ${{ env.GHCR_REGISTRY }}
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
           SAFE_REF_NAME: ${{ needs.prepare.outputs.safe_ref_name }}
 
-      # SSR 镜像：talebook/talebook:server-side-render / server-side-render-<ver|branch>
+      # 两个 registry 的 SSR 镜像：server-side-render / server-side-render-<ver|branch>
       - name: Create SSR manifest
         run: |
-          IMAGE="${REGISTRY}/${IMAGE_NAME}"
-          TAGS=()
-          if [[ $GITHUB_REF == refs/tags/* ]]; then
-            TAGS+=("-t" "${IMAGE}:server-side-render" "-t" "${IMAGE}:server-side-render-${GITHUB_REF_NAME}")
-          fi
-          if [[ "$GITHUB_REF" == "refs/heads/master" ]]; then
-            TAGS+=("-t" "${IMAGE}:server-side-render")
-          fi
-          if [[ "$GITHUB_REF" == refs/heads/dev/* || "$GITHUB_REF" == refs/heads/claude/* || "$GITHUB_REF" == refs/heads/codex/* ]]; then
-            TAGS+=("-t" "${IMAGE}:server-side-render-${SAFE_REF_NAME}")
-          fi
-          if [[ ${#TAGS[@]} -eq 0 ]]; then echo "No SSR tags for this ref, skip."; exit 0; fi
-          SRCS=()
-          for f in /tmp/digests/ssr/*; do SRCS+=("${IMAGE}@$(cat "$f")"); done
-          docker buildx imagetools create "${TAGS[@]}" "${SRCS[@]}"
+          for TARGET_REGISTRY in "$REGISTRY" "$GHCR_REGISTRY"; do
+            IMAGE="${TARGET_REGISTRY}/${IMAGE_NAME}"
+            TAGS=()
+            if [[ $GITHUB_REF == refs/tags/* ]]; then
+              TAGS+=("-t" "${IMAGE}:server-side-render" "-t" "${IMAGE}:server-side-render-${GITHUB_REF_NAME}")
+            fi
+            if [[ "$GITHUB_REF" == "refs/heads/master" ]]; then
+              TAGS+=("-t" "${IMAGE}:server-side-render")
+            fi
+            if [[ "$GITHUB_REF" == refs/heads/dev/* || "$GITHUB_REF" == refs/heads/claude/* || "$GITHUB_REF" == refs/heads/codex/* ]]; then
+              TAGS+=("-t" "${IMAGE}:server-side-render-${SAFE_REF_NAME}")
+            fi
+            if [[ ${#TAGS[@]} -eq 0 ]]; then continue; fi
+            SRCS=()
+            for f in /tmp/digests/ssr/*; do SRCS+=("${IMAGE}@$(cat "$f")"); done
+            docker buildx imagetools create "${TAGS[@]}" "${SRCS[@]}"
+          done
         env:
           REGISTRY: ${{ env.REGISTRY }}
+          GHCR_REGISTRY: ${{ env.GHCR_REGISTRY }}
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
           SAFE_REF_NAME: ${{ needs.prepare.outputs.safe_ref_name }}

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Skill 会在写入前确认目标与权限，对管理员写入、删除和批�
 
 ## Docker ![Docker Pulls](https://img.shields.io/docker/pulls/talebook/talebook.svg)
 
-部署比较简单，建议采用docker，镜像地址：[dockerhub](https://hub.docker.com/r/talebook/talebook)
+部署比较简单，建议采用 Docker。镜像同时发布到 [Docker Hub](https://hub.docker.com/r/talebook/talebook) 和 [GitHub Container Registry](https://github.com/talebook/talebook/pkgs/container/talebook)，可分别使用 `talebook/talebook` 或 `ghcr.io/talebook/talebook` 拉取。
 
 推荐使用`docker-compose`，下载仓库中的配置文件[docker-compose.yml](docker-compose.yml)，然后执行命令启动即可。
 若希望修改挂载的目录或端口，请修改docker-compose.yml文件。

--- a/README_EN.md
+++ b/README_EN.md
@@ -44,7 +44,7 @@ This project was previously named: calibre-webserver
 
 ## Docker ![Docker Pulls](https://img.shields.io/docker/pulls/talebook/talebook.svg)
 
-Deployment is relatively simple, it is recommended to use docker, image address: [dockerhub](https://hub.docker.com/r/talebook/talebook)
+Docker is the recommended deployment method. Images are published to both [Docker Hub](https://hub.docker.com/r/talebook/talebook) and [GitHub Container Registry](https://github.com/talebook/talebook/pkgs/container/talebook); pull them as `talebook/talebook` or `ghcr.io/talebook/talebook`, respectively.
 
 It is recommended to use `docker-compose`, download the configuration file [docker-compose.yml](docker-compose.yml) from the repository, and then execute the command to start.
 If you want to modify the mounted directories or ports, please modify the docker-compose.yml file.

--- a/design/project/20260813-ghcr-image.active.html
+++ b/design/project/20260813-ghcr-image.active.html
@@ -1,0 +1,103 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Talebook 同步发布 Docker Hub 与 GitHub Container Registry 镜像的内部方案。">
+  <link rel="icon" href="data:,">
+  <title>同步发布 Talebook GHCR 镜像 · ACTIVE</title>
+  <style>
+    :root { color-scheme: light; --ink:#172033; --muted:#607086; --line:#d8e0eb; --paper:#f5f8fc; --accent:#4056b4; --accent-bg:#edf0ff; --warn:#8a5511; --warn-bg:#fff5df; --ok:#176b49; --ok-bg:#e8f6ef; --code:#eef2f7; }
+    * { box-sizing: border-box; }
+    body { margin:0; padding:42px 20px 72px; color:var(--ink); background:linear-gradient(135deg,#f9fbff,var(--paper)); font:16px/1.68 system-ui,-apple-system,"PingFang SC","Microsoft YaHei",sans-serif; }
+    main { max-width:980px; margin:0 auto; }
+    header,section { margin-bottom:18px; padding:26px; background:#fff; border:1px solid var(--line); border-radius:16px; box-shadow:0 10px 26px rgba(32,48,78,.06); }
+    h1 { margin:0 0 12px; font-size:clamp(30px,5vw,46px); line-height:1.16; }
+    h2 { margin:0 0 14px; font-size:22px; line-height:1.3; }
+    p { margin:0 0 12px; } p:last-child { margin-bottom:0; }
+    code { padding:2px 5px; border-radius:4px; background:var(--code); font-size:.9em; overflow-wrap:anywhere; }
+    ul { margin:10px 0 0 22px; padding:0; } li+li { margin-top:6px; }
+    table { width:100%; margin-top:12px; border-collapse:collapse; background:#fff; }
+    th,td { padding:11px 12px; border:1px solid var(--line); text-align:left; vertical-align:top; }
+    th { color:var(--muted); background:#f5f7fb; font-size:13px; }
+    .meta { display:flex; flex-wrap:wrap; gap:8px 16px; color:var(--muted); font-size:13px; }
+    .status { color:var(--warn); font-weight:800; }
+    .summary { padding:16px 18px; background:var(--accent-bg); border-left:4px solid var(--accent); }
+    .request { padding:14px 16px; background:var(--warn-bg); border-left:4px solid var(--warn); }
+    .decision { padding:14px 16px; background:var(--ok-bg); border-left:4px solid var(--ok); }
+    @media(max-width:680px){ body{padding:18px 12px 46px} header,section{padding:20px;border-radius:11px} table{display:block;overflow-x:auto} }
+    @media(prefers-reduced-motion:reduce){*{scroll-behavior:auto}}
+    @media print{body{background:#fff;padding:0}header,section{box-shadow:none;break-inside:avoid}}
+  </style>
+</head>
+<body>
+<main>
+  <header>
+    <h1>同步发布 Talebook GHCR 镜像</h1>
+    <p class="summary">在保留 Docker Hub 发布契约的同时，把同一次多架构构建产物推送到 <code>ghcr.io/talebook/talebook</code>，不重复执行耗时的镜像构建。</p>
+    <div class="meta">
+      <span>创建日期：2026-08-13</span><span>所属模块：project</span><span>状态：<b class="status">ACTIVE</b></span><span>影响范围：GitHub Actions / 镜像发布</span><span>需求来源：TB-37</span>
+    </div>
+  </header>
+  <section>
+    <h2>1. 原始诉求</h2>
+    <div class="request">“给 talebook 项目增加 ghcr 镜像。”</div>
+    <p>当前 <code>.github/workflows/build.yml</code> 只登录 Docker Hub，并把 SPA、SSR 和开发镜像发布到 <code>docker.io/talebook/talebook</code>。仓库 workflow 已具有 <code>packages: write</code> 权限，但没有使用 GitHub 提供的令牌发布 GHCR。</p>
+  </section>
+  <section>
+    <h2>2. 目标与边界</h2>
+    <table>
+      <thead><tr><th>类型</th><th>内容</th></tr></thead>
+      <tbody>
+        <tr><td>目标</td><td>push 与版本 tag 发布时，同步产生 <code>ghcr.io/talebook/talebook</code> 的 SPA、SSR 与 <code>dev</code> 镜像。</td></tr>
+        <tr><td>目标</td><td>GHCR 沿用 Docker Hub 的 tag 和多架构集合，用户切换 registry 时无需改变 tag 语义。</td></tr>
+        <tr><td>保持不变</td><td>PR 只构建不推送；Docker Hub 主镜像与兼容别名 <code>talebook/calibre-webserver</code> 继续发布。</td></tr>
+        <tr><td>非目标</td><td>不迁移或删除 Docker Hub 镜像，不改变 Dockerfile、运行时内容与 Compose 默认镜像。</td></tr>
+      </tbody>
+    </table>
+  </section>
+  <section>
+    <h2>3. 方案</h2>
+    <p class="decision"><strong>结论：</strong>每个平台的 Buildx action 增加第二个 registry exporter，将相同构建结果按 digest 推送到 Docker Hub 和 GHCR；merge job 再分别从两个 registry 的 digest 创建同构 multi-arch manifest。</p>
+    <ul>
+      <li>增加 <code>GHCR_REGISTRY=ghcr.io</code>，镜像名继续取 <code>github.repository</code>，从而自然得到 <code>ghcr.io/talebook/talebook</code>。</li>
+      <li>build 与 merge job 使用 <code>github.actor</code> 和短期 <code>GITHUB_TOKEN</code> 登录 GHCR，权限限定为现有的 <code>packages: write</code>。</li>
+      <li>SPA、SSR 的单架构产物一次构建、双 registry 输出；manifest 脚本循环 registry，分别引用各自 registry 内的 digest。</li>
+      <li><code>dev</code> target 仍只在 master push 时发布，但一次为 Docker Hub 与 GHCR 打两个 tag。</li>
+      <li>把 <code>.github/workflows/build.yml</code> 纳入 Docker 路径过滤，确保发布配置自身变化会触发构建验证。</li>
+    </ul>
+    <table>
+      <thead><tr><th>触发</th><th>GHCR SPA</th><th>GHCR SSR</th><th>GHCR dev</th></tr></thead>
+      <tbody>
+        <tr><td>版本 tag <code>v*</code></td><td><code>latest</code>、版本号</td><td><code>server-side-render</code>、带版本号 tag</td><td>不变更</td></tr>
+        <tr><td><code>master</code> push</td><td><code>master</code></td><td><code>server-side-render</code></td><td><code>dev</code></td></tr>
+        <tr><td>受支持开发分支 push</td><td>安全化分支名</td><td>带安全化分支名 tag</td><td>不发布</td></tr>
+        <tr><td>pull request</td><td>不推送</td><td>不推送</td><td>只验证构建、不推送</td></tr>
+      </tbody>
+    </table>
+  </section>
+  <section>
+    <h2>4. 风险与回滚</h2>
+    <ul>
+      <li>首次发布依赖组织允许仓库的 <code>GITHUB_TOKEN</code> 创建或写入 package；真实权限边界需由 GitHub Actions 验证。</li>
+      <li>双 registry 推送增加上传时间和存储占用，但不会重复运行 Dockerfile 构建阶段。</li>
+      <li>任一 registry 推送失败会令发布 job 失败，避免两个来源悄然产生不同版本。</li>
+      <li>回滚可移除 GHCR 登录、第二 exporter、第二 manifest 循环目标和 dev 的 GHCR tag，不涉及镜像内容或数据迁移。</li>
+    </ul>
+  </section>
+  <section>
+    <h2>5. 测试计划与结果</h2>
+    <table>
+      <thead><tr><th>验证项</th><th>当前结果</th></tr></thead>
+      <tbody>
+        <tr><td><code>PYTHONPATH=.tools/python-packages python3 -m pytest tests/test_dev_container_workflow.py -q</code></td><td>通过：3 passed，覆盖登录凭据、双 exporter、manifest registry 循环与 dev tags。</td></tr>
+        <tr><td><code>PYTHONPATH=.tools/python-packages python3 -m pytest tests/test_dev_container_workflow.py tests/test_ci_workflow.py tests/test_agent_workflows.py tests/test_claude_review_workflow.py -q</code></td><td>通过：8 passed，覆盖仓库现有 workflow 核心回归。</td></tr>
+        <tr><td><code>act pull_request -W .github/workflows/build.yml -j build -e event.json --pull=false --matrix platform:linux/amd64</code></td><td>受环境限制：使用 act 0.2.89 执行真实 workflow；<code>changes</code>、<code>prepare</code>、QEMU、Buildx 和 PR 的 <code>type=image,push=false</code> 输出均成功，两个 registry 登录按预期跳过。随后 <code>docker/build-push-action@v5</code> 两次在拉取 <code>docker/dockerfile:1.6</code> 时遇到 Docker Hub 网络超时，未完成 SPA/SSR 构建。合并前必须以真实 GitHub Actions 的 PR build 成功作为门禁。</td></tr>
+        <tr><td><code>make check-design</code> 与 <code>git diff --check</code></td><td>通过：方案文档结构、单文件资源约束及空白检查均通过。</td></tr>
+        <tr><td>真实 push/tag 发布</td><td>本地不能安全模拟 GitHub package 写入；PR 合并后的 Actions 是 GHCR 权限与远端 manifest 的最终验收边界。</td></tr>
+      </tbody>
+    </table>
+  </section>
+</main>
+</body>
+</html>

--- a/tests/test_dev_container_workflow.py
+++ b/tests/test_dev_container_workflow.py
@@ -19,7 +19,8 @@ def workflow_step(job, name):
 
 
 def test_build_workflow_only_publishes_the_validated_dev_image_from_master():
-    build_job = workflow("build.yml")["jobs"]["build"]
+    build_workflow = workflow("build.yml")
+    build_job = build_workflow["jobs"]["build"]
     step = workflow_step(build_job, "Build development image")
 
     assert step["if"] == (
@@ -32,8 +33,44 @@ def test_build_workflow_only_publishes_the_validated_dev_image_from_master():
     assert step["with"]["push"] == (
         "${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}"
     )
-    assert step["with"]["tags"] == "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev"
+    assert step["with"]["tags"].splitlines() == [
+        "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev",
+        "${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}:dev",
+    ]
     assert step["with"]["labels"] == "org.opencontainers.image.revision=${{ github.sha }}"
+
+
+def test_build_workflow_publishes_docker_hub_and_ghcr_from_the_same_build():
+    build_workflow = workflow("build.yml")
+    jobs = build_workflow["jobs"]
+    build = jobs["build"]
+    merge = jobs["merge"]
+
+    assert build_workflow["env"] == {
+        "REGISTRY": "docker.io",
+        "GHCR_REGISTRY": "ghcr.io",
+        "IMAGE_NAME": "${{ github.repository }}",
+    }
+
+    for job in (build, merge):
+        login = workflow_step(job, "Log in to GitHub Container Registry")
+        assert login["uses"] == "docker/login-action@v3"
+        assert login["with"] == {
+            "registry": "${{ env.GHCR_REGISTRY }}",
+            "username": "${{ github.actor }}",
+            "password": "${{ secrets.GITHUB_TOKEN }}",
+        }
+
+    outputs = workflow_step(build, "Set build outputs")
+    assert "type=image,name=${REGISTRY}/${IMAGE_NAME}" in outputs["run"]
+    assert "type=image,name=${GHCR_REGISTRY}/${IMAGE_NAME}" in outputs["run"]
+    assert outputs["env"]["GHCR_REGISTRY"] == "${{ env.GHCR_REGISTRY }}"
+
+    for name in ("Create SPA manifest", "Create SSR manifest"):
+        manifest = workflow_step(merge, name)
+        assert 'for TARGET_REGISTRY in "$REGISTRY" "$GHCR_REGISTRY"' in manifest["run"]
+        assert 'SRCS+=("${IMAGE}@$(cat "$f")")' in manifest["run"]
+        assert manifest["env"]["GHCR_REGISTRY"] == "${{ env.GHCR_REGISTRY }}"
 
 
 def test_build_workflow_filters_docker_jobs_to_image_inputs():
@@ -67,6 +104,7 @@ def test_build_workflow_filters_docker_jobs_to_image_inputs():
             "requirements-test.txt",
             "docker-compose.yml",
             "docker-compose.dev.yml",
+            ".github/workflows/build.yml",
         ]
     }
 


### PR DESCRIPTION
## 背景或目标

为 Talebook 增加 GitHub Container Registry 发布，在保留 Docker Hub 镜像和 tag 契约的同时提供 `ghcr.io/talebook/talebook`。Closes TB-37。

## 关键改动

- 使用现有 `packages: write` 权限和短期 `GITHUB_TOKEN` 登录 GHCR。
- 同一次多架构 Buildx 构建按 digest 同时输出到 Docker Hub 和 GHCR，避免重复构建。
- SPA 与 SSR manifest 在两个 registry 使用一致的 `latest`、版本、`master`、开发分支 tag 语义；`dev` 镜像也同步发布到 GHCR。
- 保留 Docker Hub 的 `talebook/calibre-webserver` 兼容别名，不在 GHCR 创建额外别名。
- 将 workflow 自身纳入 Docker 路径过滤，并增加回归测试与中英文拉取文档。

## 实际验证

- `PYTHONPATH=.tools/python-packages python3 -m pytest tests/test_dev_container_workflow.py -q`：通过，3 passed。
- `PYTHONPATH=.tools/python-packages python3 -m pytest tests/test_dev_container_workflow.py tests/test_ci_workflow.py tests/test_agent_workflows.py tests/test_claude_review_workflow.py -q`：通过，8 passed。
- `make check-design`：通过，105 design documents passed。
- `git diff --check`：通过。
- `act 0.2.89 pull_request -W .github/workflows/build.yml -j build -e event.json --pull=false --matrix platform:linux/amd64`：真实 workflow 的 `changes`、`prepare`、QEMU、Buildx 和 PR `type=image,push=false` 路径均成功，Docker Hub/GHCR 登录按预期跳过；`docker/build-push-action@v5` 随后在拉取 `docker/dockerfile:1.6` 时两次遇到 Docker Hub 网络超时，未完成 SPA/SSR 构建。

## 风险与兼容性

- 本地无法安全模拟 GitHub package 写入；GHCR 权限、远端 digest 与 manifest 必须由真实 GitHub Actions 验收。
- 由于 `act` 的 Docker Hub 网络超时，完整 PR image build 必须作为合并阻断检查。
- Docker Hub 用户、现有 Compose 默认镜像和镜像运行时内容保持不变。

## 方案

- GitHub 文件：https://github.com/talebook/talebook/blob/6aa3a38647d9975ec6bb5ef5767960e0c0e54db6/design/project/20260813-ghcr-image.active.html
- RawGitHack 预览：https://raw.githack.com/talebook/talebook/6aa3a38647d9975ec6bb5ef5767960e0c0e54db6/design/project/20260813-ghcr-image.active.html

## 视觉证据

本次不涉及产品界面。
