### PR TITLE
TB-53: move Summary Duck artifacts to books/ai

### DIFF
--- a/design/webserver/20260815-summary-duck-agent-runtime.active.html
+++ b/design/webserver/20260815-summary-duck-agent-runtime.active.html
@@ -56,7 +56,7 @@
           <div><strong>权限与输入</strong><br />后端再次校验书籍可见性；仅接收裁剪后的当前章节文本、标题和 locator 范围。</div>
           <div><strong>隔离运行</strong><br />临时空目录启动 <code>codex app-server --listen stdio://</code>，禁止审批、网络和写入。</div>
           <div><strong>终态校验</strong><br />仅接受 <code>turn/completed</code>；业务层重验 schema、Markdown 和章节内引用。</div>
-          <div><strong>成果交付</strong><br />按创建者保存 AI 原稿与用户修订稿；前端可编辑、回跳、导出、重试或删除。</div>
+          <div><strong>成果交付</strong><br />在 <code>books/ai/{workspace}/summary-duck</code> 保存当前 AI 原稿与用户修订稿；前端可编辑、回跳、导出、重试或删除。</div>
         </div>
       </section>
       <section>
@@ -67,8 +67,10 @@
       <section>
         <h2>5. 数据、权限与安全</h2>
         <ul>
-          <li>保存创建者、book id/version、章节 href/title/hash/长度、五问五答及 locator、AI 原稿、用户稿、schema/prompt 版本、状态、用量与时间。</li>
+          <li>完整成果以 <code>books/ai/{workspace}/summary-duck/{task}.json</code> 为唯一内容来源，只维护当前版本，不建设版本表、回滚或 <code>v{version}</code> 目录。</li>
+          <li><code>ai_tasks</code> 只保存创建者/工作空间、book 与章节索引、相对路径、SHA-256、schema/prompt、状态、用量与时间；五问五答、locator、AI 原稿和用户稿保存在产物文件。</li>
           <li>列表、详情、编辑、删除、取消与导出均限定创建者，同时每次读取重新校验书籍权限和版本。</li>
+          <li>写入采用同目录临时文件、fsync 与原子替换；读取校验相对路径、身份和 SHA-256，删除任务或书籍同步清理文件。数据库迁移会搬运旧 JSON 字段，<code>/data</code> 备份须同时覆盖数据库与 <code>books/ai</code>。</li>
           <li>不持久化章节正文或完整提示；任务目录为空且只读，无 MCP、动态工具、网络或书库目录。</li>
           <li>Markdown 仅支持纯文本与 <code>**</code>/<code>__</code> 强调；所有 HTML、style、script 和危险 URL 作为文本处理。</li>
         </ul>
@@ -110,6 +112,7 @@
           <li>版本解析不再依赖 CLI 输出中的 <code>codex-cli</code> 产品标签；实际执行命令始终是 <code>codex</code>。</li>
           <li>特性 key、schema/prompt 版本、服务/静态资源/测试/fixture 文件名统一使用 <code>summary_duck</code>，提示词版本为 <code>summary_duck.zh.v2</code>。</li>
           <li>提示词分别覆盖中心判断、关键机制、决定性证据、边界张力和后续含义，并为非虚构/叙事章节提供不同选题框架、逐条引用规则和输出前自检。</li>
+          <li>按 AI 中心统一规范将总结鸭完整成果迁移到 <code>books/ai/{workspace}/summary-duck</code> 当前版本文件，数据库仅保留相对路径和 SHA-256 索引。</li>
         </ul>
       </section>
     </main>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     restart: always
     image: talebook/talebook
     volumes:
-      # 持久化配置、用户数据库和书库；可在 .env 中用 TALEBOOK_DATA_DIR 指定已有目录
+      # 持久化配置、用户数据库、书库及 books/ai 产物；备份/迁移时应整体保留此目录
       - "${TALEBOOK_DATA_DIR:-./data}:/data"
     ports:
       - "8080:80"

--- a/docker/start-dev.sh
+++ b/docker/start-dev.sh
@@ -40,7 +40,7 @@ find . \( -path ./library -o -name '*.pyc' \) -prune -o -type f -print | while r
 done
 
 
-mkdir -p /root/.npm /run/talebook /data/books/ssl
+mkdir -p /root/.npm /run/talebook /data/books/ssl /data/books/ai
 
 # 设置PUID/GUID权限
 permission_file=/data/.permission

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -40,7 +40,7 @@ find . \( -path ./library -o -name '*.pyc' \) -prune -o -type f -print | while r
 done
 
 
-mkdir -p /root/.npm /run/talebook /data/books/ssl
+mkdir -p /root/.npm /run/talebook /data/books/ssl /data/books/ai
 
 # 设置系统文件的权限（数量较少，且 nginx/诊断页在自检完成前就需要可用，必须先于 supervisord 启动前就绪）
 mkdir -p /data/log/nginx /var/www/talebook/status

