### PR TITLE
TB-55: move knowledge graphs to directory artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Skill 会在写入前确认目标与权限，对管理员写入、删除和批�
 推荐使用`docker-compose`，下载仓库中的配置文件[docker-compose.yml](docker-compose.yml)，然后执行命令启动即可。
 若希望修改挂载的目录或端口，请修改docker-compose.yml文件。
 
-默认配置会把 Talebook 的配置、用户数据库和书库统一保存在 `docker-compose.yml` 同目录的 `data/` 中；重新构建或替换容器不会删除这些文件。请定期备份该目录，不要把长期数据放在可能被系统清理的 `/tmp` 下。需要使用其他位置时，可在同目录的 `.env` 中设置绝对路径：
+默认配置会把 Talebook 的配置、用户数据库、书库和 `data/books/ai/` 下的 AI 产物统一保存在 `docker-compose.yml` 同目录的 `data/` 中；重新构建或替换容器不会删除这些文件。备份或迁移时必须完整处理该目录，不能只复制数据库，否则 AI 产物索引将失去对应文件。不要把长期数据放在可能被系统清理的 `/tmp` 下。需要使用其他位置时，可在同目录的 `.env` 中设置绝对路径：
 
 ```dotenv
 TALEBOOK_DATA_DIR=/path/to/talebook-data

--- a/README_EN.md
+++ b/README_EN.md
@@ -49,7 +49,7 @@ Docker is the recommended deployment method. Images are published to both [Docke
 It is recommended to use `docker-compose`, download the configuration file [docker-compose.yml](docker-compose.yml) from the repository, and then execute the command to start.
 If you want to modify the mounted directories or ports, please modify the docker-compose.yml file.
 
-By default, the Compose file keeps Talebook settings, the user database, and the library together in `data/` next to `docker-compose.yml`. Rebuilding or replacing the container does not remove those files. Back up this directory regularly, and do not keep long-lived data under `/tmp`, which the host may clean. To use another location, set an absolute path in a colocated `.env` file:
+By default, the Compose file keeps Talebook settings, the user database, the library, and AI artifacts under `data/books/ai/` together in `data/` next to `docker-compose.yml`. Back up or migrate that directory as one unit; copying only the database leaves AI artifact indexes without their files. Rebuilding or replacing the container does not remove these files. Do not keep long-lived data under `/tmp`, which the host may clean. To use another location, set an absolute path in a colocated `.env` file:
 
 ```dotenv
 TALEBOOK_DATA_DIR=/path/to/talebook-data

