### PR TITLE
TB-42: make Talebook annotations authoritative

### DIFF
--- a/design/webserver/20260716-reading-annotations.superseded.html
+++ b/design/webserver/20260716-reading-annotations.superseded.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>阅读笔记 / 高亮后端同步设计 · ACTIVE</title>
+<title>阅读笔记 / 高亮后端同步设计 · SUPERSEDED</title>
 <style>
   :root { color-scheme: light dark; }
   body { font: 15px/1.7 -apple-system, "PingFang SC", "Microsoft YaHei", sans-serif; max-width: 960px; margin: 0 auto; padding: 24px; color: #1f2328; background: #fff; }
@@ -17,7 +17,7 @@
   th { background: #f6f8fa; }
   .meta { display: flex; flex-wrap: wrap; gap: 8px 20px; color: #57606a; font-size: 14px; margin: 8px 0 16px; }
   .badge { display: inline-block; padding: 2px 10px; border-radius: 12px; font-size: 13px; font-weight: 600; }
-  .active { background: #dafbe1; color: #1a7f37; }
+  .active { background: #ffebe9; color: #cf222e; }
   .todo { color: #8250df; font-weight: 600; }
   .warn { background: #fff8c5; padding: 8px 12px; border-left: 3px solid #d4a72c; margin: 12px 0; }
   ul { padding-left: 22px; }
@@ -26,11 +26,12 @@
 <body>
 <h1>阅读笔记 / 高亮后端同步设计</h1>
 <div class="meta">
-  <span><span class="badge active">ACTIVE</span> 待实现</span>
+  <span><span class="badge active">SUPERSEDED</span> 已由 20260814-annotation-data-api 替代</span>
   <span>创建日期：2026-07-16</span>
   <span>所属模块：webserver（主） + candle-reader（外部仓库）</span>
   <span>需求来源：Issue #181（"能否支持笔记功能"）</span>
 </div>
+<div class="warn">本方案已被 <code>design/webserver/20260814-annotation-data-api.active.html</code> 替代。新方案扩展了插件来源字段、批量查询/导出/删除、冲突保护与独立 chapter_comments 数据域，并作为当前有效契约。</div>
 
 <h2>1. 原始诉求</h2>
 <blockquote>

--- a/design/webserver/20260716-reading-annotations.superseded.html
+++ b/design/webserver/20260716-reading-annotations.superseded.html
@@ -31,7 +31,7 @@
   <span>所属模块：webserver（主） + candle-reader（外部仓库）</span>
   <span>需求来源：Issue #181（"能否支持笔记功能"）</span>
 </div>
-<div class="warn">本方案已被 <code>design/webserver/20260814-annotation-data-api.active.html</code> 替代。新方案扩展了插件来源字段、批量查询/导出/删除、冲突保护与独立 chapter_comments 数据域，并作为当前有效契约。</div>
+<div class="warn">本方案已被 <code>design/webserver/20260814-annotation-data-api.active.html</code> 替代。新方案将 Talebook <code>annotations</code> 定义为权威内容表，统一公共章评、私密笔记与外部 source 副本映射。</div>
 
 <h2>1. 原始诉求</h2>
 <blockquote>

--- a/design/webserver/20260814-annotation-data-api.active.html
+++ b/design/webserver/20260814-annotation-data-api.active.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Annotation 数据域与服务端 API · ACTIVE</title>
+<style>
+  :root { color-scheme: light; --ink:#172033; --muted:#5f6b7a; --line:#d9e0ea; --panel:#f7f9fc; --accent:#3758c8; --warn:#fff4d6; }
+  * { box-sizing: border-box; }
+  body { margin:0 auto; max-width:1080px; padding:32px 24px 64px; color:var(--ink); background:#fff; font:15px/1.7 -apple-system,BlinkMacSystemFont,"PingFang SC","Microsoft YaHei",sans-serif; }
+  h1 { margin:0 0 8px; font-size:30px; line-height:1.25; }
+  h2 { margin:36px 0 12px; padding-bottom:8px; border-bottom:1px solid var(--line); font-size:21px; }
+  h3 { margin:24px 0 8px; font-size:17px; }
+  code { padding:2px 5px; border-radius:4px; background:#eef2f8; }
+  table { width:100%; border-collapse:collapse; margin:14px 0; font-size:14px; }
+  th,td { padding:9px 10px; border:1px solid var(--line); text-align:left; vertical-align:top; }
+  th { background:var(--panel); }
+  .meta { display:flex; flex-wrap:wrap; gap:8px 20px; color:var(--muted); }
+  .badge { padding:2px 10px; border-radius:999px; color:#fff; background:var(--accent); font-weight:700; }
+  .callout { margin:16px 0; padding:12px 16px; border-left:4px solid #d49b18; background:var(--warn); }
+  .flow { display:grid; grid-template-columns:repeat(3,1fr); gap:12px; margin:16px 0; }
+  .flow div { min-height:96px; padding:14px; border:1px solid var(--line); border-radius:10px; background:var(--panel); }
+  .flow strong { display:block; margin-bottom:5px; color:var(--accent); }
+  @media (max-width:720px) { body{padding:22px 16px 48px}.flow{grid-template-columns:1fr}table{display:block;overflow-x:auto} }
+</style>
+</head>
+<body>
+<h1>Annotation 数据域与服务端 API</h1>
+<div class="meta">
+  <span class="badge">ACTIVE</span>
+  <span>创建日期：2026-08-14</span>
+  <span>所属模块：webserver</span>
+  <span>需求来源：Multica TB-42</span>
+</div>
+
+<h2>1. 原始诉求</h2>
+<p>为微信读书、Readwise、Web、Moke 与 Readest 等笔记插件提供统一服务端契约：个人高亮、笔记与书签可幂等导入、查询、导出和按来源删除；无法精确定位的记录仍可按章节展示；章评使用独立数据域；管理员不能借普通接口读取其他用户的私密正文。</p>
+
+<h2>2. 目标与边界</h2>
+<ul>
+  <li>个人 annotation 以当前登录用户为强制租户边界，书籍访问同时服从现有 <code>can_view_book</code> 权限。</li>
+  <li>支持 <code>highlight</code>、<code>note</code>、<code>bookmark</code>，允许 <code>cfi=NULL</code> 并保留章节、引用文本与来源位置。</li>
+  <li>支持客户端 <code>client_id</code> 幂等，以及 <code>owner + book + source + external_id</code> 来源幂等。</li>
+  <li>章评写入独立表；其正文按书籍可见性读取，写入、修改和来源删除仅限导入者，不复用个人 annotation 的私密查询。</li>
+  <li>本次只提供后端数据与 JSON API，不改页面和阅读器；外部插件连接管理由后续插件底座承接。</li>
+</ul>
+
+<h2>3. 数据模型</h2>
+<div class="flow">
+  <div><strong>book_annotations</strong>用户私密数据。保存内容、定位、来源标识、远端时间与人工修改时间。</div>
+  <div><strong>chapter_comments</strong>章评独立数据。读取服从书籍可见性，写操作归导入者。</div>
+  <div><strong>readers / Calibre books</strong>用户外键由认证库维护；书籍存在性和可见性继续由 Calibre 与 Item.scope 判定。</div>
+</div>
+<table>
+<thead><tr><th>分组</th><th>关键字段</th><th>约束与说明</th></tr></thead>
+<tbody>
+<tr><td>身份</td><td><code>reader_id</code>、<code>book_id</code></td><td>annotation 的所有读写固定到当前用户；chapter comment 的 reader 是导入者。</td></tr>
+<tr><td>内容</td><td><code>kind</code>、<code>text</code>、<code>refer_text</code>、<code>color</code></td><td>kind 仅允许 highlight / note / bookmark；正文不进入管理接口。</td></tr>
+<tr><td>定位</td><td><code>cfi</code>、<code>chapter</code>、<code>source_position</code></td><td>CFI 可空；章节与来源位置提供降级展示。</td></tr>
+<tr><td>来源</td><td><code>source</code>、<code>external_id</code>、<code>connection_id</code>、<code>run_id</code>、<code>raw_hash</code>、<code>remote_updated_at</code></td><td>与插件 source record / connection / run 对齐，均可随 API 返回。</td></tr>
+<tr><td>冲突</td><td><code>user_modified_at</code>、<code>update_time</code></td><td>人工 PUT 后，后续来源 upsert 默认只刷新来源元数据，不覆盖正文。</td></tr>
+</tbody>
+</table>
+
+<h2>4. API 契约</h2>
+<table>
+<thead><tr><th>方法</th><th>路径</th><th>行为</th></tr></thead>
+<tbody>
+<tr><td>GET / POST</td><td><code>/api/book/:book_id/annotations</code></td><td>列出当前用户该书记录；按 client_id 或 source + external_id 幂等 upsert。</td></tr>
+<tr><td>PUT / DELETE</td><td><code>/api/book/:book_id/annotations/:id</code></td><td>仅 owner 修改或删除；PUT 标记人工修改保护。</td></tr>
+<tr><td>GET / DELETE</td><td><code>/api/annotations</code></td><td>按 book/source/run/connection 查询；DELETE 至少提供一个来源筛选，默认保留人工修改记录。</td></tr>
+<tr><td>GET</td><td><code>/api/annotations/export</code></td><td>返回带 schema version 和导出时间的 JSON 数据集，接受相同筛选。</td></tr>
+<tr><td>GET / POST</td><td><code>/api/book/:book_id/chapter-comments</code></td><td>按书读取章评；登录用户可幂等导入。</td></tr>
+<tr><td>PUT / DELETE</td><td><code>/api/book/:book_id/chapter-comments/:id</code></td><td>仅导入者修改或删除。</td></tr>
+<tr><td>GET / DELETE</td><td><code>/api/chapter-comments</code></td><td>按 source/run/connection 查询或来源清理；不会触及 annotations。</td></tr>
+<tr><td>GET</td><td><code>/api/chapter-comments/export</code></td><td>按相同来源条件导出导入者的章评，并提供独立 schema version。</td></tr>
+</tbody>
+</table>
+<p>所有端点返回 HTTP 200 的 Talebook JSON 错误契约；写接口使用 <code>@js + @auth</code>。章评集合读取也要求登录，避免在缺少产品公开策略前扩大公开面。</p>
+
+<h2>5. 幂等与冲突规则</h2>
+<ol>
+  <li>有 <code>external_id</code> 时优先按 owner + book + source + external_id 查找；否则按 owner + book + client_id 查找。</li>
+  <li><code>raw_hash</code> 相同视为重复投递；早于现存 <code>remote_updated_at</code> 的来源事件视为 stale，不回滚内容。同一远端时间允许来源修正后重新解析。</li>
+  <li>通过单条 PUT 修改内容后写入 <code>user_modified_at</code>；来源 upsert 返回 <code>conflict_protected=true</code>，保留内容但允许更新 connection/run/hash/remote time，便于审计本次同步。</li>
+  <li>来源批量删除默认跳过人工修改记录，显式 <code>include_modified=true</code> 才删除；返回删除数与保护数。</li>
+</ol>
+<div class="callout">普通管理接口不增加 annotation 查询能力。管理员调用 annotation API 时仍只以自己的 reader_id 查询，不能越权读取其他用户正文。</div>
+
+<h2>6. Migration</h2>
+<p>补强 <code>compare_and_migrate</code>：先按 SQLAlchemy metadata 创建缺失表，再沿用现有逻辑为既有表补列。新表由 metadata 一次性创建，因此唯一约束、索引和外键随 migration 落地；已有表不做破坏性重建。</p>
+
+<h2>7. 测试计划与结果</h2>
+<table>
+<thead><tr><th>层级</th><th>验证项</th><th>状态</th></tr></thead>
+<tbody>
+<tr><td>模型 / migration</td><td>唯一约束、nullable CFI、缺失表创建</td><td><code>tests/test_annotations.py</code> 通过</td></tr>
+<tr><td>Annotation API</td><td>权限、幂等、来源查询与导出、来源删除、人工修改保护、stale 保护</td><td>聚焦测试 12 项通过</td></tr>
+<tr><td>Chapter comments</td><td>独立存储、书籍可见性、导入者写权限、删除互不影响</td><td>聚焦测试通过</td></tr>
+<tr><td>工程检查</td><td>ruff、完整 pytest、check-design</td><td>完整后端测试 837 passed / 20 skipped / 7 subtests passed；ruff 通过；check-design 通过</td></tr>
+</tbody>
+</table>
+
+<h2>8. 风险与兼容性</h2>
+<ul>
+  <li>旧 SQLite / MySQL 通过缺失表创建获得新域，不修改 Calibre metadata 数据库。</li>
+  <li>当前连接和 run 只是稳定字符串引用；插件底座未来可在不改变记录结构的前提下增加实体表和外键映射。</li>
+  <li>章评的跨用户可见性被限制在登录且可查看该书的用户；若产品未来要求完全公开或完全私密，需要独立策略变更。</li>
+  <li>本次仅新增服务端数据、迁移和 JSON API，没有页面、交互、文案或其他界面消费者变更，因此豁免 interface-review；剩余风险是外部插件仍需按本契约完成接入。</li>
+</ul>
+</body>
+</html>

--- a/design/webserver/20260814-annotation-data-api.active.html
+++ b/design/webserver/20260814-annotation-data-api.active.html
@@ -34,31 +34,32 @@
 </div>
 
 <h2>1. 原始诉求</h2>
-<p>为微信读书、Readwise、Web、Moke 与 Readest 等笔记插件提供统一服务端契约：个人高亮、笔记与书签可幂等导入、查询、导出和按来源删除；无法精确定位的记录仍可按章节展示；章评使用独立数据域；管理员不能借普通接口读取其他用户的私密正文。</p>
+<p>为微信读书、BRS、Calibre、Web、Moke 与 Readest 等笔记来源提供统一服务端契约。2026-08-15 评审确认：Talebook 的 <code>annotations</code> 是唯一权威内容表；章评也是 annotation 类型，不另建内容表；Calibre 等系统只是可导入、可回写的 source。用户新建或修改非私有 annotation 后，由后台任务异步写入所有已注册 source。</p>
 
 <h2>2. 目标与边界</h2>
 <ul>
-  <li>个人 annotation 以当前登录用户为强制租户边界，书籍访问同时服从现有 <code>can_view_book</code> 权限。</li>
-  <li>支持 <code>highlight</code>、<code>note</code>、<code>bookmark</code>，允许 <code>cfi=NULL</code> 并保留章节、引用文本与来源位置。</li>
-  <li>支持客户端 <code>client_id</code> 幂等，以及 <code>owner + book + source + external_id</code> 来源幂等。</li>
-  <li>章评写入独立表；其正文按书籍可见性读取，写入、修改和来源删除仅限导入者，不复用个人 annotation 的私密查询。</li>
-  <li>本次只提供后端数据与 JSON API，不改页面和阅读器；外部插件连接管理由后续插件底座承接。</li>
+  <li><code>annotations</code> 保存权威正文、位置、隐私和 owner；外部系统不得成为内容主表。</li>
+  <li>支持 <code>highlight</code>、<code>note</code>、<code>bookmark</code>、<code>chapter_comment</code>，允许 <code>cfi=NULL</code> 并保留章节级定位。</li>
+  <li>私有记录只对 owner 可见；非私有记录对所有有该书阅读权限的登录用户可见，但只有 owner 可修改或删除。</li>
+  <li><code>annotation_sources</code> 只保存一条权威记录在各外部系统中的映射和同步状态，所有外部引用字段统一使用 <code>source_</code> 前缀。</li>
+  <li>本次提供 source writer 注册和异步分发契约；BRS、微信读书、Calibre 的具体认证与网络适配由对应插件注册 writer，不在本任务内硬编码。</li>
 </ul>
 
 <h2>3. 数据模型</h2>
 <div class="flow">
-  <div><strong>book_annotations</strong>用户私密数据。保存内容、定位、来源标识、远端时间与人工修改时间。</div>
-  <div><strong>chapter_comments</strong>章评独立数据。读取服从书籍可见性，写操作归导入者。</div>
-  <div><strong>readers / Calibre books</strong>用户外键由认证库维护；书籍存在性和可见性继续由 Calibre 与 Item.scope 判定。</div>
+  <div><strong>annotations</strong>Talebook 权威内容。私人笔记和公共章评使用同一生命周期。</div>
+  <div><strong>annotation_sources</strong>一对多外部副本映射。Calibre、微信读书、BRS 都只是 source。</div>
+  <div><strong>source writers</strong>非私有记录提交后异步扇出；失败状态留在映射表，权威内容不回滚。</div>
 </div>
 <table>
 <thead><tr><th>分组</th><th>关键字段</th><th>约束与说明</th></tr></thead>
 <tbody>
-<tr><td>身份</td><td><code>reader_id</code>、<code>book_id</code></td><td>annotation 的所有读写固定到当前用户；chapter comment 的 reader 是导入者。</td></tr>
-<tr><td>内容</td><td><code>kind</code>、<code>text</code>、<code>refer_text</code>、<code>color</code></td><td>kind 仅允许 highlight / note / bookmark；正文不进入管理接口。</td></tr>
-<tr><td>定位</td><td><code>cfi</code>、<code>chapter</code>、<code>source_position</code></td><td>CFI 可空；章节与来源位置提供降级展示。</td></tr>
-<tr><td>来源</td><td><code>source</code>、<code>external_id</code>、<code>connection_id</code>、<code>run_id</code>、<code>raw_hash</code>、<code>remote_updated_at</code></td><td>与插件 source record / connection / run 对齐，均可随 API 返回。</td></tr>
-<tr><td>冲突</td><td><code>user_modified_at</code>、<code>update_time</code></td><td>人工 PUT 后，后续来源 upsert 默认只刷新来源元数据，不覆盖正文。</td></tr>
+<tr><td>权威身份</td><td><code>annotations.id</code>、<code>reader_id</code>、<code>book_id</code>、<code>client_id</code></td><td><code>(reader_id, book_id, client_id)</code> 保证 Talebook 客户端幂等；书籍仍是跨数据库逻辑引用。</td></tr>
+<tr><td>权威内容</td><td><code>annotation_type</code>、<code>content</code>、<code>quote_text</code>、<code>color</code>、<code>author_name</code></td><td>章评用 <code>chapter_comment</code> 类型表达，不再创建 <code>chapter_comments</code> 表。</td></tr>
+<tr><td>位置与隐私</td><td><code>cfi</code>、<code>chapter</code>、<code>is_private</code></td><td>CFI 可空；<code>is_private=true</code> 为安全默认值，且不会向外部 source 扇出。</td></tr>
+<tr><td>外部身份</td><td><code>source_name</code>、<code>source_connection_id</code>、<code>source_annotation_id</code></td><td>位于 <code>annotation_sources</code>；外部唯一键为三者组合，每条 annotation 在同一 source connection 只有一个副本。</td></tr>
+<tr><td>外部状态</td><td><code>source_run_id</code>、<code>source_position</code>、<code>source_raw_hash</code>、<code>source_updated_at</code></td><td>用于来源幂等、旧事件保护和定位追踪，避免无前缀字段被误认为 Talebook 权威属性。</td></tr>
+<tr><td>同步状态</td><td><code>source_sync_status</code>、<code>source_synced_at</code>、<code>source_sync_error</code></td><td>状态为 pending / synced / failed；外部失败只更新副本状态，不回滚 <code>annotations</code>。</td></tr>
 </tbody>
 </table>
 
@@ -66,47 +67,51 @@
 <table>
 <thead><tr><th>方法</th><th>路径</th><th>行为</th></tr></thead>
 <tbody>
-<tr><td>GET / POST</td><td><code>/api/book/:book_id/annotations</code></td><td>列出当前用户该书记录；按 client_id 或 source + external_id 幂等 upsert。</td></tr>
-<tr><td>PUT / DELETE</td><td><code>/api/book/:book_id/annotations/:id</code></td><td>仅 owner 修改或删除；PUT 标记人工修改保护。</td></tr>
-<tr><td>GET / DELETE</td><td><code>/api/annotations</code></td><td>按 book/source/run/connection 查询；DELETE 至少提供一个来源筛选，默认保留人工修改记录。</td></tr>
-<tr><td>GET</td><td><code>/api/annotations/export</code></td><td>返回带 schema version 和导出时间的 JSON 数据集，接受相同筛选。</td></tr>
-<tr><td>GET / POST</td><td><code>/api/book/:book_id/chapter-comments</code></td><td>按书读取章评；登录用户可幂等导入。</td></tr>
-<tr><td>PUT / DELETE</td><td><code>/api/book/:book_id/chapter-comments/:id</code></td><td>仅导入者修改或删除。</td></tr>
-<tr><td>GET / DELETE</td><td><code>/api/chapter-comments</code></td><td>按 source/run/connection 查询或来源清理；不会触及 annotations。</td></tr>
-<tr><td>GET</td><td><code>/api/chapter-comments/export</code></td><td>按相同来源条件导出导入者的章评，并提供独立 schema version。</td></tr>
+<tr><td>GET / POST</td><td><code>/api/book/:book_id/annotations</code></td><td>GET 返回 owner 私有记录及该书公共记录；POST 按 client_id 或 source 三元身份幂等 upsert。</td></tr>
+<tr><td>PUT / DELETE</td><td><code>/api/book/:book_id/annotations/:id</code></td><td>仅 owner 修改或删除；非私有内容更新后再次异步扇出。</td></tr>
+<tr><td>GET / DELETE</td><td><code>/api/annotations</code></td><td>仅管理当前用户权威记录；来源筛选字段均为 <code>source_*</code>。DELETE 来源筛选只解除匹配 source 映射，不删除权威正文。</td></tr>
+<tr><td>GET</td><td><code>/api/annotations/export</code></td><td>导出 Talebook 权威记录以及每条记录的 <code>sources</code> 映射列表。</td></tr>
 </tbody>
 </table>
-<p>所有端点返回 HTTP 200 的 Talebook JSON 错误契约；写接口使用 <code>@js + @auth</code>。章评集合读取也要求登录，避免在缺少产品公开策略前扩大公开面。</p>
+<p>不再提供 <code>/api/*/chapter-comments</code> 路由。创建 payload 使用 <code>annotation_type</code>、<code>content</code>、<code>quote_text</code>、<code>is_private</code>；来源导入额外携带 <code>source_name</code>、<code>source_connection_id</code>、<code>source_annotation_id</code> 等统一前缀字段。</p>
 
 <h2>5. 幂等与冲突规则</h2>
 <ol>
-  <li>有 <code>external_id</code> 时优先按 owner + book + source + external_id 查找；否则按 owner + book + client_id 查找。</li>
-  <li><code>raw_hash</code> 相同视为重复投递；早于现存 <code>remote_updated_at</code> 的来源事件视为 stale，不回滚内容。同一远端时间允许来源修正后重新解析。</li>
-  <li>通过单条 PUT 修改内容后写入 <code>user_modified_at</code>；来源 upsert 返回 <code>conflict_protected=true</code>，保留内容但允许更新 connection/run/hash/remote time，便于审计本次同步。</li>
-  <li>来源批量删除默认跳过人工修改记录，显式 <code>include_modified=true</code> 才删除；返回删除数与保护数。</li>
+  <li>有 <code>source_name + source_connection_id + source_annotation_id</code> 时优先按 source 映射查找；本地创建则按 owner + book + client_id 查找。</li>
+  <li>早于现存 <code>source_updated_at</code> 且 hash 不同的来源事件视为 stale，不回滚权威内容。</li>
+  <li>通过 Talebook PUT 修改内容后写入 <code>user_modified_at</code>；后续来源导入只刷新该 source 映射并返回 <code>conflict_protected=true</code>。</li>
+  <li>来源清理删除的是 <code>annotation_sources</code> 映射。权威 annotation 只能通过单条 owner DELETE 删除。</li>
 </ol>
-<div class="callout">普通管理接口不增加 annotation 查询能力。管理员调用 annotation API 时仍只以自己的 reader_id 查询，不能越权读取其他用户正文。</div>
+<div class="callout">管理员不会获得读取他人私有正文的旁路；公共 annotation 也必须先通过该书现有可见性校验。</div>
 
-<h2>6. Migration</h2>
-<p>补强 <code>compare_and_migrate</code>：先按 SQLAlchemy metadata 创建缺失表，再沿用现有逻辑为既有表补列。新表由 metadata 一次性创建，因此唯一约束、索引和外键随 migration 落地；已有表不做破坏性重建。</p>
+<h2>6. 异步 source 扇出</h2>
+<ol>
+  <li>handler 先提交 Talebook 权威事务，再把 annotation id 放入 <code>AnnotationSyncService</code> 队列。</li>
+  <li>服务枚举插件注册的 source writer；为每个 writer upsert 一条 pending 映射，然后调用 writer。</li>
+  <li>成功后记录外部 id、hash、远端时间并标记 synced；异常写入 failed 与错误摘要，其他 source 继续执行。</li>
+  <li>私有 annotation 不入队；来源导入可排除原 source，避免回环，同时仍可扇出到其他已注册 source。</li>
+</ol>
 
-<h2>7. 测试计划与结果</h2>
+<h2>7. Migration</h2>
+<p>PR 尚未合入且旧新表均未发布，因此直接以最终模型创建 <code>annotations</code> 与 <code>annotation_sources</code>，不为草稿中的 <code>book_annotations</code> / <code>chapter_comments</code> 增加兼容迁移。<code>compare_and_migrate</code> 仍先创建缺失整表，确保唯一约束、索引和 FK 一并落地。</p>
+
+<h2>8. 测试计划与结果</h2>
 <table>
 <thead><tr><th>层级</th><th>验证项</th><th>状态</th></tr></thead>
 <tbody>
-<tr><td>模型 / migration</td><td>唯一约束、nullable CFI、缺失表创建</td><td><code>tests/test_annotations.py</code> 通过</td></tr>
-<tr><td>Annotation API</td><td>权限、幂等、来源查询与导出、来源删除、人工修改保护、stale 保护</td><td>聚焦测试 12 项通过</td></tr>
-<tr><td>Chapter comments</td><td>独立存储、书籍可见性、导入者写权限、删除互不影响</td><td>聚焦测试通过</td></tr>
-<tr><td>工程检查</td><td>ruff、完整 pytest、check-design</td><td>完整后端测试 837 passed / 20 skipped / 7 subtests passed；ruff 通过；check-design 通过</td></tr>
+<tr><td>模型 / migration</td><td>最终表名、两组唯一约束、级联删除、nullable CFI</td><td><code>tests/test_annotations.py</code> 通过</td></tr>
+<tr><td>Annotation API</td><td>本地/来源幂等、公共与私有可见性、章评同表、owner 写权限、stale 与冲突保护</td><td>聚焦回归 13 passed</td></tr>
+<tr><td>Source 同步</td><td>私有不扇出、公共异步调用全部 writer、失败隔离、来源映射状态</td><td>Calibre / 微信读书模拟 writer 测试通过</td></tr>
+<tr><td>工程检查</td><td><code>make lint-py-fix</code>、<code>make lint-py</code>、完整 pytest、<code>make check-design</code></td><td>Ruff 通过；完整后端 838 passed / 20 skipped；方案校验通过</td></tr>
 </tbody>
 </table>
 
-<h2>8. 风险与兼容性</h2>
+<h2>9. 风险与兼容性</h2>
 <ul>
-  <li>旧 SQLite / MySQL 通过缺失表创建获得新域，不修改 Calibre metadata 数据库。</li>
-  <li>当前连接和 run 只是稳定字符串引用；插件底座未来可在不改变记录结构的前提下增加实体表和外键映射。</li>
-  <li>章评的跨用户可见性被限制在登录且可查看该书的用户；若产品未来要求完全公开或完全私密，需要独立策略变更。</li>
-  <li>本次仅新增服务端数据、迁移和 JSON API，没有页面、交互、文案或其他界面消费者变更，因此豁免 interface-review；剩余风险是外部插件仍需按本契约完成接入。</li>
+  <li>外部写入不是数据库事务的一部分，允许短暂最终一致；pending / failed 状态用于观察和后续重试。</li>
+  <li>删除向外部 source 的传播和持久化重试调度暂不在本任务内，后续插件实现必须补齐。</li>
+  <li><code>book_id</code> 仍是跨用户库与 Calibre 库的逻辑引用，数据库无法建立 FK。</li>
+  <li>本次仅调整后端数据、迁移与 JSON API，没有页面、交互或文案变化，因此豁免 interface-review；外部消费者必须切换到新字段名。</li>
 </ul>
 </body>
 </html>

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -12,6 +12,7 @@ from tests.test_main import BID_EPUB, TestApp, TestWithUserLogin, get_db, tempor
 from tests.test_main import setUpModule as init
 from webserver import models
 from webserver.migrate_db import compare_and_migrate
+from webserver.services.annotation_sync import AnnotationSyncService
 
 
 def setUpModule():
@@ -26,37 +27,40 @@ class TestAnnotationModelsAndMigration(unittest.TestCase):
         self.assertTrue(compare_and_migrate(engine))
 
         inspector = inspect(engine)
-        self.assertIn("book_annotations", inspector.get_table_names())
-        self.assertIn("chapter_comments", inspector.get_table_names())
-        annotation_constraints = {item["name"] for item in inspector.get_unique_constraints("book_annotations")}
+        self.assertIn("annotations", inspector.get_table_names())
+        self.assertIn("annotation_sources", inspector.get_table_names())
+        self.assertNotIn("book_annotations", inspector.get_table_names())
+        self.assertNotIn("chapter_comments", inspector.get_table_names())
+        annotation_constraints = {item["name"] for item in inspector.get_unique_constraints("annotations")}
+        source_constraints = {item["name"] for item in inspector.get_unique_constraints("annotation_sources")}
         self.assertIn("uq_annotation_client_id", annotation_constraints)
-        self.assertIn("uq_annotation_source_external_id", annotation_constraints)
+        self.assertIn("uq_annotation_source_connection", source_constraints)
+        self.assertIn("uq_annotation_source_identity", source_constraints)
 
-    def test_source_external_id_is_unique_per_owner_and_book(self):
+    def test_source_identity_is_unique_across_authoritative_annotations(self):
         engine = create_engine("sqlite://")
         models.Base.metadata.create_all(engine)
         session = sessionmaker(bind=engine)()
         session.add(models.Reader(id=1, username="owner"))
-        session.commit()
+        first = models.Annotation(reader_id=1, book_id=1, annotation_type="highlight", client_id="first")
+        second = models.Annotation(reader_id=1, book_id=1, annotation_type="note", client_id="second")
+        session.add_all([first, second])
+        session.flush()
         session.add(
-            models.BookAnnotation(
-                reader_id=1,
-                book_id=1,
-                kind="highlight",
-                source="weread",
-                external_id="same",
-                cfi=None,
+            models.AnnotationSource(
+                annotation_id=first.id,
+                source_name="weread",
+                source_connection_id="conn-1",
+                source_annotation_id="same",
             )
         )
         session.commit()
         session.add(
-            models.BookAnnotation(
-                reader_id=1,
-                book_id=1,
-                kind="note",
-                source="weread",
-                external_id="same",
-                cfi=None,
+            models.AnnotationSource(
+                annotation_id=second.id,
+                source_name="weread",
+                source_connection_id="conn-1",
+                source_annotation_id="same",
             )
         )
         with self.assertRaises(IntegrityError):
@@ -69,41 +73,43 @@ class TestAnnotationAuthentication(TestApp):
         d = self.json("/api/book/%d/annotations" % BID_EPUB)
         self.assertEqual(d["err"], "user.need_login")
 
-        d = self.json("/api/book/%d/chapter-comments" % BID_EPUB)
-        self.assertEqual(d["err"], "user.need_login")
-
 
 class TestAnnotations(TestWithUserLogin):
     def setUp(self):
         super().setUp()
         self.user.return_value = 1
+        AnnotationSyncService.reset_writers()
         self._clear()
 
     def tearDown(self):
         self.user.return_value = 1
+        AnnotationSyncService.reset_writers()
         self._clear()
         super().tearDown()
 
     def _clear(self):
         session = get_db()
-        session.query(models.BookAnnotation).filter(models.BookAnnotation.book_id == BID_EPUB).delete()
-        session.query(models.ChapterComment).filter(models.ChapterComment.book_id == BID_EPUB).delete()
+        annotation_ids = [
+            annotation_id
+            for (annotation_id,) in session.query(models.Annotation.id).filter(models.Annotation.book_id == BID_EPUB).all()
+        ]
+        if annotation_ids:
+            session.query(models.AnnotationSource).filter(models.AnnotationSource.annotation_id.in_(annotation_ids)).delete(
+                synchronize_session=False
+            )
+        session.query(models.Annotation).filter(models.Annotation.book_id == BID_EPUB).delete()
         session.commit()
 
-    def _post_annotation(self, **overrides):
+    def _post_local(self, **overrides):
         data = {
-            "kind": "highlight",
-            "source": "weread",
-            "external_id": "ann-1",
+            "annotation_type": "note",
+            "client_id": "client-1",
+            "is_private": True,
             "chapter": "第一章",
             "cfi": None,
-            "refer_text": "引用",
-            "text": "原始笔记",
-            "source_position": "chapter:1#p2",
-            "connection_id": "conn-1",
-            "run_id": "run-1",
-            "raw_hash": "hash-1",
-            "remote_updated_at": "2026-08-14T10:00:00Z",
+            "quote_text": "引用",
+            "content": "本地笔记",
+            "color": "yellow",
         }
         data.update(overrides)
         return self.json(
@@ -112,169 +118,196 @@ class TestAnnotations(TestWithUserLogin):
             body=json.dumps(data),
         )
 
-    def _post_comment(self, **overrides):
+    def _post_source(self, **overrides):
         data = {
-            "source": "weread",
-            "external_id": "comment-1",
+            "annotation_type": "highlight",
+            "source_name": "weread",
+            "source_connection_id": "conn-1",
+            "source_annotation_id": "ann-1",
+            "source_run_id": "run-1",
+            "source_position": "chapter:1#p2",
+            "source_raw_hash": "hash-1",
+            "source_updated_at": "2026-08-14T10:00:00Z",
             "chapter": "第一章",
             "cfi": None,
-            "source_position": "chapter:1#comment:2",
-            "text": "公开章评",
-            "author_name": "读者甲",
-            "connection_id": "conn-1",
-            "run_id": "run-1",
-            "raw_hash": "comment-hash-1",
-            "remote_updated_at": "2026-08-14T10:00:00Z",
+            "quote_text": "引用",
+            "content": "来源笔记",
+            "is_private": True,
         }
         data.update(overrides)
         return self.json(
-            "/api/book/%d/chapter-comments" % BID_EPUB,
+            "/api/book/%d/annotations" % BID_EPUB,
             method="POST",
             body=json.dumps(data),
         )
 
-    def test_source_upsert_is_idempotent_and_keeps_nullable_cfi(self):
-        first = self._post_annotation()
+    def test_source_upsert_is_idempotent_and_uses_prefixed_source_fields(self):
+        first = self._post_source()
         self.assertEqual(first["err"], "ok")
         self.assertTrue(first["created"])
         self.assertIsNone(first["annotation"]["cfi"])
 
-        second = self._post_annotation(text="更新后的笔记", run_id="run-2", raw_hash="hash-2")
+        second = self._post_source(
+            content="更新后的笔记",
+            source_run_id="run-2",
+            source_raw_hash="hash-2",
+        )
         self.assertEqual(second["err"], "ok")
         self.assertFalse(second["created"])
         self.assertEqual(second["annotation"]["id"], first["annotation"]["id"])
 
-        d = self.json("/api/book/%d/annotations?source=weread&run_id=run-2&connection_id=conn-1" % BID_EPUB)
+        d = self.json("/api/book/%d/annotations?source_name=weread&source_run_id=run-2&source_connection_id=conn-1" % BID_EPUB)
         self.assertEqual(len(d["annotations"]), 1)
-        self.assertEqual(d["annotations"][0]["text"], "更新后的笔记")
-        self.assertEqual(d["annotations"][0]["source_position"], "chapter:1#p2")
+        self.assertEqual(d["annotations"][0]["content"], "更新后的笔记")
+        self.assertEqual(d["annotations"][0]["sources"][0]["source_position"], "chapter:1#p2")
 
-        d = self.json("/api/annotations/export?source=weread&run_id=run-2")
-        self.assertEqual(d["export"]["schema"], "talebook.annotations.v1")
+        d = self.json("/api/annotations/export?source_name=weread&source_run_id=run-2")
+        self.assertEqual(d["export"]["schema"], "talebook.annotations.v2")
         self.assertEqual(len(d["export"]["annotations"]), 1)
 
-    def test_client_id_upsert_is_idempotent(self):
-        first = self._post_annotation(source="talebook", external_id=None, client_id="client-1")
-        second = self._post_annotation(
-            source="talebook",
-            external_id=None,
-            client_id="client-1",
-            text="same client updated",
-        )
+    def test_legacy_unprefixed_source_fields_are_rejected(self):
+        d = self._post_local(source="weread", external_id="legacy-id")
+        self.assertEqual(d["err"], "params.invalid")
+        self.assertEqual(get_db().query(models.Annotation).count(), 0)
+
+    def test_local_client_id_upsert_is_authoritative(self):
+        first = self._post_local()
+        second = self._post_local(content="same client updated")
         self.assertEqual(first["annotation"]["id"], second["annotation"]["id"])
-        self.assertEqual(second["annotation"]["text"], "same client updated")
-        self.assertEqual(get_db().query(models.BookAnnotation).count(), 1)
+        self.assertEqual(second["annotation"]["content"], "same client updated")
+        self.assertIsNotNone(second["annotation"]["user_modified_at"])
+        self.assertEqual(get_db().query(models.Annotation).count(), 1)
 
     def test_admin_identity_cannot_read_another_users_private_annotation(self):
         session = get_db()
         admin = session.get(models.Reader, 1)
         self.assertTrue(admin.is_admin())
         session.add(
-            models.BookAnnotation(
+            models.Annotation(
                 reader_id=2,
                 book_id=BID_EPUB,
-                kind="note",
-                source="readwise",
-                external_id="private-user-2",
-                text="user two secret",
+                annotation_type="note",
+                client_id="private-user-2",
+                content="user two secret",
+                is_private=True,
             )
         )
         session.commit()
 
-        d = self.json("/api/annotations?source=readwise")
+        d = self.json("/api/annotations")
         self.assertEqual(d["annotations"], [])
         d = self.json("/api/book/%d/annotations" % BID_EPUB)
         self.assertNotIn("user two secret", json.dumps(d, ensure_ascii=False))
 
+    def test_public_chapter_comment_uses_annotations_table_and_owner_write_rule(self):
+        created = self._post_source(
+            annotation_type="chapter_comment",
+            source_annotation_id="comment-1",
+            content="公开章评",
+            author_name="读者甲",
+            is_private=False,
+        )
+        annotation_id = created["annotation"]["id"]
+        self.assertEqual(get_db().query(models.Annotation).filter_by(annotation_type="chapter_comment").count(), 1)
+
+        self.user.return_value = 2
+        d = self.json("/api/book/%d/annotations" % BID_EPUB)
+        self.assertEqual(len(d["annotations"]), 1)
+        self.assertEqual(d["annotations"][0]["content"], "公开章评")
+        d = self.json(
+            "/api/book/%d/annotations/%d" % (BID_EPUB, annotation_id),
+            method="PUT",
+            body=json.dumps({"content": "越权修改"}),
+        )
+        self.assertEqual(d["err"], "annotation.not_found")
+        d = self.json(
+            "/api/book/%d/annotations/%d" % (BID_EPUB, annotation_id),
+            method="DELETE",
+        )
+        self.assertEqual(d["err"], "annotation.not_found")
+
     def test_book_permission_is_checked_for_regular_user(self):
         self.user.return_value = 2
         with temporary_book_scope(BID_EPUB, "private", collector_id=1):
-            d = self._post_annotation(external_id="denied")
+            d = self._post_local(client_id="denied")
             self.assertEqual(d["err"], "params.book.invalid")
             d = self.json("/api/book/%d/annotations" % BID_EPUB)
             self.assertEqual(d["err"], "params.book.invalid")
 
-    def test_manual_update_is_protected_from_import_and_source_deletion(self):
-        created = self._post_annotation()
+    def test_manual_update_is_protected_from_later_source_import(self):
+        created = self._post_source()
         annotation_id = created["annotation"]["id"]
         d = self.json(
             "/api/book/%d/annotations/%d" % (BID_EPUB, annotation_id),
             method="PUT",
-            body=json.dumps({"text": "我的手工修订"}),
+            body=json.dumps({"content": "我的手工修订"}),
         )
         self.assertIsNotNone(d["annotation"]["user_modified_at"])
 
-        imported = self._post_annotation(
-            text="远端覆盖内容",
-            raw_hash="hash-new",
-            run_id="run-new",
-            remote_updated_at="2026-08-15T10:00:00Z",
+        imported = self._post_source(
+            content="远端覆盖内容",
+            source_raw_hash="hash-new",
+            source_run_id="run-new",
+            source_updated_at="2026-08-15T10:00:00Z",
         )
         self.assertTrue(imported["conflict_protected"])
-        self.assertEqual(imported["annotation"]["text"], "我的手工修订")
-        self.assertEqual(imported["annotation"]["run_id"], "run-new")
+        self.assertEqual(imported["annotation"]["content"], "我的手工修订")
+        self.assertEqual(imported["annotation"]["sources"][0]["source_run_id"], "run-new")
 
-        d = self.json("/api/annotations?source=weread", method="DELETE")
-        self.assertEqual(d["deleted"], 0)
-        self.assertEqual(d["protected"], 1)
-        self.assertEqual(get_db().query(models.BookAnnotation).count(), 1)
-
-        d = self.json("/api/annotations?source=weread&include_modified=true", method="DELETE")
-        self.assertEqual(d["deleted"], 1)
-        self.assertEqual(get_db().query(models.BookAnnotation).count(), 0)
-
-    def test_older_remote_event_is_ignored(self):
-        self._post_annotation(text="new content")
-        stale = self._post_annotation(
-            text="old content",
-            raw_hash="old-hash",
-            remote_updated_at="2026-08-13T10:00:00Z",
+    def test_older_source_event_is_ignored(self):
+        self._post_source(content="new content")
+        stale = self._post_source(
+            content="old content",
+            source_raw_hash="old-hash",
+            source_updated_at="2026-08-13T10:00:00Z",
         )
         self.assertTrue(stale["stale_ignored"])
-        self.assertEqual(stale["annotation"]["text"], "new content")
+        self.assertEqual(stale["annotation"]["content"], "new content")
 
-    def test_source_delete_requires_a_source_scope(self):
-        self._post_annotation()
+    def test_source_cleanup_unlinks_replica_but_keeps_authoritative_content(self):
+        self._post_source()
         d = self.json("/api/annotations?book_id=%d" % BID_EPUB, method="DELETE")
         self.assertEqual(d["err"], "params.invalid")
-        self.assertEqual(get_db().query(models.BookAnnotation).count(), 1)
 
-    def test_chapter_comments_are_visible_but_writable_only_by_importer(self):
-        created = self._post_comment()
-        comment_id = created["chapter_comment"]["id"]
+        d = self.json("/api/annotations?source_name=weread&source_connection_id=conn-1", method="DELETE")
+        self.assertEqual(d["sources_deleted"], 1)
+        self.assertEqual(d["annotations_deleted"], 0)
+        self.assertEqual(get_db().query(models.Annotation).count(), 1)
+        self.assertEqual(get_db().query(models.AnnotationSource).count(), 0)
 
-        self.user.return_value = 2
-        d = self.json("/api/book/%d/chapter-comments" % BID_EPUB)
-        self.assertEqual(len(d["chapter_comments"]), 1)
-        self.assertEqual(d["chapter_comments"][0]["text"], "公开章评")
-        d = self.json(
-            "/api/book/%d/chapter-comments/%d" % (BID_EPUB, comment_id),
-            method="PUT",
-            body=json.dumps({"text": "越权修改"}),
-        )
-        self.assertEqual(d["err"], "chapter_comment.not_found")
-        d = self.json(
-            "/api/book/%d/chapter-comments/%d" % (BID_EPUB, comment_id),
-            method="DELETE",
-        )
-        self.assertEqual(d["err"], "chapter_comment.not_found")
+    def test_public_annotation_fans_out_to_all_writers_and_private_does_not(self):
+        calls = []
 
-    def test_annotation_and_chapter_comment_deletion_are_isolated(self):
-        self._post_annotation()
-        self._post_comment()
+        def calibre_writer(annotation, source):
+            calls.append(("calibre", annotation["id"], source["source_sync_status"]))
+            return {
+                "source_annotation_id": "calibre-1",
+                "source_raw_hash": "calibre-hash",
+                "source_updated_at": "2026-08-15T12:00:00Z",
+            }
 
-        d = self.json("/api/chapter-comments/export?source=weread&run_id=run-1&connection_id=conn-1")
-        self.assertEqual(d["export"]["schema"], "talebook.chapter-comments.v1")
-        self.assertEqual(len(d["export"]["chapter_comments"]), 1)
+        def weread_writer(annotation, source):
+            calls.append(("weread", annotation["id"], source["source_sync_status"]))
+            raise RuntimeError("remote unavailable")
 
-        d = self.json("/api/annotations?connection_id=conn-1", method="DELETE")
-        self.assertEqual(d["deleted"], 1)
-        self.assertEqual(get_db().query(models.BookAnnotation).count(), 0)
-        self.assertEqual(get_db().query(models.ChapterComment).count(), 1)
+        AnnotationSyncService.register_writer("calibre", calibre_writer)
+        AnnotationSyncService.register_writer("weread", weread_writer, "conn-1")
 
-        d = self.json("/api/chapter-comments?run_id=run-1", method="DELETE")
-        self.assertEqual(d["deleted"], 1)
-        self.assertEqual(get_db().query(models.ChapterComment).count(), 0)
+        private = self._post_local(client_id="private")
+        self.assertFalse(private["sync_enqueued"])
+        self.assertEqual(calls, [])
+
+        public = self._post_local(client_id="public", is_private=False)
+        self.assertTrue(public["sync_enqueued"])
+        self.assertEqual([call[0] for call in calls], ["calibre", "weread"])
+        sources = {
+            source.source_name: source
+            for source in get_db().query(models.AnnotationSource).filter_by(annotation_id=public["annotation"]["id"])
+        }
+        self.assertEqual(sources["calibre"].source_sync_status, "synced")
+        self.assertEqual(sources["calibre"].source_annotation_id, "calibre-1")
+        self.assertEqual(sources["weread"].source_sync_status, "failed")
+        self.assertIn("remote unavailable", sources["weread"].source_sync_error)
 
 
 if __name__ == "__main__":

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+
+import json
+import unittest
+
+from sqlalchemy import create_engine, inspect
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import sessionmaker
+
+from tests.test_main import BID_EPUB, TestApp, TestWithUserLogin, get_db, temporary_book_scope
+from tests.test_main import setUpModule as init
+from webserver import models
+from webserver.migrate_db import compare_and_migrate
+
+
+def setUpModule():
+    init()
+
+
+class TestAnnotationModelsAndMigration(unittest.TestCase):
+    def test_missing_annotation_tables_are_migrated_with_constraints(self):
+        engine = create_engine("sqlite://")
+        models.Reader.__table__.create(engine)
+
+        self.assertTrue(compare_and_migrate(engine))
+
+        inspector = inspect(engine)
+        self.assertIn("book_annotations", inspector.get_table_names())
+        self.assertIn("chapter_comments", inspector.get_table_names())
+        annotation_constraints = {item["name"] for item in inspector.get_unique_constraints("book_annotations")}
+        self.assertIn("uq_annotation_client_id", annotation_constraints)
+        self.assertIn("uq_annotation_source_external_id", annotation_constraints)
+
+    def test_source_external_id_is_unique_per_owner_and_book(self):
+        engine = create_engine("sqlite://")
+        models.Base.metadata.create_all(engine)
+        session = sessionmaker(bind=engine)()
+        session.add(models.Reader(id=1, username="owner"))
+        session.commit()
+        session.add(
+            models.BookAnnotation(
+                reader_id=1,
+                book_id=1,
+                kind="highlight",
+                source="weread",
+                external_id="same",
+                cfi=None,
+            )
+        )
+        session.commit()
+        session.add(
+            models.BookAnnotation(
+                reader_id=1,
+                book_id=1,
+                kind="note",
+                source="weread",
+                external_id="same",
+                cfi=None,
+            )
+        )
+        with self.assertRaises(IntegrityError):
+            session.commit()
+        session.rollback()
+
+
+class TestAnnotationAuthentication(TestApp):
+    def test_annotation_endpoints_require_login(self):
+        d = self.json("/api/book/%d/annotations" % BID_EPUB)
+        self.assertEqual(d["err"], "user.need_login")
+
+        d = self.json("/api/book/%d/chapter-comments" % BID_EPUB)
+        self.assertEqual(d["err"], "user.need_login")
+
+
+class TestAnnotations(TestWithUserLogin):
+    def setUp(self):
+        super().setUp()
+        self.user.return_value = 1
+        self._clear()
+
+    def tearDown(self):
+        self.user.return_value = 1
+        self._clear()
+        super().tearDown()
+
+    def _clear(self):
+        session = get_db()
+        session.query(models.BookAnnotation).filter(models.BookAnnotation.book_id == BID_EPUB).delete()
+        session.query(models.ChapterComment).filter(models.ChapterComment.book_id == BID_EPUB).delete()
+        session.commit()
+
+    def _post_annotation(self, **overrides):
+        data = {
+            "kind": "highlight",
+            "source": "weread",
+            "external_id": "ann-1",
+            "chapter": "第一章",
+            "cfi": None,
+            "refer_text": "引用",
+            "text": "原始笔记",
+            "source_position": "chapter:1#p2",
+            "connection_id": "conn-1",
+            "run_id": "run-1",
+            "raw_hash": "hash-1",
+            "remote_updated_at": "2026-08-14T10:00:00Z",
+        }
+        data.update(overrides)
+        return self.json(
+            "/api/book/%d/annotations" % BID_EPUB,
+            method="POST",
+            body=json.dumps(data),
+        )
+
+    def _post_comment(self, **overrides):
+        data = {
+            "source": "weread",
+            "external_id": "comment-1",
+            "chapter": "第一章",
+            "cfi": None,
+            "source_position": "chapter:1#comment:2",
+            "text": "公开章评",
+            "author_name": "读者甲",
+            "connection_id": "conn-1",
+            "run_id": "run-1",
+            "raw_hash": "comment-hash-1",
+            "remote_updated_at": "2026-08-14T10:00:00Z",
+        }
+        data.update(overrides)
+        return self.json(
+            "/api/book/%d/chapter-comments" % BID_EPUB,
+            method="POST",
+            body=json.dumps(data),
+        )
+
+    def test_source_upsert_is_idempotent_and_keeps_nullable_cfi(self):
+        first = self._post_annotation()
+        self.assertEqual(first["err"], "ok")
+        self.assertTrue(first["created"])
+        self.assertIsNone(first["annotation"]["cfi"])
+
+        second = self._post_annotation(text="更新后的笔记", run_id="run-2", raw_hash="hash-2")
+        self.assertEqual(second["err"], "ok")
+        self.assertFalse(second["created"])
+        self.assertEqual(second["annotation"]["id"], first["annotation"]["id"])
+
+        d = self.json("/api/book/%d/annotations?source=weread&run_id=run-2&connection_id=conn-1" % BID_EPUB)
+        self.assertEqual(len(d["annotations"]), 1)
+        self.assertEqual(d["annotations"][0]["text"], "更新后的笔记")
+        self.assertEqual(d["annotations"][0]["source_position"], "chapter:1#p2")
+
+        d = self.json("/api/annotations/export?source=weread&run_id=run-2")
+        self.assertEqual(d["export"]["schema"], "talebook.annotations.v1")
+        self.assertEqual(len(d["export"]["annotations"]), 1)
+
+    def test_client_id_upsert_is_idempotent(self):
+        first = self._post_annotation(source="talebook", external_id=None, client_id="client-1")
+        second = self._post_annotation(
+            source="talebook",
+            external_id=None,
+            client_id="client-1",
+            text="same client updated",
+        )
+        self.assertEqual(first["annotation"]["id"], second["annotation"]["id"])
+        self.assertEqual(second["annotation"]["text"], "same client updated")
+        self.assertEqual(get_db().query(models.BookAnnotation).count(), 1)
+
+    def test_admin_identity_cannot_read_another_users_private_annotation(self):
+        session = get_db()
+        admin = session.get(models.Reader, 1)
+        self.assertTrue(admin.is_admin())
+        session.add(
+            models.BookAnnotation(
+                reader_id=2,
+                book_id=BID_EPUB,
+                kind="note",
+                source="readwise",
+                external_id="private-user-2",
+                text="user two secret",
+            )
+        )
+        session.commit()
+
+        d = self.json("/api/annotations?source=readwise")
+        self.assertEqual(d["annotations"], [])
+        d = self.json("/api/book/%d/annotations" % BID_EPUB)
+        self.assertNotIn("user two secret", json.dumps(d, ensure_ascii=False))
+
+    def test_book_permission_is_checked_for_regular_user(self):
+        self.user.return_value = 2
+        with temporary_book_scope(BID_EPUB, "private", collector_id=1):
+            d = self._post_annotation(external_id="denied")
+            self.assertEqual(d["err"], "params.book.invalid")
+            d = self.json("/api/book/%d/annotations" % BID_EPUB)
+            self.assertEqual(d["err"], "params.book.invalid")
+
+    def test_manual_update_is_protected_from_import_and_source_deletion(self):
+        created = self._post_annotation()
+        annotation_id = created["annotation"]["id"]
+        d = self.json(
+            "/api/book/%d/annotations/%d" % (BID_EPUB, annotation_id),
+            method="PUT",
+            body=json.dumps({"text": "我的手工修订"}),
+        )
+        self.assertIsNotNone(d["annotation"]["user_modified_at"])
+
+        imported = self._post_annotation(
+            text="远端覆盖内容",
+            raw_hash="hash-new",
+            run_id="run-new",
+            remote_updated_at="2026-08-15T10:00:00Z",
+        )
+        self.assertTrue(imported["conflict_protected"])
+        self.assertEqual(imported["annotation"]["text"], "我的手工修订")
+        self.assertEqual(imported["annotation"]["run_id"], "run-new")
+
+        d = self.json("/api/annotations?source=weread", method="DELETE")
+        self.assertEqual(d["deleted"], 0)
+        self.assertEqual(d["protected"], 1)
+        self.assertEqual(get_db().query(models.BookAnnotation).count(), 1)
+
+        d = self.json("/api/annotations?source=weread&include_modified=true", method="DELETE")
+        self.assertEqual(d["deleted"], 1)
+        self.assertEqual(get_db().query(models.BookAnnotation).count(), 0)
+
+    def test_older_remote_event_is_ignored(self):
+        self._post_annotation(text="new content")
+        stale = self._post_annotation(
+            text="old content",
+            raw_hash="old-hash",
+            remote_updated_at="2026-08-13T10:00:00Z",
+        )
+        self.assertTrue(stale["stale_ignored"])
+        self.assertEqual(stale["annotation"]["text"], "new content")
+
+    def test_source_delete_requires_a_source_scope(self):
+        self._post_annotation()
+        d = self.json("/api/annotations?book_id=%d" % BID_EPUB, method="DELETE")
+        self.assertEqual(d["err"], "params.invalid")
+        self.assertEqual(get_db().query(models.BookAnnotation).count(), 1)
+
+    def test_chapter_comments_are_visible_but_writable_only_by_importer(self):
+        created = self._post_comment()
+        comment_id = created["chapter_comment"]["id"]
+
+        self.user.return_value = 2
+        d = self.json("/api/book/%d/chapter-comments" % BID_EPUB)
+        self.assertEqual(len(d["chapter_comments"]), 1)
+        self.assertEqual(d["chapter_comments"][0]["text"], "公开章评")
+        d = self.json(
+            "/api/book/%d/chapter-comments/%d" % (BID_EPUB, comment_id),
+            method="PUT",
+            body=json.dumps({"text": "越权修改"}),
+        )
+        self.assertEqual(d["err"], "chapter_comment.not_found")
+        d = self.json(
+            "/api/book/%d/chapter-comments/%d" % (BID_EPUB, comment_id),
+            method="DELETE",
+        )
+        self.assertEqual(d["err"], "chapter_comment.not_found")
+
+    def test_annotation_and_chapter_comment_deletion_are_isolated(self):
+        self._post_annotation()
+        self._post_comment()
+
+        d = self.json("/api/chapter-comments/export?source=weread&run_id=run-1&connection_id=conn-1")
+        self.assertEqual(d["export"]["schema"], "talebook.chapter-comments.v1")
+        self.assertEqual(len(d["export"]["chapter_comments"]), 1)
+
+        d = self.json("/api/annotations?connection_id=conn-1", method="DELETE")
+        self.assertEqual(d["deleted"], 1)
+        self.assertEqual(get_db().query(models.BookAnnotation).count(), 0)
+        self.assertEqual(get_db().query(models.ChapterComment).count(), 1)
+
+        d = self.json("/api/chapter-comments?run_id=run-1", method="DELETE")
+        self.assertEqual(d["deleted"], 1)
+        self.assertEqual(get_db().query(models.ChapterComment).count(), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/webserver/handlers/__init__.py
+++ b/webserver/handlers/__init__.py
@@ -6,13 +6,28 @@ import logging
 def routes():
     from webserver.webdav import handler as webdav
 
-    from . import admin, audiobook, book, booksource_admin, captcha, files, meta, network_library, opds, scan, theme, user
+    from . import (
+        admin,
+        annotations,
+        audiobook,
+        book,
+        booksource_admin,
+        captcha,
+        files,
+        meta,
+        network_library,
+        opds,
+        scan,
+        theme,
+        user,
+    )
 
     routes = []
     routes += admin.routes()
     routes += scan.routes()
     routes += opds.routes()
     routes += book.routes()
+    routes += annotations.routes()
     routes += user.routes()
     routes += meta.routes()
     routes += booksource_admin.routes()

--- a/webserver/handlers/annotations.py
+++ b/webserver/handlers/annotations.py
@@ -1,0 +1,496 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+
+import datetime
+
+import tornado.escape
+from sqlalchemy.exc import IntegrityError
+
+from webserver.handlers.base import BaseHandler, auth, js
+from webserver.i18n import _
+from webserver.models import BookAnnotation, ChapterComment
+
+
+ANNOTATION_KINDS = {"highlight", "note", "bookmark"}
+SOURCE_FILTERS = ("source", "run_id", "connection_id")
+
+
+def _parse_datetime(value):
+    if value in (None, ""):
+        return None, False
+    if not isinstance(value, str):
+        return None, True
+    try:
+        parsed = datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if parsed.tzinfo:
+            parsed = parsed.astimezone(datetime.timezone.utc).replace(tzinfo=None)
+        return parsed, False
+    except ValueError:
+        return None, True
+
+
+def _as_bool(value):
+    return str(value).lower() in {"1", "true", "yes", "on"}
+
+
+class AnnotationHandlerMixin:
+    def _json_body(self):
+        try:
+            data = tornado.escape.json_decode(self.request.body)
+        except (TypeError, ValueError):
+            return None
+        return data if isinstance(data, dict) else None
+
+    def _book_is_accessible(self, book_id):
+        return self.get_book(int(book_id), raise_exception=False) is not None
+
+    def _apply_filters(self, query, model, include_book=True):
+        if include_book:
+            book_id = self.get_argument("book_id", None)
+            if book_id is not None:
+                try:
+                    query = query.filter(model.book_id == int(book_id))
+                except (TypeError, ValueError):
+                    return None
+        for field in SOURCE_FILTERS:
+            value = self.get_argument(field, None)
+            if value is not None:
+                query = query.filter(getattr(model, field) == value)
+        return query
+
+    def _has_source_filter(self):
+        return any(self.get_argument(field, None) is not None for field in SOURCE_FILTERS)
+
+    @staticmethod
+    def _source_fields_are_valid(data):
+        limits = {"connection_id": 128, "run_id": 128, "raw_hash": 128}
+        return all(
+            data.get(field) in (None, "") or isinstance(data[field], str) and len(data[field]) <= limit
+            for field, limit in limits.items()
+        )
+
+
+class BookAnnotations(AnnotationHandlerMixin, BaseHandler):
+    @js
+    @auth
+    def get(self, book_id):
+        book_id = int(book_id)
+        if not self._book_is_accessible(book_id):
+            return {"err": "params.book.invalid", "msg": _("书籍已不存在或无权访问")}
+        query = self.session.query(BookAnnotation).filter(
+            BookAnnotation.reader_id == self.user_id(), BookAnnotation.book_id == book_id
+        )
+        query = self._apply_filters(query, BookAnnotation, include_book=False)
+        annotations = query.order_by(BookAnnotation.chapter, BookAnnotation.cfi, BookAnnotation.id).all()
+        return {"err": "ok", "annotations": [item.to_api_dict() for item in annotations]}
+
+    @js
+    @auth
+    def post(self, book_id):
+        book_id = int(book_id)
+        if not self._book_is_accessible(book_id):
+            return {"err": "params.book.invalid", "msg": _("书籍已不存在或无权访问")}
+        data = self._json_body()
+        if data is None:
+            return {"err": "params.invalid", "msg": _("笔记参数错误")}
+
+        kind = data.get("kind")
+        source = str(data.get("source") or "talebook").strip()
+        external_id = str(data.get("external_id") or "").strip() or None
+        client_id = str(data.get("client_id") or "").strip() or None
+        if kind not in ANNOTATION_KINDS or not source or not (external_id or client_id):
+            return {"err": "params.invalid", "msg": _("笔记类型或幂等标识错误")}
+        if (
+            len(source) > 64
+            or (client_id and len(client_id) > 64)
+            or (external_id and len(external_id) > 255)
+            or not self._source_fields_are_valid(data)
+        ):
+            return {"err": "params.invalid", "msg": _("笔记来源标识过长")}
+
+        remote_updated_at, invalid_time = _parse_datetime(data.get("remote_updated_at"))
+        if invalid_time:
+            return {"err": "params.invalid", "msg": _("远端更新时间格式错误")}
+
+        owner_id = self.user_id()
+        query = self.session.query(BookAnnotation).filter(
+            BookAnnotation.reader_id == owner_id, BookAnnotation.book_id == book_id
+        )
+        if external_id:
+            annotation = query.filter(BookAnnotation.source == source, BookAnnotation.external_id == external_id).first()
+        else:
+            annotation = query.filter(BookAnnotation.client_id == client_id).first()
+
+        created = annotation is None
+        if created:
+            annotation = BookAnnotation(
+                reader_id=owner_id,
+                book_id=book_id,
+                source=source,
+                external_id=external_id,
+                client_id=client_id,
+                kind=kind,
+            )
+            self.session.add(annotation)
+        else:
+            existing_remote = annotation.remote_updated_at
+            incoming_hash = data.get("raw_hash") or None
+            if (
+                remote_updated_at
+                and existing_remote
+                and remote_updated_at < existing_remote
+                and incoming_hash != annotation.raw_hash
+            ):
+                return {
+                    "err": "ok",
+                    "annotation": annotation.to_api_dict(),
+                    "created": False,
+                    "stale_ignored": True,
+                    "conflict_protected": False,
+                }
+
+        for field in ("connection_id", "run_id", "raw_hash"):
+            if field in data:
+                setattr(annotation, field, data.get(field) or None)
+        if "remote_updated_at" in data:
+            annotation.remote_updated_at = remote_updated_at
+        if client_id and not annotation.client_id:
+            annotation.client_id = client_id
+
+        conflict_protected = bool(not created and annotation.user_modified_at and source != "talebook")
+        if not conflict_protected:
+            annotation.kind = kind
+            annotation.cfi = data.get("cfi") or None
+            annotation.chapter = str(data.get("chapter") or "")[:500]
+            annotation.refer_text = str(data.get("refer_text") or "")
+            annotation.text = str(data.get("text") or "")
+            annotation.color = str(data.get("color") or "")[:32]
+            annotation.source_position = data.get("source_position") or None
+        annotation.update_time = datetime.datetime.now()
+
+        try:
+            self.session.commit()
+        except IntegrityError:
+            self.session.rollback()
+            return {"err": "annotation.id_conflict", "msg": _("笔记幂等标识已被其他记录占用")}
+        return {
+            "err": "ok",
+            "annotation": annotation.to_api_dict(),
+            "created": created,
+            "stale_ignored": False,
+            "conflict_protected": conflict_protected,
+        }
+
+
+class BookAnnotationItem(AnnotationHandlerMixin, BaseHandler):
+    def _owned(self, book_id, annotation_id):
+        return (
+            self.session.query(BookAnnotation)
+            .filter(
+                BookAnnotation.id == int(annotation_id),
+                BookAnnotation.book_id == int(book_id),
+                BookAnnotation.reader_id == self.user_id(),
+            )
+            .first()
+        )
+
+    @js
+    @auth
+    def put(self, book_id, annotation_id):
+        if not self._book_is_accessible(book_id):
+            return {"err": "params.book.invalid", "msg": _("书籍已不存在或无权访问")}
+        annotation = self._owned(book_id, annotation_id)
+        if not annotation:
+            return {"err": "annotation.not_found", "msg": _("笔记不存在")}
+        data = self._json_body()
+        if data is None:
+            return {"err": "params.invalid", "msg": _("笔记参数错误")}
+        mutable = {"kind", "cfi", "chapter", "refer_text", "text", "color", "source_position"}
+        changed = False
+        for field in mutable:
+            if field not in data:
+                continue
+            value = data[field]
+            if field == "kind" and value not in ANNOTATION_KINDS:
+                return {"err": "params.invalid", "msg": _("笔记类型错误")}
+            if field == "cfi":
+                value = value or None
+            elif field == "chapter":
+                value = str(value or "")[:500]
+            elif field == "color":
+                value = str(value or "")[:32]
+            elif field in {"refer_text", "text"}:
+                value = str(value or "")
+            elif field == "source_position":
+                value = value or None
+            if getattr(annotation, field) != value:
+                setattr(annotation, field, value)
+                changed = True
+        if changed:
+            now = datetime.datetime.now()
+            annotation.user_modified_at = now
+            annotation.update_time = now
+            self.session.commit()
+        return {"err": "ok", "annotation": annotation.to_api_dict()}
+
+    @js
+    @auth
+    def delete(self, book_id, annotation_id):
+        if not self._book_is_accessible(book_id):
+            return {"err": "params.book.invalid", "msg": _("书籍已不存在或无权访问")}
+        annotation = self._owned(book_id, annotation_id)
+        if not annotation:
+            return {"err": "annotation.not_found", "msg": _("笔记不存在")}
+        self.session.delete(annotation)
+        self.session.commit()
+        return {"err": "ok", "deleted": 1}
+
+
+class AnnotationCollection(AnnotationHandlerMixin, BaseHandler):
+    def _query(self):
+        query = self.session.query(BookAnnotation).filter(BookAnnotation.reader_id == self.user_id())
+        return self._apply_filters(query, BookAnnotation)
+
+    @js
+    @auth
+    def get(self):
+        query = self._query()
+        if query is None:
+            return {"err": "params.invalid", "msg": _("书籍参数错误")}
+        annotations = query.order_by(BookAnnotation.book_id, BookAnnotation.id).all()
+        annotations = [item for item in annotations if self.can_view_book(item.book_id)]
+        return {"err": "ok", "annotations": [item.to_api_dict() for item in annotations]}
+
+    @js
+    @auth
+    def delete(self):
+        if not self._has_source_filter():
+            return {"err": "params.invalid", "msg": _("来源删除至少需要 source、run_id 或 connection_id")}
+        query = self._query()
+        if query is None:
+            return {"err": "params.invalid", "msg": _("书籍参数错误")}
+        candidates = query.all()
+        visible = [item for item in candidates if self.can_view_book(item.book_id)]
+        include_modified = _as_bool(self.get_argument("include_modified", "false"))
+        protected = [item for item in visible if item.user_modified_at and not include_modified]
+        deleted = [item for item in visible if item not in protected]
+        for item in deleted:
+            self.session.delete(item)
+        self.session.commit()
+        return {"err": "ok", "deleted": len(deleted), "protected": len(protected)}
+
+
+class AnnotationExport(AnnotationCollection):
+    @js
+    @auth
+    def get(self):
+        query = self._query()
+        if query is None:
+            return {"err": "params.invalid", "msg": _("书籍参数错误")}
+        annotations = query.order_by(BookAnnotation.book_id, BookAnnotation.id).all()
+        annotations = [item.to_api_dict() for item in annotations if self.can_view_book(item.book_id)]
+        return {
+            "err": "ok",
+            "export": {
+                "schema": "talebook.annotations.v1",
+                "exported_at": datetime.datetime.now().isoformat(),
+                "annotations": annotations,
+            },
+        }
+
+
+class BookChapterComments(AnnotationHandlerMixin, BaseHandler):
+    @js
+    @auth
+    def get(self, book_id):
+        book_id = int(book_id)
+        if not self._book_is_accessible(book_id):
+            return {"err": "params.book.invalid", "msg": _("书籍已不存在或无权访问")}
+        query = self.session.query(ChapterComment).filter(ChapterComment.book_id == book_id)
+        query = self._apply_filters(query, ChapterComment, include_book=False)
+        comments = query.order_by(ChapterComment.chapter, ChapterComment.id).all()
+        return {"err": "ok", "chapter_comments": [item.to_api_dict() for item in comments]}
+
+    @js
+    @auth
+    def post(self, book_id):
+        book_id = int(book_id)
+        if not self._book_is_accessible(book_id):
+            return {"err": "params.book.invalid", "msg": _("书籍已不存在或无权访问")}
+        data = self._json_body()
+        if data is None:
+            return {"err": "params.invalid", "msg": _("章评参数错误")}
+        source = str(data.get("source") or "").strip()
+        external_id = str(data.get("external_id") or "").strip()
+        text = str(data.get("text") or "")
+        if (
+            not source
+            or not external_id
+            or not text
+            or len(source) > 64
+            or len(external_id) > 255
+            or not self._source_fields_are_valid(data)
+        ):
+            return {"err": "params.invalid", "msg": _("章评来源标识或正文错误")}
+        remote_updated_at, invalid_time = _parse_datetime(data.get("remote_updated_at"))
+        if invalid_time:
+            return {"err": "params.invalid", "msg": _("远端更新时间格式错误")}
+
+        owner_id = self.user_id()
+        comment = (
+            self.session.query(ChapterComment)
+            .filter(
+                ChapterComment.reader_id == owner_id,
+                ChapterComment.book_id == book_id,
+                ChapterComment.source == source,
+                ChapterComment.external_id == external_id,
+            )
+            .first()
+        )
+        created = comment is None
+        if created:
+            comment = ChapterComment(
+                reader_id=owner_id,
+                book_id=book_id,
+                source=source,
+                external_id=external_id,
+                text=text,
+            )
+            self.session.add(comment)
+        elif (
+            remote_updated_at
+            and comment.remote_updated_at
+            and remote_updated_at < comment.remote_updated_at
+            and (data.get("raw_hash") or None) != comment.raw_hash
+        ):
+            return {"err": "ok", "chapter_comment": comment.to_api_dict(), "created": False, "stale_ignored": True}
+
+        comment.chapter = str(data.get("chapter") or "")[:500]
+        comment.cfi = data.get("cfi") or None
+        comment.source_position = data.get("source_position") or None
+        comment.text = text
+        comment.author_name = str(data.get("author_name") or "")[:255]
+        for field in ("connection_id", "run_id", "raw_hash"):
+            if field in data:
+                setattr(comment, field, data.get(field) or None)
+        if "remote_updated_at" in data:
+            comment.remote_updated_at = remote_updated_at
+        comment.update_time = datetime.datetime.now()
+        self.session.commit()
+        return {"err": "ok", "chapter_comment": comment.to_api_dict(), "created": created, "stale_ignored": False}
+
+
+class BookChapterCommentItem(AnnotationHandlerMixin, BaseHandler):
+    def _owned(self, book_id, comment_id):
+        return (
+            self.session.query(ChapterComment)
+            .filter(
+                ChapterComment.id == int(comment_id),
+                ChapterComment.book_id == int(book_id),
+                ChapterComment.reader_id == self.user_id(),
+            )
+            .first()
+        )
+
+    @js
+    @auth
+    def put(self, book_id, comment_id):
+        if not self._book_is_accessible(book_id):
+            return {"err": "params.book.invalid", "msg": _("书籍已不存在或无权访问")}
+        comment = self._owned(book_id, comment_id)
+        if not comment:
+            return {"err": "chapter_comment.not_found", "msg": _("章评不存在")}
+        data = self._json_body()
+        if data is None:
+            return {"err": "params.invalid", "msg": _("章评参数错误")}
+        for field in ("chapter", "cfi", "source_position", "text", "author_name"):
+            if field in data:
+                value = data[field]
+                if field == "chapter":
+                    value = str(value or "")[:500]
+                elif field == "author_name":
+                    value = str(value or "")[:255]
+                elif field == "text":
+                    value = str(value or "")
+                    if not value:
+                        return {"err": "params.invalid", "msg": _("章评正文不能为空")}
+                else:
+                    value = value or None
+                setattr(comment, field, value)
+        comment.update_time = datetime.datetime.now()
+        self.session.commit()
+        return {"err": "ok", "chapter_comment": comment.to_api_dict()}
+
+    @js
+    @auth
+    def delete(self, book_id, comment_id):
+        if not self._book_is_accessible(book_id):
+            return {"err": "params.book.invalid", "msg": _("书籍已不存在或无权访问")}
+        comment = self._owned(book_id, comment_id)
+        if not comment:
+            return {"err": "chapter_comment.not_found", "msg": _("章评不存在")}
+        self.session.delete(comment)
+        self.session.commit()
+        return {"err": "ok", "deleted": 1}
+
+
+class ChapterCommentCollection(AnnotationHandlerMixin, BaseHandler):
+    def _query(self):
+        query = self.session.query(ChapterComment).filter(ChapterComment.reader_id == self.user_id())
+        return self._apply_filters(query, ChapterComment)
+
+    @js
+    @auth
+    def get(self):
+        query = self._query()
+        if query is None:
+            return {"err": "params.invalid", "msg": _("书籍参数错误")}
+        comments = query.order_by(ChapterComment.book_id, ChapterComment.id).all()
+        comments = [item.to_api_dict() for item in comments if self.can_view_book(item.book_id)]
+        return {"err": "ok", "chapter_comments": comments}
+
+    @js
+    @auth
+    def delete(self):
+        if not self._has_source_filter():
+            return {"err": "params.invalid", "msg": _("来源删除至少需要 source、run_id 或 connection_id")}
+        query = self._query()
+        if query is None:
+            return {"err": "params.invalid", "msg": _("书籍参数错误")}
+        comments = [item for item in query.all() if self.can_view_book(item.book_id)]
+        for item in comments:
+            self.session.delete(item)
+        self.session.commit()
+        return {"err": "ok", "deleted": len(comments)}
+
+
+class ChapterCommentExport(ChapterCommentCollection):
+    @js
+    @auth
+    def get(self):
+        query = self._query()
+        if query is None:
+            return {"err": "params.invalid", "msg": _("书籍参数错误")}
+        comments = query.order_by(ChapterComment.book_id, ChapterComment.id).all()
+        comments = [item.to_api_dict() for item in comments if self.can_view_book(item.book_id)]
+        return {
+            "err": "ok",
+            "export": {
+                "schema": "talebook.chapter-comments.v1",
+                "exported_at": datetime.datetime.now().isoformat(),
+                "chapter_comments": comments,
+            },
+        }
+
+
+def routes():
+    return [
+        (r"/api/book/([0-9]+)/annotations", BookAnnotations),
+        (r"/api/book/([0-9]+)/annotations/([0-9]+)", BookAnnotationItem),
+        (r"/api/annotations", AnnotationCollection),
+        (r"/api/annotations/export", AnnotationExport),
+        (r"/api/book/([0-9]+)/chapter-comments", BookChapterComments),
+        (r"/api/book/([0-9]+)/chapter-comments/([0-9]+)", BookChapterCommentItem),
+        (r"/api/chapter-comments", ChapterCommentCollection),
+        (r"/api/chapter-comments/export", ChapterCommentExport),
+    ]

--- a/webserver/handlers/annotations.py
+++ b/webserver/handlers/annotations.py
@@ -4,15 +4,33 @@
 import datetime
 
 import tornado.escape
+from sqlalchemy import or_
 from sqlalchemy.exc import IntegrityError
 
 from webserver.handlers.base import BaseHandler, auth, js
 from webserver.i18n import _
-from webserver.models import BookAnnotation, ChapterComment
+from webserver.models import Annotation, AnnotationSource
+from webserver.services.annotation_sync import AnnotationSyncService
 
 
-ANNOTATION_KINDS = {"highlight", "note", "bookmark"}
-SOURCE_FILTERS = ("source", "run_id", "connection_id")
+ANNOTATION_TYPES = {"highlight", "note", "bookmark", "chapter_comment"}
+SOURCE_FILTERS = (
+    "source_name",
+    "source_connection_id",
+    "source_annotation_id",
+    "source_run_id",
+    "source_sync_status",
+)
+SOURCE_DELETE_FILTERS = SOURCE_FILTERS[:-1]
+SOURCE_FIELD_LIMITS = {
+    "source_name": 64,
+    "source_connection_id": 128,
+    "source_annotation_id": 255,
+    "source_run_id": 128,
+    "source_raw_hash": 128,
+}
+SOURCE_INPUT_FIELDS = set(SOURCE_FIELD_LIMITS) | {"source_position", "source_updated_at"}
+LEGACY_SOURCE_FIELDS = {"source", "external_id", "connection_id", "run_id", "raw_hash", "remote_updated_at"}
 
 
 def _parse_datetime(value):
@@ -30,6 +48,8 @@ def _parse_datetime(value):
 
 
 def _as_bool(value):
+    if isinstance(value, bool):
+        return value
     return str(value).lower() in {"1", "true", "yes", "on"}
 
 
@@ -44,30 +64,54 @@ class AnnotationHandlerMixin:
     def _book_is_accessible(self, book_id):
         return self.get_book(int(book_id), raise_exception=False) is not None
 
-    def _apply_filters(self, query, model, include_book=True):
+    def _source_filters(self):
+        return {field: self.get_argument(field, None) for field in SOURCE_FILTERS}
+
+    def _apply_filters(self, query, include_book=True):
         if include_book:
             book_id = self.get_argument("book_id", None)
             if book_id is not None:
                 try:
-                    query = query.filter(model.book_id == int(book_id))
+                    query = query.filter(Annotation.book_id == int(book_id))
                 except (TypeError, ValueError):
                     return None
-        for field in SOURCE_FILTERS:
-            value = self.get_argument(field, None)
-            if value is not None:
-                query = query.filter(getattr(model, field) == value)
+        source_filters = {field: value for field, value in self._source_filters().items() if value is not None}
+        if source_filters:
+            query = query.join(AnnotationSource)
+            for field, value in source_filters.items():
+                query = query.filter(getattr(AnnotationSource, field) == value)
+            query = query.distinct()
         return query
 
-    def _has_source_filter(self):
-        return any(self.get_argument(field, None) is not None for field in SOURCE_FILTERS)
+    def _has_source_delete_filter(self):
+        return any(self.get_argument(field, None) is not None for field in SOURCE_DELETE_FILTERS)
 
     @staticmethod
     def _source_fields_are_valid(data):
-        limits = {"connection_id": 128, "run_id": 128, "raw_hash": 128}
         return all(
             data.get(field) in (None, "") or isinstance(data[field], str) and len(data[field]) <= limit
-            for field, limit in limits.items()
+            for field, limit in SOURCE_FIELD_LIMITS.items()
         )
+
+    @staticmethod
+    def _source_identity(data):
+        source_name = str(data.get("source_name") or "").strip() or None
+        source_connection_id = str(data.get("source_connection_id") or "").strip()
+        source_annotation_id = str(data.get("source_annotation_id") or "").strip() or None
+        return source_name, source_connection_id, source_annotation_id
+
+    def _source_query(self):
+        query = self.session.query(AnnotationSource).join(Annotation).filter(Annotation.reader_id == self.user_id())
+        book_id = self.get_argument("book_id", None)
+        if book_id is not None:
+            try:
+                query = query.filter(Annotation.book_id == int(book_id))
+            except (TypeError, ValueError):
+                return None
+        for field, value in self._source_filters().items():
+            if value is not None:
+                query = query.filter(getattr(AnnotationSource, field) == value)
+        return query
 
 
 class BookAnnotations(AnnotationHandlerMixin, BaseHandler):
@@ -77,11 +121,12 @@ class BookAnnotations(AnnotationHandlerMixin, BaseHandler):
         book_id = int(book_id)
         if not self._book_is_accessible(book_id):
             return {"err": "params.book.invalid", "msg": _("书籍已不存在或无权访问")}
-        query = self.session.query(BookAnnotation).filter(
-            BookAnnotation.reader_id == self.user_id(), BookAnnotation.book_id == book_id
+        query = self.session.query(Annotation).filter(
+            Annotation.book_id == book_id,
+            or_(Annotation.reader_id == self.user_id(), Annotation.is_private.is_(False)),
         )
-        query = self._apply_filters(query, BookAnnotation, include_book=False)
-        annotations = query.order_by(BookAnnotation.chapter, BookAnnotation.cfi, BookAnnotation.id).all()
+        query = self._apply_filters(query, include_book=False)
+        annotations = query.order_by(Annotation.chapter, Annotation.cfi, Annotation.id).all()
         return {"err": "ok", "annotations": [item.to_api_dict() for item in annotations]}
 
     @js
@@ -94,52 +139,87 @@ class BookAnnotations(AnnotationHandlerMixin, BaseHandler):
         if data is None:
             return {"err": "params.invalid", "msg": _("笔记参数错误")}
 
-        kind = data.get("kind")
-        source = str(data.get("source") or "talebook").strip()
-        external_id = str(data.get("external_id") or "").strip() or None
+        annotation_type = data.get("annotation_type")
         client_id = str(data.get("client_id") or "").strip() or None
-        if kind not in ANNOTATION_KINDS or not source or not (external_id or client_id):
-            return {"err": "params.invalid", "msg": _("笔记类型或幂等标识错误")}
+        source_name, source_connection_id, source_annotation_id = self._source_identity(data)
+        has_source_fields = any(field in data for field in SOURCE_INPUT_FIELDS)
         if (
-            len(source) > 64
-            or (client_id and len(client_id) > 64)
-            or (external_id and len(external_id) > 255)
+            annotation_type not in ANNOTATION_TYPES
+            or not (client_id or source_annotation_id)
+            or source_name == "talebook"
+            or has_source_fields != bool(source_name)
+            or source_name
+            and not source_annotation_id
+            or client_id
+            and len(client_id) > 64
+            or any(field in data for field in LEGACY_SOURCE_FIELDS)
             or not self._source_fields_are_valid(data)
         ):
-            return {"err": "params.invalid", "msg": _("笔记来源标识过长")}
+            return {"err": "params.invalid", "msg": _("笔记类型或来源标识错误")}
 
-        remote_updated_at, invalid_time = _parse_datetime(data.get("remote_updated_at"))
+        source_updated_at, invalid_time = _parse_datetime(data.get("source_updated_at"))
         if invalid_time:
-            return {"err": "params.invalid", "msg": _("远端更新时间格式错误")}
+            return {"err": "params.invalid", "msg": _("来源更新时间格式错误")}
 
         owner_id = self.user_id()
-        query = self.session.query(BookAnnotation).filter(
-            BookAnnotation.reader_id == owner_id, BookAnnotation.book_id == book_id
-        )
-        if external_id:
-            annotation = query.filter(BookAnnotation.source == source, BookAnnotation.external_id == external_id).first()
-        else:
-            annotation = query.filter(BookAnnotation.client_id == client_id).first()
+        source = None
+        annotation = None
+        if source_name:
+            source = (
+                self.session.query(AnnotationSource)
+                .join(Annotation)
+                .filter(
+                    Annotation.reader_id == owner_id,
+                    Annotation.book_id == book_id,
+                    AnnotationSource.source_name == source_name,
+                    AnnotationSource.source_connection_id == source_connection_id,
+                    AnnotationSource.source_annotation_id == source_annotation_id,
+                )
+                .first()
+            )
+            annotation = source.annotation if source else None
+        if annotation is None and client_id:
+            annotation = (
+                self.session.query(Annotation)
+                .filter(
+                    Annotation.reader_id == owner_id,
+                    Annotation.book_id == book_id,
+                    Annotation.client_id == client_id,
+                )
+                .first()
+            )
 
         created = annotation is None
+        now = datetime.datetime.now()
         if created:
-            annotation = BookAnnotation(
+            annotation = Annotation(
                 reader_id=owner_id,
                 book_id=book_id,
-                source=source,
-                external_id=external_id,
                 client_id=client_id,
-                kind=kind,
+                annotation_type=annotation_type,
+                is_private=_as_bool(data.get("is_private", True)),
             )
             self.session.add(annotation)
-        else:
-            existing_remote = annotation.remote_updated_at
-            incoming_hash = data.get("raw_hash") or None
+            self.session.flush()
+        elif client_id and not annotation.client_id:
+            annotation.client_id = client_id
+
+        if source_name and source is None:
+            source = AnnotationSource(
+                annotation=annotation,
+                source_name=source_name,
+                source_connection_id=source_connection_id,
+                source_annotation_id=source_annotation_id,
+            )
+            self.session.add(source)
+
+        if source and not created:
+            incoming_hash = data.get("source_raw_hash") or None
             if (
-                remote_updated_at
-                and existing_remote
-                and remote_updated_at < existing_remote
-                and incoming_hash != annotation.raw_hash
+                source_updated_at
+                and source.source_updated_at
+                and source_updated_at < source.source_updated_at
+                and incoming_hash != source.source_raw_hash
             ):
                 return {
                     "err": "ok",
@@ -147,49 +227,73 @@ class BookAnnotations(AnnotationHandlerMixin, BaseHandler):
                     "created": False,
                     "stale_ignored": True,
                     "conflict_protected": False,
+                    "sync_enqueued": False,
                 }
 
-        for field in ("connection_id", "run_id", "raw_hash"):
-            if field in data:
-                setattr(annotation, field, data.get(field) or None)
-        if "remote_updated_at" in data:
-            annotation.remote_updated_at = remote_updated_at
-        if client_id and not annotation.client_id:
-            annotation.client_id = client_id
+        if source:
+            for field in ("source_run_id", "source_position", "source_raw_hash"):
+                if field in data:
+                    setattr(source, field, data.get(field) or None)
+            if "source_updated_at" in data:
+                source.source_updated_at = source_updated_at
+            source.source_sync_status = "synced"
+            source.source_synced_at = now
+            source.source_sync_error = None
+            source.update_time = now
 
-        conflict_protected = bool(not created and annotation.user_modified_at and source != "talebook")
+        conflict_protected = bool(source and not created and annotation.user_modified_at)
+        content_changed = created
         if not conflict_protected:
-            annotation.kind = kind
-            annotation.cfi = data.get("cfi") or None
-            annotation.chapter = str(data.get("chapter") or "")[:500]
-            annotation.refer_text = str(data.get("refer_text") or "")
-            annotation.text = str(data.get("text") or "")
-            annotation.color = str(data.get("color") or "")[:32]
-            annotation.source_position = data.get("source_position") or None
-        annotation.update_time = datetime.datetime.now()
+            values = {
+                "annotation_type": annotation_type,
+                "cfi": data.get("cfi") or None,
+                "chapter": str(data.get("chapter") or "")[:500],
+                "quote_text": str(data.get("quote_text") or ""),
+                "content": str(data.get("content") or ""),
+                "color": str(data.get("color") or "")[:32],
+                "author_name": str(data.get("author_name") or "")[:255],
+            }
+            if created or not source_name:
+                values["is_private"] = _as_bool(data.get("is_private", annotation.is_private))
+            for field, value in values.items():
+                if getattr(annotation, field) != value:
+                    setattr(annotation, field, value)
+                    content_changed = True
+        if not source_name and not created and content_changed:
+            annotation.user_modified_at = now
+        annotation.update_time = now
 
         try:
             self.session.commit()
         except IntegrityError:
             self.session.rollback()
             return {"err": "annotation.id_conflict", "msg": _("笔记幂等标识已被其他记录占用")}
+
+        sync_enqueued = bool(not annotation.is_private and content_changed)
+        if sync_enqueued:
+            AnnotationSyncService().sync_annotation(
+                annotation.id,
+                exclude_source_name=source_name,
+                exclude_source_connection_id=source_connection_id,
+            )
         return {
             "err": "ok",
             "annotation": annotation.to_api_dict(),
             "created": created,
             "stale_ignored": False,
             "conflict_protected": conflict_protected,
+            "sync_enqueued": sync_enqueued,
         }
 
 
 class BookAnnotationItem(AnnotationHandlerMixin, BaseHandler):
     def _owned(self, book_id, annotation_id):
         return (
-            self.session.query(BookAnnotation)
+            self.session.query(Annotation)
             .filter(
-                BookAnnotation.id == int(annotation_id),
-                BookAnnotation.book_id == int(book_id),
-                BookAnnotation.reader_id == self.user_id(),
+                Annotation.id == int(annotation_id),
+                Annotation.book_id == int(book_id),
+                Annotation.reader_id == self.user_id(),
             )
             .first()
         )
@@ -205,24 +309,35 @@ class BookAnnotationItem(AnnotationHandlerMixin, BaseHandler):
         data = self._json_body()
         if data is None:
             return {"err": "params.invalid", "msg": _("笔记参数错误")}
-        mutable = {"kind", "cfi", "chapter", "refer_text", "text", "color", "source_position"}
+        mutable = {
+            "annotation_type",
+            "is_private",
+            "cfi",
+            "chapter",
+            "quote_text",
+            "content",
+            "color",
+            "author_name",
+        }
         changed = False
         for field in mutable:
             if field not in data:
                 continue
             value = data[field]
-            if field == "kind" and value not in ANNOTATION_KINDS:
+            if field == "annotation_type" and value not in ANNOTATION_TYPES:
                 return {"err": "params.invalid", "msg": _("笔记类型错误")}
-            if field == "cfi":
+            if field == "is_private":
+                value = _as_bool(value)
+            elif field == "cfi":
                 value = value or None
             elif field == "chapter":
                 value = str(value or "")[:500]
             elif field == "color":
                 value = str(value or "")[:32]
-            elif field in {"refer_text", "text"}:
+            elif field == "author_name":
+                value = str(value or "")[:255]
+            else:
                 value = str(value or "")
-            elif field == "source_position":
-                value = value or None
             if getattr(annotation, field) != value:
                 setattr(annotation, field, value)
                 changed = True
@@ -231,7 +346,9 @@ class BookAnnotationItem(AnnotationHandlerMixin, BaseHandler):
             annotation.user_modified_at = now
             annotation.update_time = now
             self.session.commit()
-        return {"err": "ok", "annotation": annotation.to_api_dict()}
+            if not annotation.is_private:
+                AnnotationSyncService().sync_annotation(annotation.id)
+        return {"err": "ok", "annotation": annotation.to_api_dict(), "sync_enqueued": changed and not annotation.is_private}
 
     @js
     @auth
@@ -248,8 +365,8 @@ class BookAnnotationItem(AnnotationHandlerMixin, BaseHandler):
 
 class AnnotationCollection(AnnotationHandlerMixin, BaseHandler):
     def _query(self):
-        query = self.session.query(BookAnnotation).filter(BookAnnotation.reader_id == self.user_id())
-        return self._apply_filters(query, BookAnnotation)
+        query = self.session.query(Annotation).filter(Annotation.reader_id == self.user_id())
+        return self._apply_filters(query)
 
     @js
     @auth
@@ -257,27 +374,23 @@ class AnnotationCollection(AnnotationHandlerMixin, BaseHandler):
         query = self._query()
         if query is None:
             return {"err": "params.invalid", "msg": _("书籍参数错误")}
-        annotations = query.order_by(BookAnnotation.book_id, BookAnnotation.id).all()
+        annotations = query.order_by(Annotation.book_id, Annotation.id).all()
         annotations = [item for item in annotations if self.can_view_book(item.book_id)]
         return {"err": "ok", "annotations": [item.to_api_dict() for item in annotations]}
 
     @js
     @auth
     def delete(self):
-        if not self._has_source_filter():
-            return {"err": "params.invalid", "msg": _("来源删除至少需要 source、run_id 或 connection_id")}
-        query = self._query()
+        if not self._has_source_delete_filter():
+            return {"err": "params.invalid", "msg": _("来源清理至少需要一个 source_ 筛选条件")}
+        query = self._source_query()
         if query is None:
             return {"err": "params.invalid", "msg": _("书籍参数错误")}
-        candidates = query.all()
-        visible = [item for item in candidates if self.can_view_book(item.book_id)]
-        include_modified = _as_bool(self.get_argument("include_modified", "false"))
-        protected = [item for item in visible if item.user_modified_at and not include_modified]
-        deleted = [item for item in visible if item not in protected]
-        for item in deleted:
-            self.session.delete(item)
+        sources = [source for source in query.all() if self.can_view_book(source.annotation.book_id)]
+        for source in sources:
+            self.session.delete(source)
         self.session.commit()
-        return {"err": "ok", "deleted": len(deleted), "protected": len(protected)}
+        return {"err": "ok", "sources_deleted": len(sources), "annotations_deleted": 0}
 
 
 class AnnotationExport(AnnotationCollection):
@@ -287,198 +400,14 @@ class AnnotationExport(AnnotationCollection):
         query = self._query()
         if query is None:
             return {"err": "params.invalid", "msg": _("书籍参数错误")}
-        annotations = query.order_by(BookAnnotation.book_id, BookAnnotation.id).all()
+        annotations = query.order_by(Annotation.book_id, Annotation.id).all()
         annotations = [item.to_api_dict() for item in annotations if self.can_view_book(item.book_id)]
         return {
             "err": "ok",
             "export": {
-                "schema": "talebook.annotations.v1",
+                "schema": "talebook.annotations.v2",
                 "exported_at": datetime.datetime.now().isoformat(),
                 "annotations": annotations,
-            },
-        }
-
-
-class BookChapterComments(AnnotationHandlerMixin, BaseHandler):
-    @js
-    @auth
-    def get(self, book_id):
-        book_id = int(book_id)
-        if not self._book_is_accessible(book_id):
-            return {"err": "params.book.invalid", "msg": _("书籍已不存在或无权访问")}
-        query = self.session.query(ChapterComment).filter(ChapterComment.book_id == book_id)
-        query = self._apply_filters(query, ChapterComment, include_book=False)
-        comments = query.order_by(ChapterComment.chapter, ChapterComment.id).all()
-        return {"err": "ok", "chapter_comments": [item.to_api_dict() for item in comments]}
-
-    @js
-    @auth
-    def post(self, book_id):
-        book_id = int(book_id)
-        if not self._book_is_accessible(book_id):
-            return {"err": "params.book.invalid", "msg": _("书籍已不存在或无权访问")}
-        data = self._json_body()
-        if data is None:
-            return {"err": "params.invalid", "msg": _("章评参数错误")}
-        source = str(data.get("source") or "").strip()
-        external_id = str(data.get("external_id") or "").strip()
-        text = str(data.get("text") or "")
-        if (
-            not source
-            or not external_id
-            or not text
-            or len(source) > 64
-            or len(external_id) > 255
-            or not self._source_fields_are_valid(data)
-        ):
-            return {"err": "params.invalid", "msg": _("章评来源标识或正文错误")}
-        remote_updated_at, invalid_time = _parse_datetime(data.get("remote_updated_at"))
-        if invalid_time:
-            return {"err": "params.invalid", "msg": _("远端更新时间格式错误")}
-
-        owner_id = self.user_id()
-        comment = (
-            self.session.query(ChapterComment)
-            .filter(
-                ChapterComment.reader_id == owner_id,
-                ChapterComment.book_id == book_id,
-                ChapterComment.source == source,
-                ChapterComment.external_id == external_id,
-            )
-            .first()
-        )
-        created = comment is None
-        if created:
-            comment = ChapterComment(
-                reader_id=owner_id,
-                book_id=book_id,
-                source=source,
-                external_id=external_id,
-                text=text,
-            )
-            self.session.add(comment)
-        elif (
-            remote_updated_at
-            and comment.remote_updated_at
-            and remote_updated_at < comment.remote_updated_at
-            and (data.get("raw_hash") or None) != comment.raw_hash
-        ):
-            return {"err": "ok", "chapter_comment": comment.to_api_dict(), "created": False, "stale_ignored": True}
-
-        comment.chapter = str(data.get("chapter") or "")[:500]
-        comment.cfi = data.get("cfi") or None
-        comment.source_position = data.get("source_position") or None
-        comment.text = text
-        comment.author_name = str(data.get("author_name") or "")[:255]
-        for field in ("connection_id", "run_id", "raw_hash"):
-            if field in data:
-                setattr(comment, field, data.get(field) or None)
-        if "remote_updated_at" in data:
-            comment.remote_updated_at = remote_updated_at
-        comment.update_time = datetime.datetime.now()
-        self.session.commit()
-        return {"err": "ok", "chapter_comment": comment.to_api_dict(), "created": created, "stale_ignored": False}
-
-
-class BookChapterCommentItem(AnnotationHandlerMixin, BaseHandler):
-    def _owned(self, book_id, comment_id):
-        return (
-            self.session.query(ChapterComment)
-            .filter(
-                ChapterComment.id == int(comment_id),
-                ChapterComment.book_id == int(book_id),
-                ChapterComment.reader_id == self.user_id(),
-            )
-            .first()
-        )
-
-    @js
-    @auth
-    def put(self, book_id, comment_id):
-        if not self._book_is_accessible(book_id):
-            return {"err": "params.book.invalid", "msg": _("书籍已不存在或无权访问")}
-        comment = self._owned(book_id, comment_id)
-        if not comment:
-            return {"err": "chapter_comment.not_found", "msg": _("章评不存在")}
-        data = self._json_body()
-        if data is None:
-            return {"err": "params.invalid", "msg": _("章评参数错误")}
-        for field in ("chapter", "cfi", "source_position", "text", "author_name"):
-            if field in data:
-                value = data[field]
-                if field == "chapter":
-                    value = str(value or "")[:500]
-                elif field == "author_name":
-                    value = str(value or "")[:255]
-                elif field == "text":
-                    value = str(value or "")
-                    if not value:
-                        return {"err": "params.invalid", "msg": _("章评正文不能为空")}
-                else:
-                    value = value or None
-                setattr(comment, field, value)
-        comment.update_time = datetime.datetime.now()
-        self.session.commit()
-        return {"err": "ok", "chapter_comment": comment.to_api_dict()}
-
-    @js
-    @auth
-    def delete(self, book_id, comment_id):
-        if not self._book_is_accessible(book_id):
-            return {"err": "params.book.invalid", "msg": _("书籍已不存在或无权访问")}
-        comment = self._owned(book_id, comment_id)
-        if not comment:
-            return {"err": "chapter_comment.not_found", "msg": _("章评不存在")}
-        self.session.delete(comment)
-        self.session.commit()
-        return {"err": "ok", "deleted": 1}
-
-
-class ChapterCommentCollection(AnnotationHandlerMixin, BaseHandler):
-    def _query(self):
-        query = self.session.query(ChapterComment).filter(ChapterComment.reader_id == self.user_id())
-        return self._apply_filters(query, ChapterComment)
-
-    @js
-    @auth
-    def get(self):
-        query = self._query()
-        if query is None:
-            return {"err": "params.invalid", "msg": _("书籍参数错误")}
-        comments = query.order_by(ChapterComment.book_id, ChapterComment.id).all()
-        comments = [item.to_api_dict() for item in comments if self.can_view_book(item.book_id)]
-        return {"err": "ok", "chapter_comments": comments}
-
-    @js
-    @auth
-    def delete(self):
-        if not self._has_source_filter():
-            return {"err": "params.invalid", "msg": _("来源删除至少需要 source、run_id 或 connection_id")}
-        query = self._query()
-        if query is None:
-            return {"err": "params.invalid", "msg": _("书籍参数错误")}
-        comments = [item for item in query.all() if self.can_view_book(item.book_id)]
-        for item in comments:
-            self.session.delete(item)
-        self.session.commit()
-        return {"err": "ok", "deleted": len(comments)}
-
-
-class ChapterCommentExport(ChapterCommentCollection):
-    @js
-    @auth
-    def get(self):
-        query = self._query()
-        if query is None:
-            return {"err": "params.invalid", "msg": _("书籍参数错误")}
-        comments = query.order_by(ChapterComment.book_id, ChapterComment.id).all()
-        comments = [item.to_api_dict() for item in comments if self.can_view_book(item.book_id)]
-        return {
-            "err": "ok",
-            "export": {
-                "schema": "talebook.chapter-comments.v1",
-                "exported_at": datetime.datetime.now().isoformat(),
-                "chapter_comments": comments,
             },
         }
 
@@ -489,8 +418,4 @@ def routes():
         (r"/api/book/([0-9]+)/annotations/([0-9]+)", BookAnnotationItem),
         (r"/api/annotations", AnnotationCollection),
         (r"/api/annotations/export", AnnotationExport),
-        (r"/api/book/([0-9]+)/chapter-comments", BookChapterComments),
-        (r"/api/book/([0-9]+)/chapter-comments/([0-9]+)", BookChapterCommentItem),
-        (r"/api/chapter-comments", ChapterCommentCollection),
-        (r"/api/chapter-comments/export", ChapterCommentExport),
     ]

--- a/webserver/migrate_db.py
+++ b/webserver/migrate_db.py
@@ -10,8 +10,8 @@ Usage:
 Features:
     1. Read all table definitions from models.py
     2. Compare with actual database schema
-    3. Automatically add missing columns
-    4. Will not delete existing fields (data safety guaranteed)
+    3. Automatically create missing tables and add missing columns
+    4. Will not delete existing fields or tables (data safety guaranteed)
 """
 
 import json
@@ -170,13 +170,23 @@ def compare_and_migrate(engine):
     model_columns = get_model_columns()
     db_columns = get_database_columns(engine)
 
+    # Create whole missing tables first so their constraints and indexes are
+    # preserved. Existing tables keep the historical additive-column behavior.
+    missing_tables = [table for table in models.Base.metadata.sorted_tables if table.name not in db_columns]
+    for table in missing_tables:
+        logger.info("Creating missing table '%s'", table.name)
+        table.create(engine, checkfirst=True)
+
+    if missing_tables:
+        db_columns = get_database_columns(engine)
+
     # Compare and generate migration operations
     migrations_needed = []
 
     for table_name, columns in model_columns.items():
         if table_name not in db_columns:
-            logger.info(f"Table '{table_name}' does not exist, will be created later")
-            continue
+            logger.error("Table '%s' is still missing after create_all migration", table_name)
+            return False
 
         for col_name, col_def in columns.items():
             if col_name not in db_columns[table_name]:

--- a/webserver/models.py
+++ b/webserver/models.py
@@ -536,6 +536,121 @@ class ReadingState(Base, SQLAlchemyMixin):
         return self.progress or {}
 
 
+class BookAnnotation(Base, SQLAlchemyMixin):
+    """A reader's private highlight, note, or bookmark."""
+
+    __tablename__ = "book_annotations"
+    __table_args__ = (
+        UniqueConstraint("reader_id", "book_id", "client_id", name="uq_annotation_client_id"),
+        UniqueConstraint(
+            "reader_id",
+            "book_id",
+            "source",
+            "external_id",
+            name="uq_annotation_source_external_id",
+        ),
+    )
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    reader_id = Column(Integer, ForeignKey("readers.id", ondelete="CASCADE"), nullable=False, index=True)
+    book_id = Column(Integer, nullable=False, index=True)
+    client_id = Column(String(64), nullable=True)
+    kind = Column(String(16), nullable=False)
+    cfi = Column(Text, nullable=True)
+    chapter = Column(String(500), default="")
+    refer_text = Column(Text, default="")
+    text = Column(Text, default="")
+    color = Column(String(32), default="")
+    source = Column(String(64), default="talebook", nullable=False, index=True)
+    external_id = Column(String(255), nullable=True)
+    connection_id = Column(String(128), nullable=True, index=True)
+    run_id = Column(String(128), nullable=True, index=True)
+    source_position = Column(Text, nullable=True)
+    raw_hash = Column(String(128), nullable=True)
+    remote_updated_at = Column(DateTime, nullable=True)
+    user_modified_at = Column(DateTime, nullable=True)
+    create_time = Column(DateTime, default=datetime.datetime.now, nullable=False)
+    update_time = Column(DateTime, default=datetime.datetime.now, nullable=False)
+
+    reader = relationship(Reader, backref="book_annotations")
+
+    def to_api_dict(self):
+        return {
+            "id": self.id,
+            "book_id": self.book_id,
+            "client_id": self.client_id,
+            "kind": self.kind,
+            "cfi": self.cfi,
+            "chapter": self.chapter or "",
+            "refer_text": self.refer_text or "",
+            "text": self.text or "",
+            "color": self.color or "",
+            "source": self.source,
+            "external_id": self.external_id,
+            "connection_id": self.connection_id,
+            "run_id": self.run_id,
+            "source_position": self.source_position,
+            "raw_hash": self.raw_hash,
+            "remote_updated_at": self.remote_updated_at.isoformat() if self.remote_updated_at else None,
+            "user_modified_at": self.user_modified_at.isoformat() if self.user_modified_at else None,
+            "created_at": self.create_time.isoformat() if self.create_time else None,
+            "updated_at": self.update_time.isoformat() if self.update_time else None,
+        }
+
+
+class ChapterComment(Base, SQLAlchemyMixin):
+    """A source-provided chapter comment, isolated from private annotations."""
+
+    __tablename__ = "chapter_comments"
+    __table_args__ = (
+        UniqueConstraint(
+            "reader_id",
+            "book_id",
+            "source",
+            "external_id",
+            name="uq_chapter_comment_source_external_id",
+        ),
+    )
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    reader_id = Column(Integer, ForeignKey("readers.id", ondelete="CASCADE"), nullable=False, index=True)
+    book_id = Column(Integer, nullable=False, index=True)
+    chapter = Column(String(500), default="")
+    cfi = Column(Text, nullable=True)
+    source_position = Column(Text, nullable=True)
+    text = Column(Text, nullable=False)
+    author_name = Column(String(255), default="")
+    source = Column(String(64), nullable=False, index=True)
+    external_id = Column(String(255), nullable=False)
+    connection_id = Column(String(128), nullable=True, index=True)
+    run_id = Column(String(128), nullable=True, index=True)
+    raw_hash = Column(String(128), nullable=True)
+    remote_updated_at = Column(DateTime, nullable=True)
+    create_time = Column(DateTime, default=datetime.datetime.now, nullable=False)
+    update_time = Column(DateTime, default=datetime.datetime.now, nullable=False)
+
+    reader = relationship(Reader, backref="chapter_comments")
+
+    def to_api_dict(self):
+        return {
+            "id": self.id,
+            "book_id": self.book_id,
+            "chapter": self.chapter or "",
+            "cfi": self.cfi,
+            "source_position": self.source_position,
+            "text": self.text,
+            "author_name": self.author_name or "",
+            "source": self.source,
+            "external_id": self.external_id,
+            "connection_id": self.connection_id,
+            "run_id": self.run_id,
+            "raw_hash": self.raw_hash,
+            "remote_updated_at": self.remote_updated_at.isoformat() if self.remote_updated_at else None,
+            "created_at": self.create_time.isoformat() if self.create_time else None,
+            "updated_at": self.update_time.isoformat() if self.update_time else None,
+        }
+
+
 class BookSourceModel(Base, SQLAlchemyMixin):
     """网络书源（Legado 书源 JSON）。"""
 

--- a/webserver/models.py
+++ b/webserver/models.py
@@ -536,118 +536,105 @@ class ReadingState(Base, SQLAlchemyMixin):
         return self.progress or {}
 
 
-class BookAnnotation(Base, SQLAlchemyMixin):
-    """A reader's private highlight, note, or bookmark."""
+class Annotation(Base, SQLAlchemyMixin):
+    """Talebook's authoritative annotation content."""
 
-    __tablename__ = "book_annotations"
-    __table_args__ = (
-        UniqueConstraint("reader_id", "book_id", "client_id", name="uq_annotation_client_id"),
-        UniqueConstraint(
-            "reader_id",
-            "book_id",
-            "source",
-            "external_id",
-            name="uq_annotation_source_external_id",
-        ),
-    )
+    __tablename__ = "annotations"
+    __table_args__ = (UniqueConstraint("reader_id", "book_id", "client_id", name="uq_annotation_client_id"),)
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     reader_id = Column(Integer, ForeignKey("readers.id", ondelete="CASCADE"), nullable=False, index=True)
     book_id = Column(Integer, nullable=False, index=True)
     client_id = Column(String(64), nullable=True)
-    kind = Column(String(16), nullable=False)
+    annotation_type = Column(String(32), nullable=False, index=True)
+    is_private = Column(Boolean, default=True, nullable=False, index=True)
     cfi = Column(Text, nullable=True)
     chapter = Column(String(500), default="")
-    refer_text = Column(Text, default="")
-    text = Column(Text, default="")
+    quote_text = Column(Text, default="")
+    content = Column(Text, default="")
     color = Column(String(32), default="")
-    source = Column(String(64), default="talebook", nullable=False, index=True)
-    external_id = Column(String(255), nullable=True)
-    connection_id = Column(String(128), nullable=True, index=True)
-    run_id = Column(String(128), nullable=True, index=True)
-    source_position = Column(Text, nullable=True)
-    raw_hash = Column(String(128), nullable=True)
-    remote_updated_at = Column(DateTime, nullable=True)
+    author_name = Column(String(255), default="")
     user_modified_at = Column(DateTime, nullable=True)
     create_time = Column(DateTime, default=datetime.datetime.now, nullable=False)
     update_time = Column(DateTime, default=datetime.datetime.now, nullable=False)
 
-    reader = relationship(Reader, backref="book_annotations")
+    reader = relationship(Reader, backref="annotations")
+    sources = relationship(
+        "AnnotationSource",
+        back_populates="annotation",
+        cascade="all, delete-orphan",
+        order_by="AnnotationSource.id",
+    )
 
     def to_api_dict(self):
         return {
             "id": self.id,
             "book_id": self.book_id,
             "client_id": self.client_id,
-            "kind": self.kind,
+            "annotation_type": self.annotation_type,
+            "is_private": self.is_private,
             "cfi": self.cfi,
             "chapter": self.chapter or "",
-            "refer_text": self.refer_text or "",
-            "text": self.text or "",
+            "quote_text": self.quote_text or "",
+            "content": self.content or "",
             "color": self.color or "",
-            "source": self.source,
-            "external_id": self.external_id,
-            "connection_id": self.connection_id,
-            "run_id": self.run_id,
-            "source_position": self.source_position,
-            "raw_hash": self.raw_hash,
-            "remote_updated_at": self.remote_updated_at.isoformat() if self.remote_updated_at else None,
+            "author_name": self.author_name or "",
             "user_modified_at": self.user_modified_at.isoformat() if self.user_modified_at else None,
             "created_at": self.create_time.isoformat() if self.create_time else None,
             "updated_at": self.update_time.isoformat() if self.update_time else None,
+            "sources": [source.to_api_dict() for source in self.sources],
         }
 
 
-class ChapterComment(Base, SQLAlchemyMixin):
-    """A source-provided chapter comment, isolated from private annotations."""
+class AnnotationSource(Base, SQLAlchemyMixin):
+    """An external replica and sync state for an authoritative annotation."""
 
-    __tablename__ = "chapter_comments"
+    __tablename__ = "annotation_sources"
     __table_args__ = (
         UniqueConstraint(
-            "reader_id",
-            "book_id",
-            "source",
-            "external_id",
-            name="uq_chapter_comment_source_external_id",
+            "annotation_id",
+            "source_name",
+            "source_connection_id",
+            name="uq_annotation_source_connection",
+        ),
+        UniqueConstraint(
+            "source_name",
+            "source_connection_id",
+            "source_annotation_id",
+            name="uq_annotation_source_identity",
         ),
     )
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    reader_id = Column(Integer, ForeignKey("readers.id", ondelete="CASCADE"), nullable=False, index=True)
-    book_id = Column(Integer, nullable=False, index=True)
-    chapter = Column(String(500), default="")
-    cfi = Column(Text, nullable=True)
+    annotation_id = Column(Integer, ForeignKey("annotations.id", ondelete="CASCADE"), nullable=False, index=True)
+    source_name = Column(String(64), nullable=False, index=True)
+    source_connection_id = Column(String(128), default="", nullable=False, index=True)
+    source_annotation_id = Column(String(255), nullable=True)
+    source_run_id = Column(String(128), nullable=True, index=True)
     source_position = Column(Text, nullable=True)
-    text = Column(Text, nullable=False)
-    author_name = Column(String(255), default="")
-    source = Column(String(64), nullable=False, index=True)
-    external_id = Column(String(255), nullable=False)
-    connection_id = Column(String(128), nullable=True, index=True)
-    run_id = Column(String(128), nullable=True, index=True)
-    raw_hash = Column(String(128), nullable=True)
-    remote_updated_at = Column(DateTime, nullable=True)
+    source_raw_hash = Column(String(128), nullable=True)
+    source_updated_at = Column(DateTime, nullable=True)
+    source_sync_status = Column(String(16), default="synced", nullable=False, index=True)
+    source_synced_at = Column(DateTime, nullable=True)
+    source_sync_error = Column(Text, nullable=True)
     create_time = Column(DateTime, default=datetime.datetime.now, nullable=False)
     update_time = Column(DateTime, default=datetime.datetime.now, nullable=False)
 
-    reader = relationship(Reader, backref="chapter_comments")
+    annotation = relationship(Annotation, back_populates="sources")
 
     def to_api_dict(self):
         return {
             "id": self.id,
-            "book_id": self.book_id,
-            "chapter": self.chapter or "",
-            "cfi": self.cfi,
+            "source_name": self.source_name,
+            "source_connection_id": self.source_connection_id,
+            "source_annotation_id": self.source_annotation_id,
+            "source_run_id": self.source_run_id,
             "source_position": self.source_position,
-            "text": self.text,
-            "author_name": self.author_name or "",
-            "source": self.source,
-            "external_id": self.external_id,
-            "connection_id": self.connection_id,
-            "run_id": self.run_id,
-            "raw_hash": self.raw_hash,
-            "remote_updated_at": self.remote_updated_at.isoformat() if self.remote_updated_at else None,
-            "created_at": self.create_time.isoformat() if self.create_time else None,
-            "updated_at": self.update_time.isoformat() if self.update_time else None,
+            "source_raw_hash": self.source_raw_hash,
+            "source_updated_at": self.source_updated_at.isoformat() if self.source_updated_at else None,
+            "source_sync_status": self.source_sync_status,
+            "source_synced_at": self.source_synced_at.isoformat() if self.source_synced_at else None,
+            "source_sync_error": self.source_sync_error,
         }
 
 

--- a/webserver/services/annotation_sync.py
+++ b/webserver/services/annotation_sync.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+
+import datetime
+import logging
+
+from webserver.models import Annotation, AnnotationSource
+from webserver.services import AsyncService
+
+
+def _parse_source_datetime(value):
+    if not value or isinstance(value, datetime.datetime):
+        return value
+    parsed = datetime.datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    if parsed.tzinfo:
+        parsed = parsed.astimezone(datetime.timezone.utc).replace(tzinfo=None)
+    return parsed
+
+
+class AnnotationSyncService(AsyncService):
+    """Fan public annotations out to source writers registered by plugins."""
+
+    _writers = {}
+
+    @classmethod
+    def register_writer(cls, source_name, writer, source_connection_id=""):
+        source_name = str(source_name or "").strip()
+        source_connection_id = str(source_connection_id or "").strip()
+        if not source_name or source_name == "talebook" or not callable(writer):
+            raise ValueError("invalid annotation source writer")
+        cls._writers[(source_name, source_connection_id)] = writer
+
+    @classmethod
+    def unregister_writer(cls, source_name, source_connection_id=""):
+        cls._writers.pop((str(source_name).strip(), str(source_connection_id or "").strip()), None)
+
+    @classmethod
+    def reset_writers(cls):
+        cls._writers.clear()
+
+    def _source(self, annotation_id, source_name, source_connection_id):
+        source = (
+            self.session.query(AnnotationSource)
+            .filter(
+                AnnotationSource.annotation_id == annotation_id,
+                AnnotationSource.source_name == source_name,
+                AnnotationSource.source_connection_id == source_connection_id,
+            )
+            .first()
+        )
+        if source is None:
+            source = AnnotationSource(
+                annotation_id=annotation_id,
+                source_name=source_name,
+                source_connection_id=source_connection_id,
+                source_sync_status="pending",
+            )
+            self.session.add(source)
+        return source
+
+    @AsyncService.register_service
+    def sync_annotation(self, annotation_id, exclude_source_name=None, exclude_source_connection_id=""):
+        annotation = self.session.get(Annotation, int(annotation_id))
+        if annotation is None or annotation.is_private:
+            return
+
+        excluded = (exclude_source_name, str(exclude_source_connection_id or ""))
+        for (source_name, source_connection_id), writer in list(self._writers.items()):
+            if (source_name, source_connection_id) == excluded:
+                continue
+            now = datetime.datetime.now()
+            source = self._source(annotation.id, source_name, source_connection_id)
+            source.source_sync_status = "pending"
+            source.source_sync_error = None
+            source.update_time = now
+            self.session.commit()
+
+            try:
+                result = writer(annotation.to_api_dict(), source.to_api_dict()) or {}
+                if not isinstance(result, dict):
+                    raise TypeError("annotation source writer must return a dict or None")
+                for field in (
+                    "source_annotation_id",
+                    "source_run_id",
+                    "source_position",
+                    "source_raw_hash",
+                ):
+                    if field in result:
+                        setattr(source, field, result[field] or None)
+                if "source_updated_at" in result:
+                    source.source_updated_at = _parse_source_datetime(result["source_updated_at"])
+                source.source_sync_status = "synced"
+                source.source_synced_at = datetime.datetime.now()
+                source.source_sync_error = None
+            except Exception as err:
+                logging.exception("annotation source sync failed: %s", source_name)
+                source.source_sync_status = "failed"
+                source.source_sync_error = str(err)[:2000]
+            source.update_time = datetime.datetime.now()
+            self.session.commit()


### PR DESCRIPTION
## 背景

为微信读书、BRS、Calibre、Web、Moke、Readest 等笔记来源提供统一服务端 annotation 契约。Talebook 的 `annotations` 是唯一权威内容表；Calibre 等外部系统只作为可导入、可异步回写的 source。

Closes TB-42

## 关键改动

- 使用 `annotations` 权威表统一保存 highlight、note、bookmark 与 chapter_comment；不再创建独立 `chapter_comments` 内容表。
- 新增 `annotation_sources` 外部副本映射表，一条权威 annotation 可关联多个 source；外部字段统一使用 `source_` 前缀。
- 私有 annotation 仅 owner 可见且不向外部同步；非私有 annotation 对有书籍权限的登录用户可见，但仍仅 owner 可修改或删除。
- 按 client_id 或 source identity 幂等 upsert，保留来源旧事件保护和 Talebook 手工修改保护。
- 来源清理只解除 source 映射，不删除 Talebook 权威正文。
- 新增 `AnnotationSyncService` writer 注册与异步扇出契约；单个 source 失败记录 failed 状态，不回滚权威内容或阻塞其他 source。
- 修复 additive migration 未创建缺失整表的问题，使最终两张表连同唯一约束、索引和 FK 安全落地。

## 验证

- `tests/test_annotations.py`：13 passed。
- `pytest -q tests`（Talebook Calibre 镜像）：838 passed，20 skipped。
- `make lint-py-fix`：通过。
- `make lint-py`：通过。
- `make check-design`：109 份方案文档通过。

## 风险与兼容性

- PR 尚未合入，草稿中的 `book_annotations` / `chapter_comments` 未发布，因此直接使用最终表名，不为草稿结构增加迁移包袱。
- 外部写入是最终一致的异步操作；本次提供 writer 契约与 pending/synced/failed 状态，BRS、微信读书、Calibre 的认证和具体适配由各插件注册实现。
- 外部删除传播和持久化重试调度不在本任务内，后续 source 插件需补齐。
- API 字段从无前缀来源字段切换为 `source_*`，尚未合入的插件消费者需按新契约接入。
- 本次无页面、交互或文案变化，因此不需要界面截图或 interface-review。
- PR 保持 Draft，且仅合入 `feat/plugins`，待全部插件任务验收后再进入主干。

## 方案

- [GitHub 文件](https://github.com/talebook/talebook/blob/eda87577b25037638c9a090a3741a063996a828a/design/webserver/20260814-annotation-data-api.active.html)
- [RawGitHack 预览](https://raw.githack.com/talebook/talebook/eda87577b25037638c9a090a3741a063996a828a/design/webserver/20260814-annotation-data-api.active.html)