--- a/tests/test_ai_artifacts.py
+++ b/tests/test_ai_artifacts.py
@@ -1,0 +1,195 @@
+import datetime
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from webserver import models
+from webserver.services.agent_runtime import RuntimeResult
+from webserver.services.ai_artifacts import (
+    AIArtifactError,
+    AIArtifactStore,
+    migrate_legacy_summary_duck_artifacts,
+    workspace_identifier,
+)
+from webserver.services.summary_duck import SummaryDuckService
+
+
+def payload(label="原稿"):
+    return {
+        "items": [
+            {
+                "question": f"问题 {index + 1}",
+                "answer": f"{label} {index + 1}",
+                "citations": [{"href": "Text/chapter.xhtml", "start": index, "end": index + 1, "quote": "字"}],
+            }
+            for index in range(5)
+        ]
+    }
+
+
+def record(**overrides):
+    values = {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "request_key": "a" * 64,
+        "feature": "summary_duck",
+        "creator_id": 7,
+        "book_id": 9,
+        "book_version": "book-version",
+        "chapter_href": "Text/chapter.xhtml",
+        "chapter_title": "章节",
+        "chapter_text_hash": "b" * 64,
+        "chapter_length": 120,
+        "status": "succeeded",
+        "schema_version": "summary_duck.v1",
+        "prompt_version": "summary_duck.zh.v2",
+        "create_time": datetime.datetime(2026, 8, 18, 1, 2, 3),
+        "update_time": datetime.datetime(2026, 8, 18, 1, 3, 4),
+        "workspace_id": "",
+        "artifact_path": "",
+        "artifact_sha256": "",
+        "result_data": {},
+        "ai_draft": {},
+        "user_revision": {},
+    }
+    values.update(overrides)
+    return models.AITask(**values)
+
+
+class AIArtifactStoreTest(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.config = {"AI_ARTIFACT_ROOT": self.tempdir.name, "cookie_secret": "fixture-secret"}
+        self.store = AIArtifactStore(self.config)
+
+    def test_current_artifact_is_atomic_relative_and_digest_verified(self):
+        task = record()
+        digest = self.store.write_summary_duck(task, payload(), payload("用户稿"))
+
+        self.assertEqual(task.artifact_sha256, digest)
+        self.assertRegex(task.workspace_id, r"^[a-f0-9]{32}$")
+        self.assertEqual(
+            task.artifact_path,
+            f"{task.workspace_id}/summary-duck/{task.id}.json",
+        )
+        self.assertNotIn("/v", task.artifact_path)
+        artifact = Path(self.tempdir.name, task.artifact_path)
+        self.assertTrue(artifact.is_file())
+        self.assertEqual(oct(artifact.stat().st_mode & 0o777), "0o600")
+        self.assertFalse(any(path.suffix == ".tmp" for path in artifact.parent.iterdir()))
+        self.assertEqual(self.store.read_summary_duck(task)["user_revision"], payload("用户稿"))
+
+        replacement = payload("第二次编辑")
+        self.store.write_summary_duck(task, payload(), replacement)
+        self.assertEqual(self.store.read_summary_duck(task)["user_revision"], replacement)
+
+    def test_workspace_identifier_is_stable_across_configuration_changes(self):
+        first = workspace_identifier(7, {"cookie_secret": "old"})
+        second = workspace_identifier(7, {"cookie_secret": "rotated"})
+        self.assertEqual(first, second)
+        self.assertNotEqual(first, workspace_identifier(8, {}))
+
+    def test_path_and_digest_tampering_fail_closed(self):
+        task = record()
+        self.store.write_summary_duck(task, payload(), payload())
+        artifact = Path(self.tempdir.name, task.artifact_path)
+        artifact.write_text(json.dumps({"tampered": True}), encoding="utf-8")
+        with self.assertRaisesRegex(AIArtifactError, "校验失败"):
+            self.store.read_summary_duck(task)
+
+        task.artifact_path = "../outside.json"
+        with self.assertRaisesRegex(AIArtifactError, "路径无效"):
+            self.store.read_summary_duck(task)
+
+    def test_delete_removes_current_file_and_empty_feature_directories(self):
+        task = record()
+        self.store.write_summary_duck(task, payload(), payload())
+        workspace_dir = Path(self.tempdir.name, task.workspace_id)
+
+        self.assertTrue(self.store.delete_summary_duck(task))
+        self.assertFalse(workspace_dir.exists())
+        self.assertFalse(self.store.delete_summary_duck(task))
+
+
+class LegacyArtifactMigrationTest(unittest.TestCase):
+    def test_migration_moves_database_blobs_and_is_idempotent(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            database = os.path.join(tempdir, "users.db")
+            engine = create_engine(f"sqlite:///{database}")
+            models.Base.metadata.create_all(engine)
+            sessions = sessionmaker(bind=engine)
+            session = sessions()
+            legacy = record(
+                result_data=payload("结果"),
+                ai_draft=payload("原稿"),
+                user_revision=payload("修订"),
+            )
+            session.add(legacy)
+            session.commit()
+            legacy_id = legacy.id
+            session.close()
+
+            config = {"AI_ARTIFACT_ROOT": os.path.join(tempdir, "ai"), "cookie_secret": "migration-secret"}
+            self.assertEqual(
+                migrate_legacy_summary_duck_artifacts(sessions, config),
+                {"migrated": 1, "failed": 0},
+            )
+            migrated = sessions().get(models.AITask, legacy_id)
+            self.assertEqual(migrated.result_data, {})
+            self.assertEqual(migrated.ai_draft, {})
+            self.assertEqual(migrated.user_revision, {})
+            self.assertTrue(migrated.artifact_path)
+            self.assertEqual(AIArtifactStore(config).read_summary_duck(migrated)["user_revision"], payload("修订"))
+            self.assertEqual(
+                migrate_legacy_summary_duck_artifacts(sessions, config),
+                {"migrated": 0, "failed": 0},
+            )
+
+
+class SummaryDuckArtifactPersistenceTest(unittest.TestCase):
+    def test_success_writes_file_and_keeps_database_payload_columns_empty(self):
+        class Runtime:
+            name = "fixture"
+
+            def generate(self, request, on_event):
+                return RuntimeResult(payload(), {"inputTokens": 10}, "session")
+
+            def cancel(self, task_id):
+                return False
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            engine = create_engine(f"sqlite:///{os.path.join(tempdir, 'users.db')}")
+            models.Base.metadata.create_all(engine)
+            sessions = sessionmaker(bind=engine)
+            session = sessions()
+            task = record(status="queued")
+            session.add(task)
+            session.commit()
+            task_id = task.id
+            session.close()
+            config = {"AI_ARTIFACT_ROOT": os.path.join(tempdir, "ai")}
+            service = SummaryDuckService()
+            service.setup(sessions, config, runtime=Runtime())
+            service._run(
+                task_id,
+                {"text": "字" * 120, "href": "Text/chapter.xhtml", "title": "章节"},
+            )
+
+            stored = sessions().get(models.AITask, task_id)
+            self.assertEqual(stored.status, "succeeded")
+            self.assertEqual(stored.result_data, {})
+            self.assertEqual(stored.ai_draft, {})
+            self.assertEqual(stored.user_revision, {})
+            self.assertTrue(stored.artifact_sha256)
+            document = AIArtifactStore(config).read_summary_duck(stored)
+            self.assertEqual(document["ai_draft"], payload())
+            self.assertEqual(document["user_revision"], payload())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_self_check.py
+++ b/tests/test_self_check.py
@@ -53,12 +53,14 @@ class TestSelfCheckSteps(unittest.TestCase):
         self.assertIsNone(code)
         with open(os.path.join(self.data_dir, ".permission")) as f:
             self.assertEqual(f.read().strip(), "1000:1000")
-        chown_call, library_probe, settings_probe = m_run.call_args_list
+        chown_call, library_probe, settings_probe, ai_probe = m_run.call_args_list
         self.assertEqual(chown_call.args[0][:2], ["chown", "-R"])
         self.assertEqual(library_probe.args[0][0], "gosu")
         self.assertEqual(library_probe.args[0][-1], os.path.join(self.data_dir, "books", "library"))
         self.assertEqual(settings_probe.args[0][0], "gosu")
         self.assertEqual(settings_probe.args[0][-1], os.path.join(self.data_dir, "books", "settings"))
+        self.assertEqual(ai_probe.args[0][0], "gosu")
+        self.assertEqual(ai_probe.args[0][-1], os.path.join(self.data_dir, "books", "ai"))
 
     @mock.patch("webserver.self_check.run")
     def test_check_permission_repairs_settings_when_identity_unchanged(self, m_run):
@@ -70,13 +72,21 @@ class TestSelfCheckSteps(unittest.TestCase):
 
         self.assertTrue(ok)
         self.assertIsNone(code)
-        self.assertEqual(m_run.call_count, 3)
-        settings_chown, library_probe, settings_probe = m_run.call_args_list
+        self.assertEqual(m_run.call_count, 4)
+        settings_chown, library_probe, settings_probe, ai_probe = m_run.call_args_list
         self.assertEqual(
-            settings_chown.args[0], ["chown", "-R", "talebook:talebook", os.path.join(self.data_dir, "books", "settings")]
+            settings_chown.args[0],
+            [
+                "chown",
+                "-R",
+                "talebook:talebook",
+                os.path.join(self.data_dir, "books", "settings"),
+                os.path.join(self.data_dir, "books", "ai"),
+            ],
         )
         self.assertEqual(library_probe.args[0][-1], os.path.join(self.data_dir, "books", "library"))
         self.assertEqual(settings_probe.args[0][-1], os.path.join(self.data_dir, "books", "settings"))
+        self.assertEqual(ai_probe.args[0][-1], os.path.join(self.data_dir, "books", "ai"))
 
     @mock.patch("webserver.self_check.run")
     def test_check_permission_chown_failure(self, m_run):
@@ -103,11 +113,28 @@ class TestSelfCheckSteps(unittest.TestCase):
 
         self.assertFalse(ok)
         self.assertEqual(code, "permission_denied")
-        m_run.assert_called_once_with(["chown", "-R", "talebook:talebook", os.path.join(self.data_dir, "books", "settings")])
+        m_run.assert_called_once_with(
+            [
+                "chown",
+                "-R",
+                "talebook:talebook",
+                os.path.join(self.data_dir, "books", "settings"),
+                os.path.join(self.data_dir, "books", "ai"),
+            ]
+        )
 
     @mock.patch("webserver.self_check.run")
     def test_check_permission_settings_atomic_write_failure(self, m_run):
         m_run.side_effect = [True, True, False]
+
+        ok, code = self_check.check_permission()
+
+        self.assertFalse(ok)
+        self.assertEqual(code, "permission_denied")
+
+    @mock.patch("webserver.self_check.run")
+    def test_check_permission_ai_artifact_atomic_write_failure(self, m_run):
+        m_run.side_effect = [True, True, True, False]
 
         ok, code = self_check.check_permission()
 

--- a/tests/test_summary_duck.py
+++ b/tests/test_summary_duck.py
@@ -176,9 +176,17 @@ class CodexProtocolContractTest(unittest.TestCase):
 class SummaryDuckAPITest(test_main.TestWithUserLogin):
     def setUp(self):
         super().setUp()
+        self.artifact_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.artifact_directory.cleanup)
+        self.previous_artifact_root = test_main.main.CONF.get("AI_ARTIFACT_ROOT")
+        test_main.main.CONF["AI_ARTIFACT_ROOT"] = self.artifact_directory.name
+        self.addCleanup(self._restore_artifact_root)
         session = test_main.get_db()
         session.query(models.AITask).delete()
         session.commit()
+
+    def _restore_artifact_root(self):
+        test_main.main.CONF["AI_ARTIFACT_ROOT"] = self.previous_artifact_root
 
     def tearDown(self):
         session = test_main.get_db()
@@ -265,6 +273,15 @@ class SummaryDuckAPITest(test_main.TestWithUserLogin):
         self.assertEqual(response["err"], "ok")
         self.assertIn("用户修订", response["task"]["items"][0]["answer"])
 
+        session = test_main.get_db()
+        stored = session.get(models.AITask, record.id)
+        self.assertEqual(stored.result_data, {})
+        self.assertEqual(stored.ai_draft, {})
+        self.assertEqual(stored.user_revision, {})
+        self.assertTrue(stored.artifact_path.endswith(f"/summary-duck/{record.id}.json"))
+        artifact_path = Path(self.artifact_directory.name, stored.artifact_path)
+        self.assertTrue(artifact_path.is_file())
+
         export = self.fetch(f"/api/ai/{FEATURE_KEY}/tasks/{record.id}/export")
         self.assertEqual(export.code, 200)
         self.assertIn("text/markdown", export.headers["Content-Type"])
@@ -273,6 +290,7 @@ class SummaryDuckAPITest(test_main.TestWithUserLogin):
         response = self.json(f"/api/ai/{FEATURE_KEY}/tasks/{record.id}", method="DELETE")
         self.assertEqual(response["err"], "ok")
         self.assertIsNone(test_main.get_db().get(models.AITask, created["id"]))
+        self.assertFalse(artifact_path.exists())
 
     def test_book_version_change_fails_closed(self):
         task = self._create()["task"]
@@ -308,6 +326,7 @@ class StaticReaderContractTest(unittest.TestCase):
         delete_block = source[source.index("class BookDelete") : source.index("class BookDownload")]
         self.assertIn("AITask", delete_block)
         self.assertIn("AITask.book_id == bid", delete_block)
+        self.assertIn("delete_summary_duck", delete_block)
 
 
 if __name__ == "__main__":

--- a/webserver/handlers/ai.py
+++ b/webserver/handlers/ai.py
@@ -4,6 +4,7 @@
 import datetime
 import hashlib
 import json
+import logging
 import os
 import uuid
 
@@ -12,6 +13,7 @@ from sqlalchemy.exc import IntegrityError
 from webserver import loader
 from webserver.handlers.base import BaseHandler, auth, js
 from webserver.models import AITask
+from webserver.services.ai_artifacts import AIArtifactError, AIArtifactStore
 from webserver.services.knowledge_graph import (
     FEATURE_KEY as KNOWLEDGE_GRAPH_FEATURE_KEY,
 )
@@ -39,12 +41,12 @@ from webserver.services.summary_duck import (
     SCHEMA_VERSION,
     SummaryDuckService,
     SummaryDuckValidationError,
+    artifact_payload,
     chapter_hash,
     clean_markdown,
     export_markdown,
     request_key,
     task_dict,
-    task_items,
     validate_chapter_input,
 )
 
@@ -76,7 +78,14 @@ class SummaryDuckFeature:
     """Summary Duck behavior plugged into the stable AI task HTTP surface."""
 
     key = FEATURE_KEY
-    task_dict = staticmethod(task_dict)
+
+    @staticmethod
+    def task_dict(record):
+        return task_dict(record, CONF)
+
+    @staticmethod
+    def artifacts():
+        return AIArtifactStore(CONF)
 
     @staticmethod
     def enabled():
@@ -97,6 +106,12 @@ class SummaryDuckFeature:
             return False, {"err": "ai.not_found", "msg": "AI 结果不存在"}
         if _book_version(book) != record.book_version:
             return False, {"err": "ai.book_version_changed", "msg": "书籍版本已变化，请重新生成"}
+        if record.status == "succeeded":
+            try:
+                SummaryDuckFeature.artifacts().migrate_summary_duck_record(handler.session, record)
+                SummaryDuckFeature.artifacts().read_summary_duck(record)
+            except AIArtifactError as exc:
+                return False, {"err": exc.code, "msg": exc.safe_message}
         return True, None
 
     @classmethod
@@ -121,7 +136,13 @@ class SummaryDuckFeature:
             .order_by(AITask.create_time.desc())
             .all()
         )