--- a/design/webserver/20260818-knowledge-graph-artifact-storage.active.html
+++ b/design/webserver/20260818-knowledge-graph-artifact-storage.active.html
@@ -1,0 +1,109 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="TB-55 知识图谱目录产物存储跟进方案" />
+    <link rel="icon" href="data:," />
+    <title>知识图谱改用目录产物存储 · ACTIVE</title>
+    <style>
+      :root { color-scheme: light dark; --bg:#f4f7f5; --panel:#fff; --ink:#17312d; --muted:#526762; --line:#cbd9d5; --accent:#b84d28; --soft:#fff0e9; --ok:#176b4c; --code:#132722; }
+      * { box-sizing: border-box; }
+      body { margin:0; color:var(--ink); background:linear-gradient(145deg,#edf5f1,var(--bg)); font:15px/1.65 system-ui,-apple-system,"PingFang SC",sans-serif; }
+      main { width:min(1040px,calc(100vw - 28px)); margin:24px auto 56px; }
+      header,section { margin-bottom:16px; padding:24px 28px; border:1px solid var(--line); border-radius:18px; background:var(--panel); box-shadow:0 10px 28px rgba(23,49,45,.07); }
+      h1 { margin:0 0 8px; font-size:clamp(30px,5vw,48px); line-height:1.1; }
+      h2 { margin:0 0 12px; font-size:22px; }
+      h3 { margin:18px 0 8px; font-size:17px; }
+      p { margin:8px 0; }
+      ul,ol { margin:8px 0 0 22px; padding:0; }
+      li + li { margin-top:5px; }
+      code { padding:.12em .35em; border-radius:5px; color:#fff; background:var(--code); overflow-wrap:anywhere; }
+      pre { overflow:auto; padding:16px; border-radius:13px; color:#eef8f4; background:var(--code); }
+      pre code { padding:0; background:transparent; }
+      .meta { display:flex; flex-wrap:wrap; gap:8px; margin-top:18px; }
+      .meta span { padding:5px 10px; border-radius:999px; background:#e7efec; font-size:12px; font-weight:700; }
+      .meta .wip { color:#8e391e; background:var(--soft); }
+      .meta .active { color:var(--ok); background:#e5f6ee; }
+      .quote { padding:14px 16px; border-left:4px solid var(--accent); background:var(--soft); }
+      .grid { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:14px; }
+      .box { padding:16px; border:1px solid var(--line); border-radius:13px; }
+      .flow { display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); gap:10px; }
+      .flow div { padding:14px; border:1px solid var(--line); border-radius:12px; background:#f8fbfa; }
+      .flow b { display:block; color:var(--accent); }
+      table { width:100%; border-collapse:collapse; }
+      th,td { padding:10px; border:1px solid var(--line); text-align:left; vertical-align:top; }
+      th { background:#edf3f1; }
+      .pending { color:#9a5c09; font-weight:800; }
+      .verified { color:var(--ok); font-weight:800; }
+      @media (max-width:720px) { header,section { padding:20px; } .grid,.flow { grid-template-columns:1fr; } }
+      @media (prefers-reduced-motion:reduce) { * { scroll-behavior:auto !important; } }
+      @media (prefers-color-scheme:dark) { :root { --bg:#0d1916; --panel:#14231f; --ink:#ecf7f3; --muted:#b8c9c4; --line:#36514a; --soft:#3b211b; --code:#09120f; } .meta span,.flow div,th { background:#20332e; } }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>知识图谱改用目录产物存储</h1>
+        <p>将已合并的 TB-55 完整图谱与恢复检查点移出数据库，以 <code>books/ai/{workspace}/knowledge-graphs</code> 下的当前文件作为唯一内容来源，同时保持现有 API、ACL、重试和引用回跳行为。</p>
+        <div class="meta"><span class="active">状态：ACTIVE</span><span>创建日期：2026-08-18</span><span>所属模块：webserver</span><span>需求来源：TB-52 / TB-55</span><span>影响：存储、迁移、删除、备份</span></div>
+      </header>
+
+      <section>
+        <h2>1. 原始诉求</h2>
+        <p class="quote">“实体产物优先保存在目录中……统一目录结构：<code>books/ai/{user-workspace}/{feature}/...</code>；数据库仅承担管理与检索；写入采用临时文件/目录校验后原子替换；删除业务对象时同步清理目录；Talebook 的备份与迁移必须同时覆盖数据库和 <code>books/ai</code>。”</p>
+        <p>PR #994 已把知识图谱完整结果和分章检查点写入 <code>ai_tasks.result_data</code> / <code>ai_tasks.ai_draft</code>。该实现已合并至 <code>feat/ai_1.0</code>，因此本工作以独立跟进 PR 修正持久化契约，并兼容已生成的旧记录。</p>
+      </section>
+
+      <section>
+        <h2>2. 目标与边界</h2>
+        <div class="grid">
+          <div class="box"><h3>目标</h3><ul><li>正式图谱和恢复检查点只保存在目录文件中，数据库仅留范围、相对路径、SHA-256、状态和统计索引。</li><li>每次读取仍先校验创建者、原书 ACL 与文件版本，再读取并校验文件摘要。</li><li>写入同目录临时文件，完成 JSON 校验和落盘后原子替换；任务、书籍或用户删除时清理对应目录。</li><li>旧数据库内联结果可安全迁移，迁移成功后移除数据库正文。</li></ul></div>
+          <div class="box"><h3>非目标</h3><ul><li>不新增版本表、版本列表、回滚 UI 或 <code>v{version}</code> 目录。</li><li>不改变图谱提取 schema、前端画布、引用 locator 或 AgentRuntime。</li><li>不跨书聚合图谱，不提供公开文件 URL。</li><li>不把运行日志、提示词或 EPUB 正文写入产物目录。</li></ul></div>
+        </div>
+      </section>
+
+      <section>
+        <h2>3. 数据布局与提交协议</h2>
+        <pre><code>/data/books/ai/
+└── {opaque-workspace}/
+    └── knowledge-graphs/
+        └── {task-uuid}/
+            ├── checkpoint.json  # 运行中当前检查点，成功后删除
+            └── graph.json       # 当前正式成果，无版本子目录</code></pre>
+        <p>数据库保存相对于 <code>/data/books/ai</code> 的路径，且路径必须由服务端构造并限制在同一 workspace、feature 与 task 目录内。每个索引同时保存 SHA-256 与字节数；读取时摘要不一致、越界路径、缺失文件或非法 JSON 均按“产物不可用”失败关闭。</p>
+        <div class="flow" aria-label="原子发布流程"><div><b>1 校验</b>结构化模型输出与每条引用先通过现有 schema/locator 校验。</div><div><b>2 暂存</b>在目标目录创建仅当前进程可写的同目录临时文件。</div><div><b>3 发布</b>写入、刷新、解析复核并计算 SHA 后使用 <code>os.replace</code> 原子替换。</div><div><b>4 索引</b>最后提交数据库相对路径和摘要；只有该终态才对 API 可见。</div></div>
+      </section>
+
+      <section>
+        <h2>4. 权限、迁移与生命周期</h2>
+        <table>
+          <thead><tr><th>场景</th><th>处理</th><th>不变量</th></tr></thead>
+          <tbody>
+            <tr><td>列表、详情、导出</td><td>先按 creator 查询，再复核书 ACL 和 book_version，最后按受限相对路径读取并核验 SHA。</td><td>知道任务 ID 或路径不能绕过 ACL；不返回物理绝对路径。</td></tr>
+            <tr><td>崩溃恢复</td><td>从 <code>checkpoint.json</code> 读取已校验分章结果；数据库只保存范围与检查点索引。</td><td>流式文本和未校验段不落库、不发布。</td></tr>
+            <tr><td>旧记录迁移</td><td>在已授权访问或恢复前，将旧内联 graph/segments 原子写文件；文件和摘要成功后再清空内联正文。</td><td>任何写入失败都保留旧记录，不做有损半迁移。</td></tr>
+            <tr><td>删除</td><td>删除任务、书籍或用户时按已验证的 task 目录递归清理，再删除数据库索引。</td><td>清理函数拒绝根目录、workspace 目录、越界路径与符号链接目标。</td></tr>
+            <tr><td>备份/数据迁移</td><td>默认产物根位于持久化的 <code>/data/books/ai</code>；启动自检创建并验证原子写，文档明确与整个 data 目录一起备份/迁移。</td><td>数据库与目录必须视为同一备份单元。</td></tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section>
+        <h2>5. 风险与降级</h2>
+        <ul><li>数据库提交失败可能留下未索引文件；task UUID 目录隔离使其不会被其他用户读取，后续同任务写入会原子覆盖，删除路径可回收。</li><li>跨设备只迁移数据库会导致摘要索引指向缺失文件；API 将失败关闭并提示重新生成，备份文档与自检强调必须同步迁移 <code>books/ai</code>。</li><li>旧内联数据可能很大；迁移按单任务进行，不把所有图谱一次性载入内存，且只在 ACL 通过后的任务访问或恢复路径触发。</li><li>本次纯后端存储修正不改变 UI DOM、样式、交互或文案，因此 follow-up 不重复执行大型界面审查；保留 PR #994 已完成的 full interface-review 结论。</li></ul>
+      </section>
+
+      <section>
+        <h2>6. 测试计划与结果</h2>
+        <p class="verified">验证通过</p>
+        <ul><li><code>docker run … talebook/test pytest tests/test_runtime_identity_config.py tests/test_knowledge_graph.py tests/test_self_check.py tests/test_main.py::TestBook::test_delete_cleans_knowledge_graph_artifact_directory tests/test_admin.py::TestAdminUserArtifactCleanup -q</code>：45 passed；覆盖路径与摘要校验、并发安全的稳定 workspace、原子替换、旧记录迁移、ACL 顺序、导出、三类删除及持久化目录自检。</li><li><code>docker run … talebook/test pytest tests -q</code>：881 passed、20 skipped、25 个既有 warning。第一次全量运行发现启动脚本契约测试仍只断言 library/settings 两个目录（880 passed、1 failed）；更新为同时覆盖 AI 目录后重新全量通过。</li><li><code>make lint-py-fix</code>：Ruff 自动修正与格式化通过；<code>make lint-py</code>：110 个后端文件检查及格式 diff 通过。</li><li><code>make check-design</code>：112 份设计文档全部通过路径、状态、HTML 结构与单文件资源校验。</li><li>本次没有修改前端资源、HTTP 响应结构中的图谱字段、交互、样式或文案；因此按项目规则豁免 full interface-review，沿用 PR #994 对现有画布的已通过审查。</li></ul>
+      </section>
+
+      <section>
+        <h2>7. 决策记录</h2>
+        <ul><li>feature 目录使用产品固定 slug <code>knowledge-graphs</code>，HTTP/API feature key 继续使用 <code>knowledge_graph</code>。</li><li>workspace 使用由稳定用户主键和创建时间生成、并持久化到用户 <code>extra</code> 的 UUIDv5 不透明 ID；不使用用户名、邮箱或可变展示名，同一用户首次并发创建也得到同一目录。</li><li>不新增图谱专用版本模型；task 本身是管理索引，<code>graph.json</code> 是该 task 当前且唯一的正式成果。</li><li>实现与上述契约一致；验证完成后仅保留本 ACTIVE 文件，不保留中间 WIP。</li></ul>
+      </section>
+    </main>
+  </body>
+</html>

--- a/docker/start-dev.sh
+++ b/docker/start-dev.sh
@@ -40,7 +40,7 @@ find . \( -path ./library -o -name '*.pyc' \) -prune -o -type f -print | while r
 done
 
 
-mkdir -p /root/.npm /run/talebook /data/books/ssl
+mkdir -p /root/.npm /run/talebook /data/books/ssl /data/books/ai
 
 # 设置PUID/GUID权限
 permission_file=/data/.permission
@@ -52,7 +52,7 @@ if [ "x$permission" != "x$PUID:$PGID" ]; then
     echo "$PUID:$PGID" > $permission_file
 else
     # settings 目录体积很小；标记命中时仍定向修复，避免宿主目录重建或预置文件复制后属主失真。
-    chown -R talebook:talebook /data/books/settings || exit 1
+    chown -R talebook:talebook /data/books/settings /data/books/ai || exit 1
 fi
 
 # 设置系统文件的权限
@@ -60,6 +60,7 @@ fi
 chown talebook:talebook /var/www/talebook/app
 chown -R talebook:talebook \
   /run/talebook \
+  /data/books/ai \
   /data/books/ssl \
   /data/log/ \
   /var/lib/nginx \
@@ -97,7 +98,7 @@ check_atomic_write() {
     ' talebook-write-check "$directory"
 }
 
-for directory in /data/books/library /data/books/settings; do
+for directory in /data/books/library /data/books/settings /data/books/ai; do
     if ! check_atomic_write "$directory"; then
         echo "目录权限异常，无法以 PUID/PGID 原子写入 $directory"
         exit 1

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -40,7 +40,7 @@ find . \( -path ./library -o -name '*.pyc' \) -prune -o -type f -print | while r
 done
 
 
-mkdir -p /root/.npm /run/talebook /data/books/ssl
+mkdir -p /root/.npm /run/talebook /data/books/ssl /data/books/ai
 
 # 设置系统文件的权限（数量较少，且 nginx/诊断页在自检完成前就需要可用，必须先于 supervisord 启动前就绪）
 mkdir -p /data/log/nginx /var/www/talebook/status
@@ -48,6 +48,7 @@ mkdir -p /data/log/nginx /var/www/talebook/status
 chown talebook:talebook /var/www/talebook/app
 chown -R talebook:talebook \
   /run/talebook \
+  /data/books/ai \
   /data/books/ssl \
   /data/log/ \
   /var/lib/nginx \

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -6,6 +6,7 @@ import json
 import os
 import tempfile
 import urllib.parse
+from pathlib import Path
 from unittest import mock
 
 from tests.test_main import (
@@ -693,6 +694,69 @@ class TestAdminUsersBatch(TestWithAdminUser):
         finally:
             user.admin = original_admin
             session.commit()
+
+
+class TestAdminUserArtifactCleanup(TestWithAdminUser):
+    def test_delete_user_removes_ai_workspace_and_task_indexes(self):
+        from webserver import models
+        from webserver.services.ai_artifacts import AIArtifactStorage
+
+        username = "artifactcleanup"
+        temporary = tempfile.TemporaryDirectory()
+        session = get_db()
+        session.query(models.Reader).filter(models.Reader.username == username).delete(synchronize_session=False)
+        session.commit()
+        user = models.Reader(
+            username=username,
+            name=username,
+            email=f"{username}@example.com",
+            admin=False,
+            active=True,
+            create_time=datetime.datetime.now(),
+            update_time=datetime.datetime.now(),
+            access_time=datetime.datetime.now(),
+            extra={"kindle_email": "", "ai_workspace_id": "c" * 32},
+        )
+        user.set_secure_password("Passw0rd!")
+        session.add(user)
+        session.commit()
+        task_id = "cccccccc-cccc-cccc-cccc-cccccccccccc"
+        task = models.AITask(
+            id=task_id,
+            request_key="c" * 64,
+            feature="knowledge_graph",
+            creator_id=user.id,
+            book_id=BID_EPUB,
+            book_version="fixture",
+            chapter_href="graph:fixture",
+            chapter_title="fixture",
+            chapter_text_hash="d" * 64,
+            chapter_length=1,
+            status="succeeded",
+        )
+        session.add(task)
+        session.commit()
+        storage = AIArtifactStorage({"AI_ARTIFACT_ROOT": temporary.name})
+        metadata = storage.write_json("c" * 32, "knowledge-graphs", task_id, "graph.json", {"graph": {}})
+        workspace_path = Path(temporary.name, metadata["relative_path"]).parents[2]
+        self.assertTrue(workspace_path.is_dir())
+
+        try:
+            with mock.patch.dict("webserver.handlers.admin.CONF", {"AI_ARTIFACT_ROOT": temporary.name}, clear=False):
+                response = self.json(
+                    "/api/admin/users",
+                    method="POST",
+                    body=json.dumps({"id": user.id, "delete": username}),
+                )
+            self.assertEqual(response["err"], "ok", response)
+            self.assertFalse(workspace_path.exists())
+            self.assertIsNone(get_db().get(models.AITask, task_id))
+        finally:
+            session = get_db()
+            session.query(models.AITask).filter(models.AITask.id == task_id).delete(synchronize_session=False)
+            session.query(models.Reader).filter(models.Reader.username == username).delete(synchronize_session=False)
+            session.commit()
+            temporary.cleanup()
 
 
 class TestAdminDefaultUserPermission(TestWithAdminUser):

--- a/tests/test_knowledge_graph.py
+++ b/tests/test_knowledge_graph.py
@@ -9,13 +9,16 @@ from unittest import mock
 from tests import test_main
 from webserver import models
 from webserver.services.agent_runtime import RuntimeResult
+from webserver.services.ai_artifacts import AIArtifactError, AIArtifactStorage, ensure_workspace_id
 from webserver.services.knowledge_graph import (
+    ARTIFACT_FEATURE_SLUG,
     FEATURE_KEY,
     PROMPT_VERSION,
     SCHEMA_VERSION,
     KnowledgeGraphService,
     KnowledgeGraphValidationError,
     extract_epub_chapters,
+    load_graph_artifact,
     merge_segments,
     scope_fingerprint,
     validate_segment,
@@ -74,6 +77,104 @@ def valid_segment(chapter, confidence=0.9):
     }
 
 
+class AIArtifactStorageTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.storage = AIArtifactStorage({"AI_ARTIFACT_ROOT": self.temporary.name})
+        self.workspace = "a" * 32
+        self.task_id = "11111111-1111-1111-1111-111111111111"
+
+    def test_atomic_json_replace_and_sha_verified_read(self):
+        first = self.storage.write_json(
+            self.workspace,
+            ARTIFACT_FEATURE_SLUG,
+            self.task_id,
+            "graph.json",
+            {"value": 1},
+        )
+        second = self.storage.write_json(
+            self.workspace,
+            ARTIFACT_FEATURE_SLUG,
+            self.task_id,
+            "graph.json",
+            {"value": 2},
+        )
+        self.assertNotEqual(first["sha256"], second["sha256"])
+        self.assertEqual(
+            self.storage.read_json(
+                second,
+                self.workspace,
+                ARTIFACT_FEATURE_SLUG,
+                self.task_id,
+                {"graph.json"},
+            ),
+            {"value": 2},
+        )
+        directory = Path(self.temporary.name, self.workspace, ARTIFACT_FEATURE_SLUG, self.task_id)
+        self.assertEqual([path.name for path in directory.iterdir()], ["graph.json"])
+
+    def test_workspace_id_is_opaque_stable_and_persisted_in_user_record(self):
+        session = test_main.get_db()
+        reader = session.get(models.Reader, 1)
+        original = dict(reader.extra or {})
+        try:
+            reader.extra = {key: value for key, value in original.items() if key != "ai_workspace_id"}
+            first = ensure_workspace_id(session, reader.id)
+            session.commit()
+            second = ensure_workspace_id(session, reader.id)
+            reader.extra = {key: value for key, value in original.items() if key != "ai_workspace_id"}
+            independently_generated = ensure_workspace_id(session, reader.id)
+            self.assertRegex(first, r"^[0-9a-f]{32}$")
+            self.assertEqual(first, second)
+            self.assertEqual(first, independently_generated)
+            self.assertNotEqual(first, str(reader.id))
+            self.assertNotIn(str(reader.username), first)
+        finally:
+            reader.extra = original
+            session.commit()
+
+    def test_rejects_cross_workspace_path_and_digest_tampering(self):
+        metadata = self.storage.write_json(
+            self.workspace,
+            ARTIFACT_FEATURE_SLUG,
+            self.task_id,
+            "graph.json",
+            {"private": True},
+        )
+        crossed = dict(metadata)
+        crossed["relative_path"] = crossed["relative_path"].replace(self.workspace, "b" * 32, 1)
+        with self.assertRaises(AIArtifactError):
+            self.storage.read_json(
+                crossed,
+                self.workspace,
+                ARTIFACT_FEATURE_SLUG,
+                self.task_id,
+                {"graph.json"},
+            )
+        path = Path(self.temporary.name, metadata["relative_path"])
+        path.write_text('{"private":false}', encoding="utf-8")
+        with self.assertRaisesRegex(AIArtifactError, "摘要"):
+            self.storage.read_json(
+                metadata,
+                self.workspace,
+                ARTIFACT_FEATURE_SLUG,
+                self.task_id,
+                {"graph.json"},
+            )
+
+    def test_deletes_only_the_exact_task_directory(self):
+        metadata = self.storage.write_json(
+            self.workspace,
+            ARTIFACT_FEATURE_SLUG,
+            self.task_id,
+            "graph.json",
+            {"value": 1},
+        )
+        task_dir = Path(self.temporary.name, metadata["relative_path"]).parent
+        self.storage.delete_task(self.workspace, ARTIFACT_FEATURE_SLUG, self.task_id)
+        self.assertFalse(task_dir.exists())
+        self.assertTrue(Path(self.temporary.name).exists())
 class KnowledgeGraphValidationTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -185,14 +286,18 @@ class _FakeGraphRuntime:
 
 class KnowledgeGraphServiceTest(unittest.TestCase):
     def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
         session = test_main.get_db()
+        self.reader_extra = dict(session.get(models.Reader, 1).extra or {})
         session.query(models.AITask).delete()
         session.commit()
 
     def tearDown(self):
         session = test_main.get_db()
         session.query(models.AITask).delete()
+        session.get(models.Reader, 1).extra = self.reader_extra
         session.commit()
+        self.temporary.cleanup()
 
     def test_pipeline_checkpoints_structured_segments_then_publishes_graph(self):
         chapter = extract_epub_chapters("tests/cases/old.epub")[1]
@@ -215,7 +320,7 @@ class KnowledgeGraphServiceTest(unittest.TestCase):
             chapter_text_hash=scope_fingerprint([chapter]),
             chapter_length=len(chapter["text"]),
             status="queued",
-            ai_draft={"scope": scope, "segments": {}},
+            ai_draft={"scope": scope, "completed_segments": 0},
             schema_version=SCHEMA_VERSION,
             prompt_version=PROMPT_VERSION,
         )
@@ -227,31 +332,50 @@ class KnowledgeGraphServiceTest(unittest.TestCase):
         service._configured = False
         service._threads = {}
         service._threads_lock = threading.Lock()
-        service.setup(test_main._app.settings["SessionMaker"], {}, runtime=_FakeGraphRuntime())
+        service.setup(
+            test_main._app.settings["SessionMaker"],
+            {"AI_ARTIFACT_ROOT": self.temporary.name},
+            runtime=_FakeGraphRuntime(),
+        )
         service._run(record.id, "tests/cases/old.epub", [chapter["href"]])
 
         finished = test_main.get_db().get(models.AITask, record.id)
         self.assertEqual(finished.status, "succeeded")
-        self.assertIn(chapter["href"], finished.ai_draft["segments"])
-        self.assertEqual(len(finished.result_data["graph"]["nodes"]), 2)
-        self.assertEqual(len(finished.result_data["graph"]["relations"]), 1)
+        self.assertNotIn("segments", finished.ai_draft)
+        self.assertNotIn("graph", finished.result_data)
+        payload = load_graph_artifact(finished, AIArtifactStorage({"AI_ARTIFACT_ROOT": self.temporary.name}))
+        self.assertEqual(len(payload["graph"]["nodes"]), 2)
+        self.assertEqual(len(payload["graph"]["relations"]), 1)
+        artifact_path = Path(self.temporary.name, finished.result_data["artifact"]["relative_path"])
+        self.assertTrue(artifact_path.is_file())
+        self.assertFalse((artifact_path.parent / "checkpoint.json").exists())
         self.assertEqual(finished.usage["input_tokens"], 10)
 
 
 class KnowledgeGraphAPITest(test_main.TestWithUserLogin):
     def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.config_patch = mock.patch.dict(
+            "webserver.handlers.ai.CONF", {"AI_ARTIFACT_ROOT": self.temporary.name}, clear=False
+        )
+        self.config_patch.start()
         super().setUp()
         session = test_main.get_db()
+        self.reader_extra = dict(session.get(models.Reader, 1).extra or {})
         session.query(models.AITask).delete()
         session.commit()
         book = test_main._app.settings["legacy"].get_data_as_dict(ids=[test_main.BID_EPUB])[0]
+        self.epub_path = book["fmt_epub"]
         self.chapter_href = extract_epub_chapters(book["fmt_epub"])[0]["href"]
 
     def tearDown(self):
         session = test_main.get_db()
         session.query(models.AITask).delete()
+        session.get(models.Reader, 1).extra = self.reader_extra
         session.commit()
         super().tearDown()
+        self.config_patch.stop()
+        self.temporary.cleanup()
 
     def _post(self, body):
         return self.json(
@@ -313,6 +437,63 @@ class KnowledgeGraphAPITest(test_main.TestWithUserLogin):
         self.assertEqual(response["err"], "ok")
         submit.assert_called_once()
         self.assertEqual(submit.call_args.args[2], [self.chapter_href])
+
+    def test_legacy_inline_result_is_migrated_then_read_exported_and_deleted_from_files(self):
+        with mock.patch.object(KnowledgeGraphService, "submit"):
+            task = self._post({"scope": "chapter", "chapter_href": self.chapter_href})["task"]
+        chapter = extract_epub_chapters(self.epub_path, [self.chapter_href])[0]
+        segment = validate_segment(valid_segment(chapter), chapter)
+        result = merge_segments([segment])
+        session = test_main.get_db()
+        record = session.get(models.AITask, task["id"])
+        scope = dict(record.ai_draft["scope"])
+        result["scope"] = scope
+        record.status = "succeeded"
+        record.result_data = result
+        record.ai_draft = {"scope": scope, "segments": {chapter["href"]: segment}}
+        session.commit()
+
+        detail = self.json(f"/api/ai/{FEATURE_KEY}/tasks/{record.id}")
+        self.assertEqual(detail["err"], "ok", detail)
+        self.assertEqual(len(detail["task"]["graph"]["nodes"]), 2)
+
+        migrated = test_main.get_db().get(models.AITask, record.id)
+        self.assertNotIn("graph", migrated.result_data)
+        self.assertNotIn("segments", migrated.ai_draft)
+        artifact_path = Path(self.temporary.name, migrated.result_data["artifact"]["relative_path"])
+        self.assertTrue(artifact_path.is_file())
+
+        exported = self.fetch(f"/api/ai/{FEATURE_KEY}/tasks/{record.id}/export")
+        self.assertEqual(exported.code, 200)
+        self.assertEqual(len(json.loads(exported.body)["graph"]["nodes"]), 2)
+
+        deleted = self.json(f"/api/ai/{FEATURE_KEY}/tasks/{record.id}", method="DELETE")
+        self.assertEqual(deleted["err"], "ok")
+        self.assertFalse(artifact_path.parent.exists())
+
+    def test_acl_fails_before_a_corrupt_artifact_is_read(self):
+        with mock.patch.object(KnowledgeGraphService, "submit"):
+            task = self._post({"scope": "chapter", "chapter_href": self.chapter_href})["task"]
+        chapter = extract_epub_chapters(self.epub_path, [self.chapter_href])[0]
+        result = merge_segments([validate_segment(valid_segment(chapter), chapter)])
+        session = test_main.get_db()
+        record = session.get(models.AITask, task["id"])
+        result["scope"] = dict(record.ai_draft["scope"])
+        record.status = "succeeded"
+        record.result_data = result
+        session.commit()
+        self.json(f"/api/ai/{FEATURE_KEY}/tasks/{record.id}")
+
+        migrated = test_main.get_db().get(models.AITask, record.id)
+        artifact_path = Path(self.temporary.name, migrated.result_data["artifact"]["relative_path"])
+        artifact_path.write_text("{}", encoding="utf-8")
+        with mock.patch("webserver.handlers.ai._AITaskBase.can_view_book", return_value=False):
+            hidden = self.json(f"/api/ai/{FEATURE_KEY}/tasks/{record.id}")
+        self.assertEqual(hidden["err"], "ai.not_found")
+
+        unavailable = self.json(f"/api/ai/{FEATURE_KEY}/tasks/{record.id}")
+        self.assertEqual(unavailable["err"], "ok")
+        self.assertEqual(unavailable["task"]["error"]["code"], "artifact.unavailable")
 
 
 class KnowledgeGraphStaticContractTest(unittest.TestCase):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -9,6 +9,7 @@ import logging
 import os
 import shutil
 import sys
+import tempfile
 import time
 import unittest
 import urllib
@@ -654,6 +655,50 @@ class TestBook(TestWithUserLogin):
                 d = self.json("/api/book/1/delete", method="POST", body="")
                 self.assertEqual(d["err"], "ok")
                 self.assertEqual(m.call_count, 2)
+
+    def test_delete_cleans_knowledge_graph_artifact_directory(self):
+        from webserver.services.ai_artifacts import AIArtifactStorage
+
+        task_id = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+        temporary = tempfile.TemporaryDirectory()
+        session = get_db()
+        reader = session.get(models.Reader, 1)
+        original_extra = dict(reader.extra or {})
+        reader.extra = {**original_extra, "ai_workspace_id": "b" * 32}
+        storage = AIArtifactStorage({"AI_ARTIFACT_ROOT": temporary.name})
+        metadata = storage.write_json("b" * 32, "knowledge-graphs", task_id, "graph.json", {"graph": {}})
+        task = models.AITask(
+            id=task_id,
+            request_key="b" * 64,
+            feature="knowledge_graph",
+            creator_id=1,
+            book_id=1,
+            book_version="fixture",
+            chapter_href="graph:fixture",
+            chapter_title="fixture",
+            chapter_text_hash="b" * 64,
+            chapter_length=1,
+            status="succeeded",
+            result_data={"workspace": "b" * 32, "artifact": metadata},
+        )
+        session.add(task)
+        session.commit()
+        task_directory = os.path.dirname(os.path.join(temporary.name, metadata["relative_path"]))
+        try:
+            with mock.patch.dict(
+                "webserver.handlers.book.CONF", {"AI_ARTIFACT_ROOT": temporary.name}, clear=False
+            ), mock.patch.object(_app.settings["legacy"], "delete_book", return_value="Yo"):
+                with mock_permission():
+                    response = self.json("/api/book/1/delete", method="POST", body="")
+            self.assertEqual(response["err"], "ok", response)
+            self.assertFalse(os.path.exists(task_directory))
+            self.assertIsNone(get_db().get(models.AITask, task_id))
+        finally:
+            session = get_db()
+            session.query(models.AITask).filter(models.AITask.id == task_id).delete(synchronize_session=False)
+            session.get(models.Reader, 1).extra = original_extra
+            session.commit()
+            temporary.cleanup()
 
     def test_read(self):
         with mock.patch("webserver.services.convert.ConvertService.convert_and_save", return_value="Yo"):

--- a/tests/test_runtime_identity_config.py
+++ b/tests/test_runtime_identity_config.py
@@ -56,11 +56,11 @@ def test_start_scripts_grant_atomic_nuxt_config_parent_without_recursive_app_cho
         assert "  /var/www/talebook/app \\" not in recursive_chown
 
 
-def test_ssr_start_repairs_settings_and_probes_both_mounts_as_application_user():
+def test_ssr_start_repairs_and_probes_all_persistent_writable_mounts_as_application_user():
     script = read("docker/start-dev.sh")
 
-    assert "chown -R talebook:talebook /data/books/settings || exit 1" in script
+    assert "chown -R talebook:talebook /data/books/settings /data/books/ai || exit 1" in script
     assert "gosu talebook:talebook sh -c" in script
-    assert "for directory in /data/books/library /data/books/settings" in script
+    assert "for directory in /data/books/library /data/books/settings /data/books/ai" in script
     assert "mktemp" in script
     assert 'mv "$tmp" "$moved"' in script

--- a/tests/test_self_check.py
+++ b/tests/test_self_check.py
@@ -53,12 +53,13 @@ class TestSelfCheckSteps(unittest.TestCase):
         self.assertIsNone(code)
         with open(os.path.join(self.data_dir, ".permission")) as f:
             self.assertEqual(f.read().strip(), "1000:1000")
-        chown_call, library_probe, settings_probe = m_run.call_args_list
+        chown_call, library_probe, settings_probe, ai_probe = m_run.call_args_list
         self.assertEqual(chown_call.args[0][:2], ["chown", "-R"])
         self.assertEqual(library_probe.args[0][0], "gosu")
         self.assertEqual(library_probe.args[0][-1], os.path.join(self.data_dir, "books", "library"))
         self.assertEqual(settings_probe.args[0][0], "gosu")
         self.assertEqual(settings_probe.args[0][-1], os.path.join(self.data_dir, "books", "settings"))
+        self.assertEqual(ai_probe.args[0][-1], os.path.join(self.data_dir, "books", "ai"))
 
     @mock.patch("webserver.self_check.run")
     def test_check_permission_repairs_settings_when_identity_unchanged(self, m_run):
@@ -70,13 +71,21 @@ class TestSelfCheckSteps(unittest.TestCase):
 
         self.assertTrue(ok)
         self.assertIsNone(code)
-        self.assertEqual(m_run.call_count, 3)
-        settings_chown, library_probe, settings_probe = m_run.call_args_list
+        self.assertEqual(m_run.call_count, 4)
+        settings_chown, library_probe, settings_probe, ai_probe = m_run.call_args_list
         self.assertEqual(
-            settings_chown.args[0], ["chown", "-R", "talebook:talebook", os.path.join(self.data_dir, "books", "settings")]
+            settings_chown.args[0],
+            [
+                "chown",
+                "-R",
+                "talebook:talebook",
+                os.path.join(self.data_dir, "books", "settings"),
+                os.path.join(self.data_dir, "books", "ai"),
+            ],
         )
         self.assertEqual(library_probe.args[0][-1], os.path.join(self.data_dir, "books", "library"))
         self.assertEqual(settings_probe.args[0][-1], os.path.join(self.data_dir, "books", "settings"))
+        self.assertEqual(ai_probe.args[0][-1], os.path.join(self.data_dir, "books", "ai"))
 
     @mock.patch("webserver.self_check.run")
     def test_check_permission_chown_failure(self, m_run):
@@ -103,11 +112,28 @@ class TestSelfCheckSteps(unittest.TestCase):
 
         self.assertFalse(ok)
         self.assertEqual(code, "permission_denied")
-        m_run.assert_called_once_with(["chown", "-R", "talebook:talebook", os.path.join(self.data_dir, "books", "settings")])
+        m_run.assert_called_once_with(
+            [
+                "chown",
+                "-R",
+                "talebook:talebook",
+                os.path.join(self.data_dir, "books", "settings"),
+                os.path.join(self.data_dir, "books", "ai"),
+            ]
+        )
 
     @mock.patch("webserver.self_check.run")
     def test_check_permission_settings_atomic_write_failure(self, m_run):
         m_run.side_effect = [True, True, False]
+
+        ok, code = self_check.check_permission()
+
+        self.assertFalse(ok)
+        self.assertEqual(code, "permission_denied")
+
+    @mock.patch("webserver.self_check.run")
+    def test_check_permission_ai_artifact_atomic_write_failure(self, m_run):
+        m_run.side_effect = [True, True, True, False]
 
         ok, code = self_check.check_permission()
 

--- a/webserver/handlers/admin.py
+++ b/webserver/handlers/admin.py
@@ -18,7 +18,8 @@ from webserver.base.trash_manager import TrashManager
 from webserver.handlers.admin_opds_sources import AdminOpdsSources
 from webserver.handlers.base import BaseHandler, auth, is_admin, js
 from webserver.i18n import _
-from webserver.models import Item, Reader, ScanFile
+from webserver.models import AITask, Item, Reader, ScanFile
+from webserver.services.ai_artifacts import AIArtifactError, AIArtifactStorage, workspace_id_from_reader
 from webserver.services.autofill import AutoFillService
 from webserver.services.batch_convert import BatchConvertService
 from webserver.services.external_index import delete_external_index_book_record, is_external_index_book
@@ -216,6 +217,14 @@ class AdminUsers(BaseHandler):
             if self.user_id() == user.id:
                 return {"err": "params.user.invalid", "msg": _("不允许删除自己")}
 
+            workspace = workspace_id_from_reader(user)
+            if workspace:
+                try:
+                    AIArtifactStorage(CONF).delete_workspace(workspace)
+                except AIArtifactError:
+                    logging.exception("failed to clean AI workspace for reader_id=%s", user.id)
+                    return {"err": "ai.artifact_cleanup_failed", "msg": _("AI 产物清理失败，请重试")}
+            self.session.query(AITask).filter(AITask.creator_id == user.id).delete()
             self.session.query(Reader).filter(Reader.id == user.id).delete()
             self.session.commit()
             return {"err": "ok", "msg": _("删除成功")}

--- a/webserver/handlers/ai.py
+++ b/webserver/handlers/ai.py
@@ -12,6 +12,7 @@ from sqlalchemy.exc import IntegrityError
 from webserver import loader
 from webserver.handlers.base import BaseHandler, auth, js
 from webserver.models import AITask
+from webserver.services.ai_artifacts import AIArtifactError, AIArtifactStorage, ensure_workspace_id
 from webserver.services.knowledge_graph import (
     FEATURE_KEY as KNOWLEDGE_GRAPH_FEATURE_KEY,
 )
@@ -24,7 +25,10 @@ from webserver.services.knowledge_graph import (
 from webserver.services.knowledge_graph import (
     KnowledgeGraphService,
     KnowledgeGraphValidationError,
+    cleanup_record_artifacts,
     extract_epub_chapters,
+    load_graph_artifact,
+    migrate_legacy_artifacts,
     scope_fingerprint,
 )
 from webserver.services.knowledge_graph import (
@@ -229,7 +233,10 @@ class KnowledgeGraphFeature:
     """Grounded single-book graph behavior on the shared AI task surface."""
 
     key = KNOWLEDGE_GRAPH_FEATURE_KEY
-    task_dict = staticmethod(knowledge_graph_task_dict)
+
+    @staticmethod
+    def task_dict(record):
+        return knowledge_graph_task_dict(record, AIArtifactStorage(CONF))
 
     @staticmethod
     def enabled():
@@ -250,6 +257,12 @@ class KnowledgeGraphFeature:
             return False, {"err": "ai.not_found", "msg": "AI 结果不存在"}
         if _book_version(book) != record.book_version:
             return False, {"err": "ai.book_version_changed", "msg": "书籍版本已变化，请重新生成"}
+        try:
+            if migrate_legacy_artifacts(handler.session, record, AIArtifactStorage(CONF)):
+                handler.session.commit()
+        except AIArtifactError:
+            handler.session.rollback()
+            return False, {"err": "ai.artifact_unavailable", "msg": "知识图谱产物不可用，请重新生成"}
         if record.status in {"queued", "running"}:
             scope = (record.ai_draft or {}).get("scope") or {}
             hrefs = scope.get("chapter_hrefs") or []
@@ -279,6 +292,16 @@ class KnowledgeGraphFeature:
             .order_by(AITask.create_time.desc())
             .all()
         )
+        try:
+            changed = False
+            storage = AIArtifactStorage(CONF)
+            for record in records:
+                changed = migrate_legacy_artifacts(handler.session, record, storage) or changed
+            if changed:
+                handler.session.commit()
+        except AIArtifactError:
+            handler.session.rollback()
+            return {"err": "ai.artifact_unavailable", "msg": "知识图谱产物不可用，请重新生成"}
         return {"err": "ok", "tasks": [cls.task_dict(record) for record in records]}
 
     @staticmethod
@@ -340,6 +363,10 @@ class KnowledgeGraphFeature:
         if bool(body.get("preview_only")):
             return {"err": "ok", "scope": scope, "estimate": estimate}
         version = _book_version(book)
+        try:
+            workspace = ensure_workspace_id(handler.session, handler.user_id())
+        except AIArtifactError:
+            return {"err": "ai.artifact_unavailable", "msg": "无法准备知识图谱存储"}
         key = knowledge_graph_request_key(handler.user_id(), book_id, version, scope_hash)
         if bool(body.get("regenerate")):
             key = hashlib.sha256((key + ":" + uuid.uuid4().hex).encode("utf-8")).hexdigest()
@@ -350,7 +377,8 @@ class KnowledgeGraphFeature:
             if existing.status in {"failed", "cancelled"}:
                 draft = dict(existing.ai_draft or {})
                 draft["scope"] = scope
-                draft.setdefault("segments", {})
+                draft.setdefault("workspace", workspace)
+                draft.setdefault("completed_segments", 0)
                 existing.ai_draft = draft
                 existing.status = "queued"
                 existing.cancel_requested = False
@@ -374,7 +402,7 @@ class KnowledgeGraphFeature:
             chapter_length=character_count,
             status="queued",
             progress_message="等待提取",
-            ai_draft={"scope": scope, "segments": {}},
+            ai_draft={"workspace": workspace, "scope": scope, "completed_segments": 0},
             schema_version=KNOWLEDGE_GRAPH_SCHEMA_VERSION,
             prompt_version=KNOWLEDGE_GRAPH_PROMPT_VERSION,
         )
@@ -400,9 +428,19 @@ class KnowledgeGraphFeature:
             handler.write({"err": "ai.not_ready", "msg": "知识图谱尚未完成"})
             return
         filename = f"knowledge-graph-{record.book_id}-{record.id[:8]}.json"
+        try:
+            payload = load_graph_artifact(record, AIArtifactStorage(CONF))
+        except AIArtifactError:
+            handler.set_header("Content-Type", "application/json; charset=UTF-8")
+            handler.write({"err": "ai.artifact_unavailable", "msg": "知识图谱产物不可用，请重新生成"})
+            return
         handler.set_header("Content-Type", "application/json; charset=UTF-8")
         handler.set_header("Content-Disposition", f'attachment; filename="{filename}"')
-        handler.write(json.dumps(record.result_data or {}, ensure_ascii=False, separators=(",", ":")))
+        handler.write(json.dumps(payload, ensure_ascii=False, separators=(",", ":")))
+
+    @staticmethod
+    def delete_artifact(record):
+        cleanup_record_artifacts(record, AIArtifactStorage(CONF))
 
 
 AI_FEATURES = {
@@ -491,6 +529,11 @@ class AITaskItem(_AITaskBase):
             return error
         if record.status in {"queued", "running"}:
             feature.service(self).cancel(record.id)
+        try:
+            if hasattr(feature, "delete_artifact"):
+                feature.delete_artifact(record)
+        except AIArtifactError:
+            return {"err": "ai.artifact_cleanup_failed", "msg": "AI 产物清理失败，请重试"}
         self.session.delete(record)
         self.session.commit()
         return {"err": "ok", "msg": "AI 任务已删除"}

--- a/webserver/handlers/book.py
+++ b/webserver/handlers/book.py
@@ -1017,8 +1017,21 @@ class BookDelete(BaseHandler):
             delete_external_index_book_record(self.db, bid)
         else:
             self.db.delete_book(bid)
-        # 同步清理该书籍对应的 ScanFile 记录，避免重新导入时因哈希重复被误判为 drop
+        # 同步清理该书籍对应的 AI 目录产物和 ScanFile 记录，避免遗留私有内容或重复导入误判。
         from webserver.models import AITask, ScanFile
+        from webserver.services.ai_artifacts import AIArtifactError, AIArtifactStorage
+        from webserver.services.knowledge_graph import FEATURE_KEY as KNOWLEDGE_GRAPH_FEATURE_KEY
+        from webserver.services.knowledge_graph import cleanup_record_artifacts
+
+        ai_tasks = self.session.query(AITask).filter(AITask.book_id == bid).all()
+        try:
+            storage = AIArtifactStorage(CONF)
+            for task in ai_tasks:
+                if task.feature == KNOWLEDGE_GRAPH_FEATURE_KEY:
+                    cleanup_record_artifacts(task, storage)
+        except AIArtifactError:
+            logging.exception("failed to clean AI artifacts for deleted book_id=%s", bid)
+            return {"err": "ai.artifact_cleanup_failed", "msg": _("书籍已删除，但 AI 产物清理失败，请联系管理员")}
 
         self.session.query(ScanFile).filter(ScanFile.book_id == bid).delete()
         self.session.query(AITask).filter(AITask.book_id == bid).delete()

--- a/webserver/self_check.py
+++ b/webserver/self_check.py
@@ -76,11 +76,13 @@ def check_atomic_write(directory):
 
 
 def check_permission():
-    """修复 /data/books 的属主，并校验书库与配置目录的原子写入能力。"""
+    """修复 /data/books 的属主，并校验持久化目录的原子写入能力。"""
     permission_file = os.path.join(DATA_DIR, ".permission")
     current = "%s:%s" % (os.environ.get("PUID", "0"), os.environ.get("PGID", "0"))
     books_dir = os.path.join(DATA_DIR, "books")
     settings_dir = os.path.join(books_dir, "settings")
+    ai_dir = os.path.join(books_dir, "ai")
+    os.makedirs(ai_dir, exist_ok=True)
     previous = None
     if os.path.exists(permission_file):
         with open(permission_file) as f:
@@ -91,11 +93,11 @@ def check_permission():
             return False, "permission_denied"
         with open(permission_file, "w") as f:
             f.write(current)
-    elif not run(["chown", "-R", "%s:%s" % (RUN_USER, RUN_USER), settings_dir]):
-        # settings 很小，标记命中时仍定向修复，避免宿主目录重建或预置文件复制后属主失真。
+    elif not run(["chown", "-R", "%s:%s" % (RUN_USER, RUN_USER), settings_dir, ai_dir]):
+        # 小型可写目录在标记命中时仍定向修复，避免宿主目录重建后属主失真。
         return False, "permission_denied"
 
-    for directory in (os.path.join(books_dir, "library"), settings_dir):
+    for directory in (os.path.join(books_dir, "library"), settings_dir, ai_dir):
         if not check_atomic_write(directory):
             return False, "permission_denied"
 

--- a/webserver/services/ai_artifacts.py
+++ b/webserver/services/ai_artifacts.py
@@ -1,0 +1,242 @@
+"""Directory-backed storage for creator-private AI artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import tempfile
+import uuid
+from pathlib import Path
+from typing import Any, Dict, Iterable
+
+from webserver.models import Reader
+
+
+DEFAULT_ARTIFACT_ROOT = "/data/books/ai"
+WORKSPACE_EXTRA_KEY = "ai_workspace_id"
+WORKSPACE_RE = re.compile(r"^[0-9a-f]{32}$")
+COMPONENT_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
+TASK_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f-]{27}$")
+
+
+class AIArtifactError(RuntimeError):
+    """An artifact path, payload, or storage operation is unsafe or invalid."""
+
+
+def ensure_workspace_id(session, owner_id: int) -> str:
+    """Return the user's stable opaque AI workspace, creating it transactionally."""
+    reader = session.get(Reader, int(owner_id))
+    if reader is None:
+        raise AIArtifactError("AI 产物所属用户不存在")
+    extra = dict(reader.extra or {})
+    workspace = str(extra.get(WORKSPACE_EXTRA_KEY, ""))
+    if WORKSPACE_RE.fullmatch(workspace):
+        return workspace
+    # Deterministic generation prevents two first-use requests from assigning
+    # different workspaces before either transaction commits.  The value is an
+    # opaque directory key, not an authorization token; ACLs remain database-backed.
+    workspace = uuid.uuid5(
+        uuid.NAMESPACE_URL,
+        f"talebook-ai-workspace:{reader.id}:{reader.create_time or ''}",
+    ).hex
+    extra[WORKSPACE_EXTRA_KEY] = workspace
+    reader.extra = extra
+    return workspace
+
+
+def workspace_id_from_reader(reader: Reader) -> str:
+    workspace = str((reader.extra or {}).get(WORKSPACE_EXTRA_KEY, ""))
+    return workspace if WORKSPACE_RE.fullmatch(workspace) else ""
+
+
+class AIArtifactStorage:
+    """Write and read JSON artifacts beneath one non-public persistent root."""
+
+    def __init__(self, config: Dict[str, Any]):
+        configured = str(config.get("AI_ARTIFACT_ROOT", "") or DEFAULT_ARTIFACT_ROOT)
+        root = Path(configured).expanduser()
+        if not root.is_absolute():
+            raise AIArtifactError("AI 产物根目录必须是绝对路径")
+        self.root = root
+        self.max_bytes = int(config.get("AI_ARTIFACT_MAX_BYTES", 128 * 1024 * 1024))
+
+    @staticmethod
+    def _validate_identity(workspace: str, feature: str, task_id: str) -> None:
+        if not WORKSPACE_RE.fullmatch(str(workspace)):
+            raise AIArtifactError("AI workspace 标识无效")
+        if not COMPONENT_RE.fullmatch(str(feature)):
+            raise AIArtifactError("AI feature 标识无效")
+        if not TASK_RE.fullmatch(str(task_id)):
+            raise AIArtifactError("AI task 标识无效")
+
+    def _root_resolved(self) -> Path:
+        self.root.mkdir(parents=True, exist_ok=True, mode=0o700)
+        return self.root.resolve(strict=True)
+
+    def _task_dir(self, workspace: str, feature: str, task_id: str, create: bool = False) -> Path:
+        self._validate_identity(workspace, feature, task_id)
+        root = self._root_resolved()
+        path = self.root / workspace / feature / task_id
+        if create:
+            path.mkdir(parents=True, exist_ok=True, mode=0o700)
+        resolved = path.resolve(strict=False)
+        if resolved.parent.parent.parent != root:
+            raise AIArtifactError("AI 产物路径越界")
+        return path
+
+    def _metadata_path(
+        self,
+        metadata: Dict[str, Any],
+        workspace: str,
+        feature: str,
+        task_id: str,
+        allowed_names: Iterable[str],
+    ) -> Path:
+        self._validate_identity(workspace, feature, task_id)
+        if not isinstance(metadata, dict):
+            raise AIArtifactError("AI 产物索引缺失")
+        relative = metadata.get("relative_path")
+        digest = metadata.get("sha256")
+        if not isinstance(relative, str) or not isinstance(digest, str) or len(digest) != 64:
+            raise AIArtifactError("AI 产物索引无效")
+        relative_path = Path(relative)
+        if relative_path.is_absolute() or len(relative_path.parts) != 4:
+            raise AIArtifactError("AI 产物相对路径无效")
+        expected_prefix = (workspace, feature, task_id)
+        if relative_path.parts[:3] != expected_prefix or relative_path.name not in set(allowed_names):
+            raise AIArtifactError("AI 产物索引与任务不匹配")
+        path = self.root / relative_path
+        root = self._root_resolved()
+        if path.resolve(strict=False).parent.parent.parent.parent != root:
+            raise AIArtifactError("AI 产物路径越界")
+        return path
+
+    def write_json(
+        self,
+        workspace: str,
+        feature: str,
+        task_id: str,
+        filename: str,
+        payload: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        if filename not in {"checkpoint.json", "graph.json"} or not isinstance(payload, dict):
+            raise AIArtifactError("AI 产物文件或内容无效")
+        directory = self._task_dir(workspace, feature, task_id, create=True)
+        encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        if len(encoded) > self.max_bytes:
+            raise AIArtifactError("AI 产物超过大小限制")
+        target = directory / filename
+        temporary = None
+        try:
+            descriptor, temporary = tempfile.mkstemp(prefix=f".{filename}.", dir=str(directory))
+            os.fchmod(descriptor, 0o600)
+            with os.fdopen(descriptor, "wb") as stream:
+                stream.write(encoded)
+                stream.flush()
+                os.fsync(stream.fileno())
+            checked = Path(temporary).read_bytes()
+            if checked != encoded or not isinstance(json.loads(checked.decode("utf-8")), dict):
+                raise AIArtifactError("AI 产物暂存校验失败")
+            os.replace(temporary, target)
+            temporary = None
+            directory_fd = os.open(directory, os.O_RDONLY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+        except (OSError, UnicodeError, ValueError, TypeError) as exc:
+            raise AIArtifactError("AI 产物写入失败") from exc
+        finally:
+            if temporary:
+                try:
+                    os.unlink(temporary)
+                except FileNotFoundError:
+                    pass
+        relative = target.relative_to(self.root).as_posix()
+        return {
+            "workspace": workspace,
+            "feature": feature,
+            "relative_path": relative,
+            "sha256": hashlib.sha256(encoded).hexdigest(),
+            "size": len(encoded),
+        }
+
+    def read_json(
+        self,
+        metadata: Dict[str, Any],
+        workspace: str,
+        feature: str,
+        task_id: str,
+        allowed_names: Iterable[str],
+    ) -> Dict[str, Any]:
+        path = self._metadata_path(metadata, workspace, feature, task_id, allowed_names)
+        try:
+            size = path.stat().st_size
+            if size < 2 or size > self.max_bytes:
+                raise AIArtifactError("AI 产物大小无效")
+            encoded = path.read_bytes()
+        except (OSError, ValueError) as exc:
+            raise AIArtifactError("AI 产物不可用") from exc
+        if hashlib.sha256(encoded).hexdigest() != metadata["sha256"]:
+            raise AIArtifactError("AI 产物摘要不匹配")
+        try:
+            payload = json.loads(encoded.decode("utf-8"))
+        except (UnicodeError, ValueError) as exc:
+            raise AIArtifactError("AI 产物 JSON 无效") from exc
+        if not isinstance(payload, dict):
+            raise AIArtifactError("AI 产物结构无效")
+        return payload
+
+    def delete_file(
+        self,
+        metadata: Dict[str, Any],
+        workspace: str,
+        feature: str,
+        task_id: str,
+        allowed_names: Iterable[str],
+    ) -> None:
+        path = self._metadata_path(metadata, workspace, feature, task_id, allowed_names)
+        try:
+            path.unlink(missing_ok=True)
+        except OSError as exc:
+            raise AIArtifactError("AI 产物清理失败") from exc
+
+    def delete_task(self, workspace: str, feature: str, task_id: str) -> None:
+        path = self._task_dir(workspace, feature, task_id)
+        if not path.exists():
+            return
+        if path.is_symlink() or len(path.relative_to(self.root).parts) != 3:
+            raise AIArtifactError("拒绝清理不安全的 AI task 目录")
+        try:
+            shutil.rmtree(path)
+            self._prune_empty(path.parent, stop=self.root / workspace)
+        except OSError as exc:
+            raise AIArtifactError("AI task 目录清理失败") from exc
+
+    def delete_workspace(self, workspace: str) -> None:
+        if not WORKSPACE_RE.fullmatch(str(workspace)):
+            raise AIArtifactError("AI workspace 标识无效")
+        root = self._root_resolved()
+        path = self.root / workspace
+        if not path.exists():
+            return
+        if path.is_symlink() or path.resolve(strict=False).parent != root:
+            raise AIArtifactError("拒绝清理不安全的 AI workspace 目录")
+        try:
+            shutil.rmtree(path)
+        except OSError as exc:
+            raise AIArtifactError("AI workspace 目录清理失败") from exc
+
+    @staticmethod
+    def _prune_empty(path: Path, stop: Path) -> None:
+        while path != stop.parent:
+            try:
+                path.rmdir()
+            except OSError:
+                return
+            if path == stop:
+                return
+            path = path.parent

--- a/webserver/services/knowledge_graph.py
+++ b/webserver/services/knowledge_graph.py
@@ -20,11 +20,13 @@ from xml.etree import ElementTree
 
 from webserver.models import AITask
 from webserver.services.agent_runtime import AgentRuntimeError, RuntimeEvent, RuntimeRequest
+from webserver.services.ai_artifacts import AIArtifactError, AIArtifactStorage, ensure_workspace_id
 from webserver.services.codex_app_server import CodexAppServerRuntime
 
 
 LOG = logging.getLogger(__name__)
 FEATURE_KEY = "knowledge_graph"
+ARTIFACT_FEATURE_SLUG = "knowledge-graphs"
 SCHEMA_VERSION = "knowledge_graph.v1"
 PROMPT_VERSION = "knowledge_graph.zh.v1"
 ENTITY_TYPES = ("person", "place", "organization", "event", "concept", "claim", "evidence")
@@ -595,10 +597,171 @@ def merge_segments(segments: Iterable[Dict[str, Any]]) -> Dict[str, Any]:
     }
 
 
-def task_dict(record: AITask) -> Dict[str, Any]:
-    data = record.result_data or {}
+def _artifact_payload(record: AITask, data: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "task_id": record.id,
+        "owner_id": record.creator_id,
+        "book_id": record.book_id,
+        "book_version": record.book_version,
+        "schema_version": record.schema_version,
+        "prompt_version": record.prompt_version,
+        "scope": dict(data.get("scope") or {}),
+        "graph": data.get("graph", {"nodes": [], "relations": []}),
+        "review": data.get("review", {"low_confidence": [], "alias_conflicts": []}),
+        "stats": data.get("stats", {}),
+    }
+
+
+def _checkpoint_payload(record: AITask, draft: Dict[str, Any], segments: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "task_id": record.id,
+        "owner_id": record.creator_id,
+        "book_id": record.book_id,
+        "book_version": record.book_version,
+        "schema_version": record.schema_version,
+        "prompt_version": record.prompt_version,
+        "scope": dict(draft.get("scope") or {}),
+        "segments": segments,
+    }
+
+
+def _record_workspace(record: AITask) -> str:
+    for container in (record.result_data or {}, record.ai_draft or {}):
+        workspace = str(container.get("workspace", ""))
+        if len(workspace) == 32 and all(character in "0123456789abcdef" for character in workspace):
+            return workspace
+        metadata = container.get("artifact") or container.get("checkpoint") or {}
+        workspace = str(metadata.get("workspace", "")) if isinstance(metadata, dict) else ""
+        if len(workspace) == 32 and all(character in "0123456789abcdef" for character in workspace):
+            return workspace
+    return ""
+
+
+def migrate_legacy_artifacts(session, record: AITask, storage: AIArtifactStorage) -> bool:
+    """Move old inline graph/checkpoint content to files before clearing it from the DB."""
+    workspace = ensure_workspace_id(session, record.creator_id)
+    existing_workspace = _record_workspace(record)
+    if existing_workspace and existing_workspace != workspace:
+        raise AIArtifactError("AI 产物 workspace 与所属用户不匹配")
+    draft = dict(record.ai_draft or {})
+    data = dict(record.result_data or {})
+    changed = draft.get("workspace") != workspace or data.get("workspace") != workspace
+
+    inline_segments = draft.pop("segments", None)
+    if isinstance(inline_segments, dict) and inline_segments and record.status != "succeeded":
+        checkpoint = storage.write_json(
+            workspace,
+            ARTIFACT_FEATURE_SLUG,
+            record.id,
+            "checkpoint.json",
+            _checkpoint_payload(record, draft, inline_segments),
+        )
+        draft["checkpoint"] = checkpoint
+        draft["completed_segments"] = len(inline_segments)
+        changed = True
+    elif inline_segments is not None:
+        draft.pop("checkpoint", None)
+        draft["completed_segments"] = len(inline_segments) if record.status != "succeeded" else 0
+        changed = True
+
+    if "graph" in data:
+        payload = _artifact_payload(record, data)
+        artifact = storage.write_json(
+            workspace,
+            ARTIFACT_FEATURE_SLUG,
+            record.id,
+            "graph.json",
+            payload,
+        )
+        data = {
+            "workspace": workspace,
+            "scope": payload["scope"],
+            "stats": payload["stats"],
+            "artifact": artifact,
+        }
+        draft.pop("checkpoint", None)
+        draft["completed_segments"] = 0
+        changed = True
+
+    if changed:
+        draft["workspace"] = workspace
+        data["workspace"] = workspace
+        record.ai_draft = draft
+        record.result_data = data
+        record.update_time = datetime.datetime.now()
+    return changed
+
+
+def load_graph_artifact(record: AITask, storage: AIArtifactStorage) -> Dict[str, Any]:
+    data = dict(record.result_data or {})
+    metadata = data.get("artifact")
+    workspace = _record_workspace(record)
+    payload = storage.read_json(
+        metadata,
+        workspace,
+        ARTIFACT_FEATURE_SLUG,
+        record.id,
+        {"graph.json"},
+    )
+    expected = {
+        "task_id": record.id,
+        "owner_id": record.creator_id,
+        "book_id": record.book_id,
+        "book_version": record.book_version,
+        "schema_version": record.schema_version,
+        "prompt_version": record.prompt_version,
+    }
+    if any(payload.get(key) != value for key, value in expected.items()):
+        raise AIArtifactError("AI 图谱产物与任务索引不匹配")
+    if not isinstance(payload.get("graph"), dict) or not isinstance(payload.get("review"), dict):
+        raise AIArtifactError("AI 图谱产物结构无效")
+    return payload
+
+
+def load_checkpoint(record: AITask, storage: AIArtifactStorage) -> Dict[str, Any]:
+    draft = dict(record.ai_draft or {})
+    metadata = draft.get("checkpoint")
+    if not metadata:
+        return {}
+    workspace = _record_workspace(record)
+    payload = storage.read_json(
+        metadata,
+        workspace,
+        ARTIFACT_FEATURE_SLUG,
+        record.id,
+        {"checkpoint.json"},
+    )
+    if (
+        payload.get("task_id") != record.id
+        or payload.get("owner_id") != record.creator_id
+        or payload.get("book_id") != record.book_id
+        or payload.get("book_version") != record.book_version
+        or payload.get("schema_version") != record.schema_version
+        or payload.get("prompt_version") != record.prompt_version
+        or not isinstance(payload.get("segments"), dict)
+    ):
+        raise AIArtifactError("AI 检查点与任务索引不匹配")
+    return dict(payload["segments"])
+
+
+def cleanup_record_artifacts(record: AITask, storage: AIArtifactStorage) -> None:
+    workspace = _record_workspace(record)
+    if workspace:
+        storage.delete_task(workspace, ARTIFACT_FEATURE_SLUG, record.id)
+
+
+def task_dict(record: AITask, storage: Optional[AIArtifactStorage] = None) -> Dict[str, Any]:
+    index = record.result_data or {}
     draft = record.ai_draft or {}
-    scope = data.get("scope") or draft.get("scope") or {}
+    scope = index.get("scope") or draft.get("scope") or {}
+    data = index
+    artifact_error = None
+    if storage is not None and index.get("artifact"):
+        try:
+            data = load_graph_artifact(record, storage)
+        except AIArtifactError:
+            data = {}
+            artifact_error = {"code": "artifact.unavailable", "message": "知识图谱产物不可用，请重新生成"}
     return {
         "id": record.id,
         "feature": record.feature,
@@ -607,7 +770,7 @@ def task_dict(record: AITask) -> Dict[str, Any]:
         "scope": scope,
         "status": record.status,
         "progress_message": record.progress_message,
-        "completed_segments": len((draft.get("segments") or {})),
+        "completed_segments": int(draft.get("completed_segments", 0) or 0),
         "total_segments": int(scope.get("chapter_count", 0) or 0),
         "graph": data.get("graph", {"nodes": [], "relations": []}),
         "review": data.get("review", {"low_confidence": [], "alias_conflicts": []}),
@@ -616,7 +779,8 @@ def task_dict(record: AITask) -> Dict[str, Any]:
         "prompt_version": record.prompt_version,
         "runtime": record.runtime_name,
         "usage": record.usage or {},
-        "error": {"code": record.error_code, "message": record.error_message} if record.error_code else None,
+        "error": artifact_error
+        or ({"code": record.error_code, "message": record.error_message} if record.error_code else None),
         "created_at": record.create_time.isoformat() if record.create_time else None,
         "updated_at": record.update_time.isoformat() if record.update_time else None,
     }
@@ -638,6 +802,7 @@ class KnowledgeGraphService:
     def setup(self, session_maker, config: Dict[str, Any], runtime=None) -> None:
         self.session_maker = session_maker
         self.config = config
+        self.storage = AIArtifactStorage(config)
         if runtime is not None:
             self.runtime = runtime
         elif not self._configured:
@@ -682,8 +847,8 @@ class KnowledgeGraphService:
         finally:
             session.close()
 
-    def _save_segment(
-        self, record_id: str, chapter: Dict[str, str], segment: Dict[str, Any], usage: Dict[str, Any], index: int, total: int
+    def _save_checkpoint(
+        self, record_id: str, segments: Dict[str, Any], usage: Dict[str, Any], index: int, total: int
     ) -> None:
         session = self.session_maker()
         try:
@@ -691,9 +856,17 @@ class KnowledgeGraphService:
             if not record:
                 return
             draft = dict(record.ai_draft or {})
-            segments = dict(draft.get("segments") or {})
-            segments[chapter["href"]] = segment
-            draft["segments"] = segments
+            workspace = ensure_workspace_id(session, record.creator_id)
+            checkpoint = self.storage.write_json(
+                workspace,
+                ARTIFACT_FEATURE_SLUG,
+                record.id,
+                "checkpoint.json",
+                _checkpoint_payload(record, draft, segments),
+            )
+            draft["workspace"] = workspace
+            draft["checkpoint"] = checkpoint
+            draft["completed_segments"] = len(segments)
             record.ai_draft = draft
             aggregate = dict(record.usage or {})
             for key, value in (usage or {}).items():
@@ -707,26 +880,28 @@ class KnowledgeGraphService:
             session.close()
 
     def _run(self, record_id: str, epub_path: str, chapter_hrefs: Sequence[str]) -> None:
-        session = self.session_maker()
         try:
-            record = session.get(AITask, record_id)
-            if not record or record.status not in {"queued", "running", "failed", "cancelled"}:
-                return
-            if record.cancel_requested:
-                record.status = "cancelled"
-                record.finished_at = datetime.datetime.now()
+            session = self.session_maker()
+            try:
+                record = session.get(AITask, record_id)
+                if not record or record.status not in {"queued", "running", "failed", "cancelled"}:
+                    return
+                migrate_legacy_artifacts(session, record, self.storage)
+                if record.cancel_requested:
+                    record.status = "cancelled"
+                    record.finished_at = datetime.datetime.now()
+                    session.commit()
+                    return
+                completed = load_checkpoint(record, self.storage)
+                record.status = "running"
+                record.runtime_name = self.runtime.name
+                record.error_code = ""
+                record.error_message = ""
+                record.started_at = datetime.datetime.now()
+                record.update_time = record.started_at
                 session.commit()
-                return
-            record.status = "running"
-            record.runtime_name = self.runtime.name
-            record.error_code = ""
-            record.error_message = ""
-            record.started_at = datetime.datetime.now()
-            record.update_time = record.started_at
-            session.commit()
-        finally:
-            session.close()
-        try:
+            finally:
+                session.close()
             chapters = extract_epub_chapters(
                 epub_path,
                 chapter_hrefs,
@@ -734,12 +909,6 @@ class KnowledgeGraphService:
                 int(self.config.get("AI_KNOWLEDGE_GRAPH_MAX_CHAPTER_CHARACTERS", 16_000)),
                 int(self.config.get("AI_KNOWLEDGE_GRAPH_MAX_TOTAL_CHARACTERS", 400_000)),
             )
-            session = self.session_maker()
-            try:
-                record = session.get(AITask, record_id)
-                completed = dict((record.ai_draft or {}).get("segments") or {}) if record else {}
-            finally:
-                session.close()
             for index, chapter in enumerate(chapters, 1):
                 if self._is_cancelled(record_id):
                     raise _cancel_error()
@@ -756,34 +925,70 @@ class KnowledgeGraphService:
                 )
                 checked = validate_segment(result.output, chapter)
                 completed[chapter["href"]] = checked
-                self._save_segment(record_id, chapter, checked, result.usage or {}, index, len(chapters))
+                self._save_checkpoint(record_id, completed, result.usage or {}, index, len(chapters))
             result_data = merge_segments(completed[href] for href in chapter_hrefs if href in completed)
             session = self.session_maker()
             try:
                 record = session.get(AITask, record_id)
                 if not record:
                     return
+                checkpoint = None
+                workspace = ""
                 if record.cancel_requested:
                     record.status = "cancelled"
                 else:
-                    result_data["scope"] = dict((record.ai_draft or {}).get("scope") or {})
+                    draft = dict(record.ai_draft or {})
+                    workspace = ensure_workspace_id(session, record.creator_id)
+                    result_data["scope"] = dict(draft.get("scope") or {})
+                    payload = _artifact_payload(record, result_data)
+                    artifact = self.storage.write_json(
+                        workspace,
+                        ARTIFACT_FEATURE_SLUG,
+                        record.id,
+                        "graph.json",
+                        payload,
+                    )
                     record.status = "succeeded"
-                    record.result_data = result_data
+                    record.result_data = {
+                        "workspace": workspace,
+                        "scope": payload["scope"],
+                        "stats": payload["stats"],
+                        "artifact": artifact,
+                    }
+                    checkpoint = draft.get("checkpoint")
+                    record.ai_draft = {
+                        "workspace": workspace,
+                        "scope": payload["scope"],
+                        "completed_segments": 0,
+                    }
                     record.progress_message = "知识图谱生成完成"
                 record.finished_at = datetime.datetime.now()
                 record.update_time = record.finished_at
                 session.commit()
+                if not record.cancel_requested and checkpoint:
+                    try:
+                        self.storage.delete_file(
+                            checkpoint,
+                            workspace,
+                            ARTIFACT_FEATURE_SLUG,
+                            record.id,
+                            {"checkpoint.json"},
+                        )
+                    except AIArtifactError:
+                        LOG.warning("Failed to remove knowledge graph checkpoint record_id=%s", record_id)
             finally:
                 session.close()
-        except (AgentRuntimeError, KnowledgeGraphValidationError) as exc:
+        except (AgentRuntimeError, KnowledgeGraphValidationError, AIArtifactError) as exc:
             session = self.session_maker()
             try:
                 record = session.get(AITask, record_id)
                 if record:
                     cancelled = isinstance(exc, AgentRuntimeError) and getattr(exc.code, "value", "") == "runtime.cancelled"
                     record.status = "cancelled" if cancelled or record.cancel_requested else "failed"
-                    record.error_code = getattr(getattr(exc, "code", None), "value", "result.invalid")
-                    record.error_message = str(getattr(exc, "safe_message", str(exc)))[:500]
+                    fallback_code = "artifact.invalid" if isinstance(exc, AIArtifactError) else "result.invalid"
+                    record.error_code = getattr(getattr(exc, "code", None), "value", fallback_code)
+                    safe_message = "知识图谱产物存储失败，请重试" if isinstance(exc, AIArtifactError) else str(exc)
+                    record.error_message = str(getattr(exc, "safe_message", safe_message))[:500]
                     record.progress_message = record.error_message
                     record.finished_at = datetime.datetime.now()
                     record.update_time = record.finished_at

--- a/webserver/settings.py
+++ b/webserver/settings.py
@@ -96,6 +96,9 @@ settings = {
     "AI_CODEX_MIN_VERSION": "0.147.0",
     "AI_CODEX_MAX_VERSION": "0.148.0",
     "AI_TASK_ROOT": "/data/books/progress",
+    # AI 实体产物的唯一内容来源；数据库仅保存相对于此目录的路径、摘要和管理索引。
+    "AI_ARTIFACT_ROOT": "/data/books/ai",
+    "AI_ARTIFACT_MAX_BYTES": 128 * 1024 * 1024,
     "AI_HANDSHAKE_TIMEOUT_SECONDS": 10,
     "AI_FIRST_PROGRESS_TIMEOUT_SECONDS": 30,
     "AI_SILENCE_TIMEOUT_SECONDS": 45,


### PR DESCRIPTION
## 背景

PR #994 已将 TB-55 知识图谱合入 `feat/ai_1.0`，但完整图谱和分章恢复检查点仍内联保存在 `ai_tasks` JSON 字段中，不符合 AI 产物目录为唯一内容来源的新统一规范。

## 关键改动

- 新增通用目录产物存储器，在 `books/ai/{opaque-workspace}/knowledge-graphs/{task-id}/` 原子写入当前 `graph.json` 与运行中 `checkpoint.json`。
- 数据库仅保留 workspace、生成范围、相对路径、SHA-256、字节数、状态与统计索引；正式 graph/引用和分章 segments 不再重复入库。
- 所有读取先校验创建者、原书 ACL 与文件版本，再校验受限相对路径、任务身份和 SHA；损坏或越界产物失败关闭。
- 旧内联记录在授权读取或恢复前安全迁移；文件写入和摘要成功后才清除数据库正文。
- 删除任务、书籍或用户时同步清理对应 task/workspace 目录；启动自检覆盖 `/data/books/ai` 原子写权限，备份文档明确数据库与 data 目录必须整体迁移。
- 保持现有知识图谱 API 字段、画布、引用回跳、AgentRuntime、取消/重试行为；不新增版本表、回滚 UI 或 `v{version}` 目录。

## 验证

- 聚焦存储/ACL/迁移/生命周期：45 passed
- 全量后端：881 passed, 20 skipped（25 个既有 warning）
- `make lint-py-fix` / `make lint-py`：通过
- `make check-design`：112 份文档通过
- 本次为纯后端持久化修正，无 UI 变更，按项目规则豁免重复 interface-review

## 方案

- [GitHub 文件](https://github.com/talebook/talebook/blob/573fb715965ff3db9dd388734437a805fc7e6295/design/webserver/20260818-knowledge-graph-artifact-storage.active.html)
- [RawGitHack 预览](https://raw.githack.com/talebook/talebook/573fb715965ff3db9dd388734437a805fc7e6295/design/webserver/20260818-knowledge-graph-artifact-storage.active.html)

## 风险与兼容性

旧记录按单任务惰性迁移，任一文件写入或校验失败都会保留原数据库内容，不做有损半迁移。若备份只恢复数据库而遗漏 `books/ai`，接口会拒绝返回缺失/摘要不符的成果并要求重新生成。

Closes TB-55
Related to TB-52