-        return {"err": "ok", "tasks": task_items(records)}
+        for record in records:
+            if record.status == "succeeded" and not record.artifact_sha256:
+                try:
+                    cls.artifacts().migrate_summary_duck_record(handler.session, record)
+                except AIArtifactError as exc:
+                    logging.warning("Summary Duck legacy artifact migration failed task_id=%s code=%s", record.id, exc.code)
+        return {"err": "ok", "tasks": [cls.task_dict(record) for record in records]}
 
     @classmethod
     def create(cls, handler, body):
@@ -153,7 +174,7 @@ class SummaryDuckFeature:
                 existing.update_time = datetime.datetime.now()
                 handler.session.commit()
                 cls.service(handler).submit(existing.id, chapter)
-            return {"err": "ok", "task": task_dict(existing), "idempotent": True}
+            return {"err": "ok", "task": cls.task_dict(existing), "idempotent": True}
         record = AITask(
             id=str(uuid.uuid4()),
             request_key=key,
@@ -170,6 +191,7 @@ class SummaryDuckFeature:
             schema_version=SCHEMA_VERSION,
             prompt_version=PROMPT_VERSION,
         )
+        cls.artifacts().prepare_summary_duck_record(record)
         handler.session.add(record)
         try:
             handler.session.commit()
@@ -179,15 +201,17 @@ class SummaryDuckFeature:
             if not record or record.creator_id != handler.user_id() or record.feature != cls.key:
                 return {"err": "ai.conflict", "msg": "无法创建总结"}
         cls.service(handler).submit(record.id, chapter)
-        return {"err": "ok", "task": task_dict(record), "idempotent": False}
+        return {"err": "ok", "task": cls.task_dict(record), "idempotent": False}
 
     @staticmethod
     def update(handler, record, body):
         if record.status != "succeeded":
             return {"err": "ai.not_editable", "msg": "仅成功结果可编辑"}
         try:
+            document = SummaryDuckFeature.artifacts().read_summary_duck(record)
             items = body.get("items")
-            original = (record.ai_draft or {}).get("items", [])
+            original_payload = document.get("ai_draft") or {}
+            original = original_payload.get("items", [])
             if not isinstance(items, list) or len(items) != 5 or len(original) != 5:
                 raise SummaryDuckValidationError("结果必须恰好包含五组问答")
             revision = []
@@ -207,11 +231,28 @@ class SummaryDuckFeature:
                 )
         except SummaryDuckValidationError as exc:
             return {"err": "params.invalid", "msg": str(exc)}
-        record.user_revision = {"items": revision}
-        record.result_data = {"items": revision}
+        except AIArtifactError as exc:
+            return {"err": exc.code, "msg": exc.safe_message}
         record.update_time = datetime.datetime.now()
+        try:
+            SummaryDuckFeature.artifacts().write_summary_duck(
+                record,
+                original_payload,
+                {"items": revision},
+                status="succeeded",
+                updated_at=record.update_time,
+            )
+        except AIArtifactError as exc:
+            return {"err": exc.code, "msg": exc.safe_message}
+        record.user_revision = {}
+        record.result_data = {}
+        record.ai_draft = {}
         handler.session.commit()
-        return {"err": "ok", "task": task_dict(record)}
+        return {"err": "ok", "task": SummaryDuckFeature.task_dict(record)}
+
+    @staticmethod
+    def delete(handler, record):
+        SummaryDuckFeature.artifacts().delete_summary_duck(record)
 
     @staticmethod
     def export(handler, record):
@@ -219,10 +260,16 @@ class SummaryDuckFeature:
             handler.set_header("Content-Type", "application/json; charset=UTF-8")
             handler.write({"err": "ai.not_ready", "msg": "总结尚未完成"})
             return
+        try:
+            markdown = export_markdown(record, artifact_payload(record, CONF))
+        except AIArtifactError as exc:
+            handler.set_header("Content-Type", "application/json; charset=UTF-8")
+            handler.write({"err": exc.code, "msg": exc.safe_message})
+            return
         filename = f"summary-duck-{record.book_id}-{record.id[:8]}.md"
         handler.set_header("Content-Type", "text/markdown; charset=UTF-8")
         handler.set_header("Content-Disposition", f'attachment; filename="{filename}"')
-        handler.write(export_markdown(record))
+        handler.write(markdown)
 
 
 class KnowledgeGraphFeature:
@@ -486,11 +533,24 @@ class AITaskItem(_AITaskBase):
     @js
     @auth
     def delete(self, feature_name, task_id):
-        record, feature, error = self._visible_task(feature_name, task_id)
-        if error:
+        feature = _feature(feature_name)
+        if not feature:
+            return {"err": "ai.feature_not_found", "msg": "不支持的 AI 功能"}
+        record = self._own_task(feature.key, task_id)
+        if not record:
+            return {"err": "ai.not_found", "msg": "AI 任务不存在"}
+        visible, error = feature.can_access(self, record)
+        removable_artifact_errors = {"artifact.unavailable", "artifact.digest_mismatch", "artifact.invalid"}
+        if not visible and error.get("err") not in removable_artifact_errors:
             return error
         if record.status in {"queued", "running"}:
             feature.service(self).cancel(record.id)
+        try:
+            delete = getattr(feature, "delete", None)
+            if delete:
+                delete(self, record)
+        except AIArtifactError as exc:
+            return {"err": exc.code, "msg": exc.safe_message}
         self.session.delete(record)
         self.session.commit()
         return {"err": "ok", "msg": "AI 任务已删除"}

--- a/webserver/handlers/book.py
+++ b/webserver/handlers/book.py
@@ -1012,14 +1012,24 @@ class BookDelete(BaseHandler):
         if not can_manage or not (self.is_admin() or self.is_book_owner(bid, self.user_id())):
             return {"err": "permission", "msg": _("无权操作")}
 
+        from webserver.models import AITask, ScanFile
+        from webserver.services.ai_artifacts import SUMMARY_DUCK_FEATURE, AIArtifactError, AIArtifactStore
+
+        artifact_store = AIArtifactStore(CONF)
+        ai_tasks = self.session.query(AITask).filter(AITask.book_id == bid).all()
+        try:
+            for task in ai_tasks:
+                if task.feature == SUMMARY_DUCK_FEATURE:
+                    artifact_store.delete_summary_duck(task)
+        except AIArtifactError as exc:
+            return {"err": exc.code, "msg": exc.safe_message}
+
         external_indexed = is_external_index_book(self.session, bid)
         if external_indexed:
             delete_external_index_book_record(self.db, bid)
         else:
             self.db.delete_book(bid)
         # 同步清理该书籍对应的 ScanFile 记录，避免重新导入时因哈希重复被误判为 drop
-        from webserver.models import AITask, ScanFile
-
         self.session.query(ScanFile).filter(ScanFile.book_id == bid).delete()
         self.session.query(AITask).filter(AITask.book_id == bid).delete()
         if external_indexed:

--- a/webserver/migrate_db.py
+++ b/webserver/migrate_db.py
@@ -24,6 +24,7 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.orm import sessionmaker
 
 from webserver import loader, models
 
@@ -283,6 +284,17 @@ def main():
     # Perform migration
     try:
         success = compare_and_migrate(engine)
+        if success:
+            from webserver.services.ai_artifacts import migrate_legacy_summary_duck_artifacts
+
+            artifact_result = migrate_legacy_summary_duck_artifacts(sessionmaker(bind=engine), CONF)
+            logger.info(
+                "Summary Duck artifact migration: %d migrated, %d failed",
+                artifact_result["migrated"],
+                artifact_result["failed"],
+            )
+            if artifact_result["failed"]:
+                success = False
         return success
     except Exception as e:
         logger.error(f"Migration error: {e}")

--- a/webserver/models.py
+++ b/webserver/models.py
@@ -553,6 +553,11 @@ class AITask(Base, SQLAlchemyMixin):
     chapter_length = Column(Integer, nullable=False)
     status = Column(String(24), default="queued", nullable=False, index=True)
     progress_message = Column(String(256), default="")
+    # Durable payloads live below books/ai/{workspace}/{feature}; these fields
+    # are the database index needed to locate and verify the current artifact.
+    workspace_id = Column(String(64), default="", nullable=False, index=True)
+    artifact_path = Column(String(1024), default="", nullable=False)
+    artifact_sha256 = Column(String(64), default="", nullable=False)
     result_data = Column(MutableDict.as_mutable(JSONType), default={})
     ai_draft = Column(MutableDict.as_mutable(JSONType), default={})
     user_revision = Column(MutableDict.as_mutable(JSONType), default={})

--- a/webserver/self_check.py
+++ b/webserver/self_check.py
@@ -76,11 +76,16 @@ def check_atomic_write(directory):
 
 
 def check_permission():
-    """修复 /data/books 的属主，并校验书库与配置目录的原子写入能力。"""
+    """修复 /data/books 的属主，并校验书库、配置与 AI 产物目录可原子写入。"""
     permission_file = os.path.join(DATA_DIR, ".permission")
     current = "%s:%s" % (os.environ.get("PUID", "0"), os.environ.get("PGID", "0"))
     books_dir = os.path.join(DATA_DIR, "books")
     settings_dir = os.path.join(books_dir, "settings")
+    ai_dir = os.path.join(books_dir, "ai")
+    try:
+        os.makedirs(ai_dir, exist_ok=True)
+    except OSError:
+        return False, "permission_denied"
     previous = None
     if os.path.exists(permission_file):
         with open(permission_file) as f:
@@ -91,11 +96,11 @@ def check_permission():
             return False, "permission_denied"
         with open(permission_file, "w") as f:
             f.write(current)
-    elif not run(["chown", "-R", "%s:%s" % (RUN_USER, RUN_USER), settings_dir]):
-        # settings 很小，标记命中时仍定向修复，避免宿主目录重建或预置文件复制后属主失真。
+    elif not run(["chown", "-R", "%s:%s" % (RUN_USER, RUN_USER), settings_dir, ai_dir]):
+        # settings/ai 很小，标记命中时仍定向修复，避免宿主目录重建后属主失真。
         return False, "permission_denied"
 
-    for directory in (os.path.join(books_dir, "library"), settings_dir):
+    for directory in (os.path.join(books_dir, "library"), settings_dir, ai_dir):
         if not check_atomic_write(directory):
             return False, "permission_denied"
 

--- a/webserver/services/ai_artifacts.py
+++ b/webserver/services/ai_artifacts.py
@@ -1,0 +1,244 @@
+"""Filesystem-backed, current-version storage for durable AI artifacts."""
+
+from __future__ import annotations
+
+import datetime
+import hashlib
+import hmac
+import json
+import os
+import re
+import tempfile
+import uuid
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+SUMMARY_DUCK_FEATURE = "summary_duck"
+SUMMARY_DUCK_DIRECTORY = "summary-duck"
+ARTIFACT_FORMAT = "talebook.ai.summary-duck.v1"
+WORKSPACE_RE = re.compile(r"^[a-f0-9]{32}$")
+TASK_ID_RE = re.compile(r"^[a-f0-9-]{36}$")
+WORKSPACE_NAMESPACE = uuid.UUID("fd75df4a-22c1-4bf1-bb30-83534b556b6b")
+
+
+class AIArtifactError(RuntimeError):
+    """An artifact could not be accessed without weakening storage guarantees."""
+
+    def __init__(self, code: str, safe_message: str):
+        self.code = code
+        self.safe_message = safe_message
+        super().__init__(safe_message)
+
+
+def workspace_identifier(creator_id: int, config: Dict[str, Any]) -> str:
+    """Return a stable opaque directory identifier without exposing user fields."""
+
+    del config
+    return uuid.uuid5(WORKSPACE_NAMESPACE, f"talebook:reader:{int(creator_id)}").hex
+
+
+def _iso(value: Optional[datetime.datetime]) -> Optional[str]:
+    return value.isoformat() if value else None
+
+
+class AIArtifactStore:
+    """Store one authoritative JSON file per artifact, without application versions."""
+
+    def __init__(self, config: Dict[str, Any]):
+        configured = config.get("AI_ARTIFACT_ROOT") or "/data/books/ai"
+        self.root = Path(str(configured)).expanduser().resolve()
+        self.config = config
+
+    def prepare_summary_duck_record(self, record) -> str:
+        if record.feature != SUMMARY_DUCK_FEATURE:
+            raise AIArtifactError("artifact.feature_invalid", "AI 产物类型无效")
+        workspace_id = record.workspace_id or workspace_identifier(record.creator_id, self.config)
+        if not WORKSPACE_RE.fullmatch(workspace_id):
+            raise AIArtifactError("artifact.workspace_invalid", "AI 工作空间标识无效")
+        if not TASK_ID_RE.fullmatch(str(record.id)):
+            raise AIArtifactError("artifact.task_invalid", "AI 任务标识无效")
+        relative_path = f"{workspace_id}/{SUMMARY_DUCK_DIRECTORY}/{record.id}.json"
+        if record.artifact_path and record.artifact_path != relative_path:
+            raise AIArtifactError("artifact.path_invalid", "AI 产物路径无效")
+        record.workspace_id = workspace_id
+        record.artifact_path = relative_path
+        return relative_path
+
+    def _path(self, record) -> Path:
+        relative_path = self.prepare_summary_duck_record(record)
+        candidate = (self.root / relative_path).resolve()
+        try:
+            candidate.relative_to(self.root)
+        except ValueError as exc:
+            raise AIArtifactError("artifact.path_invalid", "AI 产物路径无效") from exc
+        return candidate
+
+    @staticmethod
+    def _document(record, ai_draft, user_revision, status, updated_at):
+        return {
+            "format": ARTIFACT_FORMAT,
+            "task": {
+                "id": record.id,
+                "creator_id": record.creator_id,
+                "workspace_id": record.workspace_id,
+                "feature": record.feature,
+                "book_id": record.book_id,
+                "book_version": record.book_version,
+                "chapter": {
+                    "href": record.chapter_href,
+                    "title": record.chapter_title or "",
+                    "text_sha256": record.chapter_text_hash,
+                    "length": record.chapter_length,
+                },
+                "schema_version": record.schema_version,
+                "prompt_version": record.prompt_version,
+                "status": status,
+                "created_at": _iso(record.create_time),
+                "updated_at": _iso(updated_at),
+            },
+            "ai_draft": ai_draft or {},
+            "user_revision": user_revision or {},
+        }
+
+    def write_summary_duck(
+        self,
+        record,
+        ai_draft: Dict[str, Any],
+        user_revision: Dict[str, Any],
+        *,
+        status: str = "succeeded",
+        updated_at: Optional[datetime.datetime] = None,
+    ) -> str:
+        updated_at = updated_at or datetime.datetime.now()
+        path = self._path(record)
+        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        try:
+            os.chmod(path.parent.parent, 0o700)
+            os.chmod(path.parent, 0o700)
+        except OSError as exc:
+            raise AIArtifactError("artifact.write_failed", "AI 产物目录不可写") from exc
+        document = self._document(record, ai_draft, user_revision, status, updated_at)
+        payload = json.dumps(document, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        digest = hashlib.sha256(payload).hexdigest()
+        fd = None
+        temp_path = None
+        try:
+            fd, temp_path = tempfile.mkstemp(dir=str(path.parent), prefix=f".{record.id}.", suffix=".tmp")
+            os.fchmod(fd, 0o600)
+            with os.fdopen(fd, "wb") as output:
+                fd = None
+                output.write(payload)
+                output.flush()
+                os.fsync(output.fileno())
+            os.replace(temp_path, path)
+            temp_path = None
+            directory_fd = os.open(str(path.parent), os.O_RDONLY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+        except OSError as exc:
+            raise AIArtifactError("artifact.write_failed", "AI 产物保存失败，请重试") from exc
+        finally:
+            if fd is not None:
+                os.close(fd)
+            if temp_path:
+                try:
+                    os.unlink(temp_path)
+                except OSError:
+                    pass
+        record.artifact_sha256 = digest
+        return digest
+
+    def read_summary_duck(self, record) -> Dict[str, Any]:
+        path = self._path(record)
+        try:
+            payload = path.read_bytes()
+        except OSError as exc:
+            raise AIArtifactError("artifact.unavailable", "总结产物暂时不可用，请重试或重新生成") from exc
+        digest = hashlib.sha256(payload).hexdigest()
+        if not record.artifact_sha256 or not hmac.compare_digest(digest, record.artifact_sha256):
+            raise AIArtifactError("artifact.digest_mismatch", "总结产物校验失败，请重新生成")
+        try:
+            document = json.loads(payload)
+        except (TypeError, ValueError) as exc:
+            raise AIArtifactError("artifact.invalid", "总结产物格式无效，请重新生成") from exc
+        if not isinstance(document, dict):
+            raise AIArtifactError("artifact.invalid", "总结产物格式无效，请重新生成")
+        task = document.get("task")
+        if (
+            document.get("format") != ARTIFACT_FORMAT
+            or not isinstance(task, dict)
+            or task.get("id") != record.id
+            or task.get("creator_id") != record.creator_id
+            or task.get("workspace_id") != record.workspace_id
+            or task.get("feature") != SUMMARY_DUCK_FEATURE
+            or task.get("book_id") != record.book_id
+            or task.get("book_version") != record.book_version
+        ):
+            raise AIArtifactError("artifact.invalid", "总结产物身份校验失败，请重新生成")
+        return document
+
+    def delete_summary_duck(self, record) -> bool:
+        if not record.artifact_path:
+            return False
+        path = self._path(record)
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            return False
+        except OSError as exc:
+            raise AIArtifactError("artifact.delete_failed", "AI 产物删除失败，请重试") from exc
+        for directory in (path.parent, path.parent.parent):
+            try:
+                directory.rmdir()
+            except OSError:
+                break
+        return True
+
+    def migrate_summary_duck_record(self, session, record) -> bool:
+        """Move one legacy database-backed result to the authoritative file."""
+
+        if record.artifact_sha256:
+            return False
+        ai_draft = dict(record.ai_draft or record.result_data or {})
+        user_revision = dict(record.user_revision or record.result_data or ai_draft)
+        if not ai_draft and not user_revision:
+            self.prepare_summary_duck_record(record)
+            return False
+        self.write_summary_duck(
+            record,
+            ai_draft,
+            user_revision,
+            status=record.status,
+            updated_at=record.update_time,
+        )
+        record.result_data = {}
+        record.ai_draft = {}
+        record.user_revision = {}
+        session.add(record)
+        session.commit()
+        return True
+
+
+def migrate_legacy_summary_duck_artifacts(session_maker, config: Dict[str, Any]) -> Dict[str, int]:
+    """Migrate legacy Summary Duck blobs after the additive DB schema migration."""
+
+    from webserver.models import AITask
+
+    store = AIArtifactStore(config)
+    session = session_maker()
+    migrated = 0
+    failed = 0
+    try:
+        records = session.query(AITask).filter(AITask.feature == SUMMARY_DUCK_FEATURE).all()
+        for record in records:
+            try:
+                migrated += int(store.migrate_summary_duck_record(session, record))
+            except Exception:
+                failed += 1
+                session.rollback()
+        return {"migrated": migrated, "failed": failed}
+    finally:
+        session.close()

--- a/webserver/services/summary_duck.py
+++ b/webserver/services/summary_duck.py
@@ -9,10 +9,12 @@ import json
 import logging
 import re
 import threading
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, List, Optional
 
+from webserver import loader
 from webserver.models import AITask
 from webserver.services.agent_runtime import AgentRuntimeError, RuntimeEvent, RuntimeRequest
+from webserver.services.ai_artifacts import AIArtifactError, AIArtifactStore
 from webserver.services.codex_app_server import CodexAppServerRuntime
 
 
@@ -189,8 +191,13 @@ def request_key(creator_id: int, book_id: int, book_version: str, chapter_href: 
     return hashlib.sha256(raw.encode("utf-8")).hexdigest()
 
 
-def export_markdown(record: AITask) -> str:
-    data = record.user_revision or record.result_data or {}
+def artifact_payload(record: AITask, config: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    document = AIArtifactStore(config or loader.get_settings()).read_summary_duck(record)
+    return document.get("user_revision") or document.get("ai_draft") or {}
+
+
+def export_markdown(record: AITask, data: Optional[Dict[str, Any]] = None) -> str:
+    data = data if data is not None else artifact_payload(record)
     lines = [f"# 总结鸭 TOP5：{record.chapter_title or record.chapter_href}", ""]
     for number, item in enumerate(data.get("items", []), 1):
         lines.extend([f"## {number}. {item.get('question', '')}", "", item.get("answer", ""), "", "原文引用："])
@@ -217,6 +224,7 @@ class SummaryDuckService:
     def setup(self, session_maker, config: Dict[str, Any], runtime=None) -> None:
         self.session_maker = session_maker
         self.config = config
+        self.artifacts = AIArtifactStore(config)
         if runtime is not None:
             self.runtime = runtime
         elif not self._configured:
@@ -288,26 +296,47 @@ class SummaryDuckService:
             )
             checked = validate_summary_duck(result.output, chapter["text"], chapter["href"])
             session = self.session_maker()
+            artifact_written = False
             try:
                 record = session.get(AITask, record_id)
                 if not record:
                     return
+                finished_at = datetime.datetime.now()
                 if record.cancel_requested:
                     record.status = "cancelled"
                 else:
+                    self.artifacts.write_summary_duck(
+                        record,
+                        checked,
+                        checked,
+                        status="succeeded",
+                        updated_at=finished_at,
+                    )
+                    artifact_written = True
                     record.status = "succeeded"
-                    record.result_data = checked
-                    record.ai_draft = checked
-                    record.user_revision = checked
+                    record.result_data = {}
+                    record.ai_draft = {}
+                    record.user_revision = {}
                     record.usage = result.usage or {}
                     record.runtime_session_id = (result.session_id or "")[:128]
                     record.progress_message = "生成完成"
-                record.finished_at = datetime.datetime.now()
+                record.finished_at = finished_at
                 record.update_time = record.finished_at
                 session.commit()
+            except Exception:
+                if artifact_written:
+                    try:
+                        self.artifacts.delete_summary_duck(record)
+                    except AIArtifactError as cleanup_error:
+                        LOG.error(
+                            "Summary Duck artifact rollback failed record_id=%s code=%s",
+                            record_id,
+                            cleanup_error.code,
+                        )
+                raise
             finally:
                 session.close()
-        except (AgentRuntimeError, SummaryDuckValidationError) as exc:
+        except (AgentRuntimeError, SummaryDuckValidationError, AIArtifactError) as exc:
             session = self.session_maker()
             try:
                 record = session.get(AITask, record_id)
@@ -315,7 +344,8 @@ class SummaryDuckService:
                     return
                 cancelled = isinstance(exc, AgentRuntimeError) and exc.code.value == "runtime.cancelled"
                 record.status = "cancelled" if cancelled or record.cancel_requested else "failed"
-                record.error_code = getattr(getattr(exc, "code", None), "value", "result.invalid")
+                code = getattr(exc, "code", None)
+                record.error_code = getattr(code, "value", code) or "result.invalid"
                 record.error_message = str(getattr(exc, "safe_message", "AI 返回结果未通过校验"))[:500]
                 record.progress_message = record.error_message
                 record.finished_at = datetime.datetime.now()
@@ -351,12 +381,14 @@ class SummaryDuckService:
         self.submit(record_id, chapter)
 
 
-def task_items(records: Iterable[AITask]) -> List[Dict[str, Any]]:
-    return [task_dict(record) for record in records]
-
-
-def task_dict(record: AITask) -> Dict[str, Any]:
-    data = record.user_revision or record.result_data or {}
+def task_dict(record: AITask, config: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    data: Dict[str, Any] = {}
+    artifact_error = None
+    if record.status == "succeeded":
+        try:
+            data = artifact_payload(record, config)
+        except AIArtifactError as exc:
+            artifact_error = {"code": exc.code, "message": exc.safe_message}
     return {
         "id": record.id,
         "feature": record.feature,
@@ -371,7 +403,8 @@ def task_dict(record: AITask) -> Dict[str, Any]:
         "prompt_version": record.prompt_version,
         "runtime": record.runtime_name,
         "usage": record.usage or {},
-        "error": {"code": record.error_code, "message": record.error_message} if record.error_code else None,
+        "error": artifact_error
+        or ({"code": record.error_code, "message": record.error_message} if record.error_code else None),
         "created_at": record.create_time.isoformat() if record.create_time else None,
         "updated_at": record.update_time.isoformat() if record.update_time else None,
     }

--- a/webserver/settings.py
+++ b/webserver/settings.py
@@ -96,6 +96,9 @@ settings = {
     "AI_CODEX_MIN_VERSION": "0.147.0",
     "AI_CODEX_MAX_VERSION": "0.148.0",
     "AI_TASK_ROOT": "/data/books/progress",
+    # Durable AI artifacts are part of the /data/books backup boundary. The DB
+    # stores only paths relative to this books/ai root plus SHA-256 indexes.
+    "AI_ARTIFACT_ROOT": "/data/books/ai",
     "AI_HANDSHAKE_TIMEOUT_SECONDS": 10,
     "AI_FIRST_PROGRESS_TIMEOUT_SECONDS": 30,
     "AI_SILENCE_TIMEOUT_SECONDS": 45,


### PR DESCRIPTION
## Summary

- move Summary Duck's complete Q&A, citations, AI draft, and user revision into one authoritative current-version JSON artifact under `books/ai/{workspace}/summary-duck`
- keep only workspace, relative path, SHA-256, lifecycle, and lookup metadata in `ai_tasks`; migrate legacy database blobs during database migration and lazily on access
- enforce atomic replacement, path/identity/digest checks, creator/book ACL rechecks, task and book deletion cleanup, and `/data` backup/bootstrap coverage
- update the active design document and add storage, migration, tamper, cleanup, service persistence, and self-check tests

## Why

TB-52 established a unified AI artifact policy: filesystem directories are authoritative for durable artifacts, the database is an index, and application-level artifact version tables or rollback directories are not created.

## Validation

- `879 passed, 20 skipped` in the repository test container
- Ruff: 110 Python files passed and formatted
- Design checks: 111 documents passed
- `git diff --check` passed

Closes TB-53

Related: TB-52
