### PR TITLE
TB-51：修复插件安全与数据保护阻塞项

### DIFF
--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -98,6 +98,10 @@ class TestAnnotations(TestWithUserLogin):
             for (annotation_id,) in session.query(models.Annotation.id).filter(models.Annotation.book_id == BID_EPUB).all()
         ]
         if annotation_ids:
+            session.query(models.PluginSourceRecord).filter(
+                models.PluginSourceRecord.entity_type == "annotation",
+                models.PluginSourceRecord.entity_id.in_([str(value) for value in annotation_ids]),
+            ).delete(synchronize_session=False)
             session.query(models.AnnotationSource).filter(models.AnnotationSource.annotation_id.in_(annotation_ids)).delete(
                 synchronize_session=False
             )
@@ -270,6 +274,44 @@ class TestAnnotations(TestWithUserLogin):
         self.assertTrue(imported["conflict_protected"])
         self.assertEqual(imported["annotation"]["content"], "我的手工修订")
         self.assertEqual(imported["annotation"]["sources"][0]["source_run_id"], "run-new")
+
+    def test_manual_update_and_delete_mark_materialized_plugin_records_as_local(self):
+        updated = self._post_source(source_annotation_id="plugin-update")
+        deleted = self._post_source(source_annotation_id="plugin-delete")
+        session = get_db()
+        records = []
+        for value, external_id in ((updated, "weread:update"), (deleted, "weread:delete")):
+            record = models.PluginSourceRecord(
+                connection_id=1,
+                source="talebook.weread",
+                external_id=external_id,
+                entity_type="annotation",
+                entity_id=str(value["annotation"]["id"]),
+                run_id=1,
+                raw_hash="remote-hash",
+                local_modified=False,
+                status="active",
+                data={},
+            )
+            session.add(record)
+            records.append(record)
+        session.commit()
+
+        changed = self.json(
+            "/api/book/%d/annotations/%d" % (BID_EPUB, updated["annotation"]["id"]),
+            method="PUT",
+            body=json.dumps({"content": "manual edit"}),
+        )
+        removed = self.json(
+            "/api/book/%d/annotations/%d" % (BID_EPUB, deleted["annotation"]["id"]),
+            method="DELETE",
+        )
+        session.expire_all()
+
+        self.assertEqual(changed["annotation"]["content"], "manual edit")
+        self.assertEqual(removed["err"], "ok")
+        self.assertTrue(session.get(models.PluginSourceRecord, records[0].id).local_modified)
+        self.assertTrue(session.get(models.PluginSourceRecord, records[1].id).local_modified)
 
     def test_older_source_event_is_ignored(self):
         self._post_source(content="new content")

--- a/tests/test_enrichment_connectors.py
+++ b/tests/test_enrichment_connectors.py
@@ -2,34 +2,37 @@ import base64
 import io
 import json
 import zipfile
+from types import SimpleNamespace
 
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from webserver.models import Annotation, Base, PluginConnection, PluginDefinition, PluginRunItem, PluginSourceRecord
+from webserver.plugins.runtime import enrichment
 from webserver.plugins.runtime.enrichment import (
+    REVIEW_SPECS,
     BRSProvider,
     CalibreProviderBridge,
     CatalogReviewProvider,
     EmbeddedMetadataProvider,
     OpenLibraryProvider,
-    REVIEW_SPECS,
     ReviewFileProvider,
     build_field_decisions,
     extract_epub_metadata,
     parse_review_file,
 )
 from webserver.plugins.runtime.protocol import PluginManifest, ProviderRateLimitError
+from webserver.plugins.runtime.safe_http import EndpointPolicyError, EndpointResponseTooLarge, SafeHttpClient
 from webserver.services.plugin_runtime import (
     PluginRegistry,
     PluginRuntime,
+    PluginRuntimeError,
     ensure_builtin_definitions,
     install_builtin,
     rotate_connection_secret,
     save_connection,
 )
-from webserver.services.plugin_runtime import PluginRuntimeError
 
 
 SETTINGS = {"PLUGIN_SECRET_KEY": "enrichment-test-key", "cookie_secret": "unused-cookie-secret"}
@@ -138,6 +141,56 @@ def test_network_connectors_reject_user_owned_connections(db_session):
             config={"endpoint": "http://127.0.0.1/internal"},
         )
     assert exc.value.code == "plugin.owner_forbidden"
+
+
+@pytest.mark.parametrize("endpoint", ["http://127.0.0.1", "http://169.254.169.254", "http://10.0.0.8"])
+def test_brs_rejects_local_link_local_and_private_endpoints(monkeypatch, endpoint):
+    request = SimpleNamespace(request=lambda *args, **kwargs: pytest.fail("blocked endpoint was requested"))
+
+    def resolver(host, port, **kwargs):
+        return [(2, 1, 6, "", (host, port))]
+
+    monkeypatch.setattr(enrichment, "SafeHttpClient", lambda: SafeHttpClient(session=request, resolver=resolver))
+
+    with pytest.raises(EndpointPolicyError):
+        BRSProvider().execute({"action": "test", "config": {"endpoint": endpoint}, "secrets": {"token": "x"}, "cursor": {}})
+
+
+def test_brs_revalidates_redirects_and_limits_response_size(monkeypatch):
+    public = [(2, 1, 6, "", ("93.184.216.34", 443))]
+    private = [(2, 1, 6, "", ("127.0.0.1", 80))]
+    redirect = SimpleNamespace(
+        status_code=302,
+        headers={"Location": "http://127.0.0.1/private"},
+        content=b"",
+    )
+    redirect_session = SimpleNamespace(request=lambda *args, **kwargs: redirect)
+    def resolver(host, *args, **kwargs):
+        return private if host == "127.0.0.1" else public
+
+    monkeypatch.setattr(
+        enrichment,
+        "SafeHttpClient",
+        lambda: SafeHttpClient(session=redirect_session, resolver=resolver),
+    )
+    context = {
+        "action": "test",
+        "config": {"endpoint": "https://brs.example"},
+        "secrets": {"token": "x"},
+        "cursor": {},
+    }
+    with pytest.raises(EndpointPolicyError):
+        BRSProvider().execute(context)
+
+    oversized = SimpleNamespace(status_code=200, headers={}, content=b"0123456789")
+    oversized_session = SimpleNamespace(request=lambda *args, **kwargs: oversized)
+    monkeypatch.setattr(
+        enrichment,
+        "SafeHttpClient",
+        lambda: SafeHttpClient(session=oversized_session, resolver=lambda *args, **kwargs: public, max_bytes=4),
+    )
+    with pytest.raises(EndpointResponseTooLarge):
+        BRSProvider().execute(context)
 
 
 def test_field_decisions_never_silently_replace_locked_or_nonempty_values():

--- a/tests/test_plugins_api.py
+++ b/tests/test_plugins_api.py
@@ -1,9 +1,10 @@
 import json
 from unittest import mock
 
+from tests.test_main import TestWithAdminUser, get_db
+from tests.test_main import setUpModule as init
 from webserver import loader
-from tests.test_main import TestWithAdminUser, get_db, setUpModule as init
-from webserver.models import PluginConnection, PluginInstallation, PluginSecret
+from webserver.models import PluginConnection, PluginInstallation, PluginRun, PluginRunItem, PluginSecret
 from webserver.plugins.runtime import ProviderAuthError, ProviderRateLimitError, WereadProvider
 
 
@@ -12,6 +13,13 @@ def setUpModule():
 
 
 class TestPluginsApi(TestWithAdminUser):
+    def _delete_private_run(self, connection_id, run_id):
+        session = get_db()
+        session.query(PluginRunItem).filter(PluginRunItem.run_id == run_id).delete()
+        session.query(PluginRun).filter(PluginRun.id == run_id).delete()
+        session.query(PluginConnection).filter(PluginConnection.id == connection_id).delete()
+        session.commit()
+
     def test_catalog_bootstraps_builtin_capabilities_without_excluded_sources(self):
         data = self.json("/api/admin/plugins")
 
@@ -85,6 +93,59 @@ class TestPluginsApi(TestWithAdminUser):
         data = self.json("/api/admin/plugins/runs/999999")
         self.assertEqual(data["err"], "plugin.run_missing")
         self.assertNotIn("traceback", json.dumps(data).lower())
+
+    def test_admin_cannot_execute_list_or_read_user_owned_plugin_runs(self):
+        self.json("/api/admin/plugins")
+        session = get_db()
+        installation = session.query(PluginInstallation).filter_by(plugin_key="talebook.book-source.opds").one()
+        connection = PluginConnection(
+            installation_id=installation.id,
+            owner_type="user",
+            owner_id=2,
+            name="qa-private-run",
+            config={},
+            scopes=[],
+            cursor={},
+        )
+        session.add(connection)
+        session.flush()
+        run = PluginRun(
+            connection_id=connection.id,
+            action="run",
+            status="succeeded",
+            requested_by=2,
+            counts={},
+            cursor_before={},
+            cursor_after={},
+            input_data={},
+        )
+        session.add(run)
+        session.flush()
+        session.add(
+            PluginRunItem(
+                run_id=run.id,
+                external_id="private-note",
+                entity_type="annotation",
+                status="succeeded",
+                data={"content": "user two private highlight"},
+            )
+        )
+        session.commit()
+        self.addCleanup(self._delete_private_run, connection.id, run.id)
+
+        action = self.json(
+            "/api/admin/plugins/connections/%d/run" % connection.id,
+            method="POST",
+            body="{}",
+        )
+        listed = self.json("/api/admin/plugins/runs?include_items=true")
+        detail = self.json("/api/admin/plugins/runs/%d" % run.id)
+
+        self.assertEqual(action["err"], "plugin.connection_forbidden")
+        self.assertNotIn(run.id, [item["id"] for item in listed["runs"]])
+        self.assertNotIn("user two private highlight", json.dumps(listed, ensure_ascii=False))
+        self.assertEqual(detail["err"], "plugin.run_missing")
+        self.assertNotIn("user two private highlight", json.dumps(detail, ensure_ascii=False))
 
     def tearDown(self):
         session = get_db()

--- a/webserver/handlers/annotations.py
+++ b/webserver/handlers/annotations.py
@@ -9,7 +9,7 @@ from sqlalchemy.exc import IntegrityError
 
 from webserver.handlers.base import BaseHandler, auth, js
 from webserver.i18n import _
-from webserver.models import Annotation, AnnotationSource
+from webserver.models import Annotation, AnnotationSource, PluginSourceRecord
 from webserver.services.annotation_sync import AnnotationSyncService
 
 
@@ -31,6 +31,16 @@ SOURCE_FIELD_LIMITS = {
 }
 SOURCE_INPUT_FIELDS = set(SOURCE_FIELD_LIMITS) | {"source_position", "source_updated_at"}
 LEGACY_SOURCE_FIELDS = {"source", "external_id", "connection_id", "run_id", "raw_hash", "remote_updated_at"}
+
+
+def _mark_plugin_records_locally_modified(session, annotation_id, now):
+    session.query(PluginSourceRecord).filter(
+        PluginSourceRecord.entity_type == "annotation",
+        PluginSourceRecord.entity_id == str(annotation_id),
+    ).update(
+        {PluginSourceRecord.local_modified: True, PluginSourceRecord.update_time: now},
+        synchronize_session="fetch",
+    )
 
 
 def _parse_datetime(value):
@@ -350,6 +360,7 @@ class BookAnnotationItem(AnnotationHandlerMixin, BaseHandler):
             now = datetime.datetime.now()
             annotation.user_modified_at = now
             annotation.update_time = now
+            _mark_plugin_records_locally_modified(self.session, annotation.id, now)
             self.session.commit()
             if not annotation.is_private:
                 AnnotationSyncService().sync_annotation(annotation.id)
@@ -367,6 +378,7 @@ class BookAnnotationItem(AnnotationHandlerMixin, BaseHandler):
         annotation = self._owned(book_id, annotation_id)
         if not annotation:
             return {"err": "annotation.not_found", "msg": _("笔记不存在")}
+        _mark_plugin_records_locally_modified(self.session, annotation.id, datetime.datetime.now())
         self.session.delete(annotation)
         self.session.commit()
         return {"err": "ok", "deleted": 1}

--- a/webserver/handlers/plugins.py
+++ b/webserver/handlers/plugins.py
@@ -266,9 +266,12 @@ class AdminPluginAction(BaseHandler):
     @is_admin
     def post(self, connection_id, action):
         try:
+            connection = self.session.get(PluginConnection, int(connection_id))
+            if connection is None or connection.owner_type != "instance":
+                raise PluginRuntimeError("plugin.connection_forbidden", "Plugin connection is not available")
             req = _body(self)
             run = PluginRuntime(self.session, loader.get_settings()).prepare_run(
-                int(connection_id),
+                connection.id,
                 action,
                 self.user_id(),
                 trigger=req.get("trigger", "manual"),
@@ -285,7 +288,11 @@ class AdminPluginRuns(BaseHandler):
     @js
     @is_admin
     def get(self):
-        query = self.session.query(PluginRun)
+        query = (
+            self.session.query(PluginRun)
+            .join(PluginConnection, PluginConnection.id == PluginRun.connection_id)
+            .filter(PluginConnection.owner_type == "instance")
+        )
         connection_id = self.get_argument("connection_id", "")
         if connection_id:
             try:
@@ -316,7 +323,8 @@ class AdminPluginRunDetail(BaseHandler):
             run = self.session.get(PluginRun, int(run_id))
         except (TypeError, ValueError):
             run = None
-        if run is None:
+        connection = self.session.get(PluginConnection, run.connection_id) if run is not None else None
+        if connection is None or connection.owner_type != "instance":
             return {"err": "plugin.run_missing", "msg": "Plugin run was not found"}
         items = self.session.query(PluginRunItem).filter(PluginRunItem.run_id == run.id).order_by(PluginRunItem.id).all()
         return {"err": "ok", "run": run.to_public_dict(), "items": [item.to_public_dict(include_data=True) for item in items]}

--- a/webserver/plugins/runtime/enrichment.py
+++ b/webserver/plugins/runtime/enrichment.py
@@ -6,19 +6,16 @@ import re
 import zipfile
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from urllib.parse import quote, urlparse
+from urllib.parse import quote
 from xml.etree import ElementTree
-
-import requests
 
 from .protocol import (
     PROTOCOL_VERSION,
-    ProviderAuthError,
     ProviderError,
     ProviderItem,
-    ProviderRateLimitError,
     ProviderResult,
 )
+from .safe_http import SafeHttpClient
 
 
 SUMMARY_LIMIT = 500
@@ -65,22 +62,15 @@ def _manifest(
 
 
 def _http_json(method, url, headers=None, params=None, body=None, timeout=30):
-    parsed = urlparse(url)
-    if parsed.scheme not in {"http", "https"} or not parsed.netloc or parsed.username or parsed.password:
-        raise ProviderError("Connector endpoint must be an HTTP(S) URL without embedded credentials")
     headers = {"Accept": "application/json", "User-Agent": USER_AGENT, **dict(headers or {})}
-    response = requests.request(method, url, headers=headers, params=params, json=body, timeout=timeout)
-    if response.status_code in {401, 403}:
-        raise ProviderAuthError("Provider rejected the configured credentials")
-    if response.status_code == 429:
-        retry_after = response.headers.get("Retry-After")
-        try:
-            retry_after = float(retry_after) if retry_after else None
-        except ValueError:
-            retry_after = None
-        raise ProviderRateLimitError("Provider rate limit exceeded", retry_after=retry_after)
-    if response.status_code >= 400:
-        raise ProviderError("Provider returned HTTP %d" % response.status_code)
+    response = SafeHttpClient().request(
+        method,
+        url,
+        headers=headers,
+        params=params,
+        json=body,
+        timeout=timeout,
+    )
     try:
         return response.json()
     except ValueError as exc:

--- a/webserver/plugins/runtime/safe_http.py
+++ b/webserver/plugins/runtime/safe_http.py
@@ -55,7 +55,7 @@ class SafeHttpClient:
         self.max_redirects = max_redirects
         self.max_bytes = max_bytes
 
-    def request(self, method, url, *, allowed_hosts=(), headers=None, timeout=30, data=None):
+    def request(self, method, url, *, allowed_hosts=(), headers=None, timeout=30, data=None, params=None, json=None):
         current = url
         origin = self._origin(url)
         for redirect_count in range(self.max_redirects + 1):
@@ -67,6 +67,8 @@ class SafeHttpClient:
                 current,
                 headers=dict(headers or {}),
                 data=data,
+                params=params,
+                json=json,
                 timeout=timeout,
                 allow_redirects=False,
             )
@@ -78,7 +80,7 @@ class SafeHttpClient:
                     raise EndpointPolicyError("Endpoint returned a redirect without a location")
                 current = urllib.parse.urljoin(current, location)
                 if response.status_code == 303:
-                    method, data = "GET", None
+                    method, data, json = "GET", None, None
                 continue
             if response.status_code in {401, 403}:
                 raise ProviderAuthError("Book source rejected the configured credentials")

--- a/webserver/services/plugin_runtime.py
+++ b/webserver/services/plugin_runtime.py
@@ -715,7 +715,14 @@ class PluginRuntime:
             self.session.add(record)
             self.session.flush()
             return "created", "succeeded", record
-        if record.local_modified and record.raw_hash != payload_hash:
+        if item.entity_type == "annotation":
+            from webserver.services.weread_annotations import materialized_annotation_is_locally_modified
+
+            if materialized_annotation_is_locally_modified(self.session, record):
+                record.local_modified = True
+        if record.local_modified:
+            if record.status == "active" and record.raw_hash == payload_hash:
+                return "skipped", "succeeded", record
             return "protected", "conflict", record
         if record.status == "active" and record.raw_hash == payload_hash:
             return "skipped", "succeeded", record
@@ -741,6 +748,11 @@ class PluginRuntime:
         counts["fetched"] = len(records)
         now = datetime.datetime.now()
         for record in records:
+            if record.entity_type == "annotation":
+                from webserver.services.weread_annotations import materialized_annotation_is_locally_modified
+
+                if materialized_annotation_is_locally_modified(self.session, record):
+                    record.local_modified = True
             if record.local_modified:
                 counts["conflicts"] += 1
                 self._add_item(

--- a/webserver/services/weread_annotations.py
+++ b/webserver/services/weread_annotations.py
@@ -335,6 +335,25 @@ def materialize_annotation(session, run, connection, record, data, payload_hash,
     return annotation
 
 
+def materialized_annotation_is_locally_modified(session, record):
+    """Detect local edits/deletes even if an older caller missed the record flag."""
+    try:
+        annotation_id = int(record.entity_id)
+    except (TypeError, ValueError):
+        return False
+    annotation = session.get(Annotation, annotation_id)
+    if annotation is None:
+        return True
+    if record.local_modified:
+        return True
+    sources = [source for source in annotation.sources if source.source_connection_id == str(record.connection_id)]
+    if not sources:
+        return True
+    if annotation.user_modified_at is None:
+        return False
+    return all(source.source_updated_at != annotation.user_modified_at for source in sources)
+
+
 def rollback_materialized_annotation(session, record):
     try:
         annotation_id = int(record.entity_id)


### PR DESCRIPTION
## 变更摘要

- 管理员插件 action、run 列表和 run detail 仅允许访问 instance-owned connection/run
- 用户手工编辑或删除导入笔记后，后续同步与回滚均保留本地修改
- enrichment connector 的默认 HTTP transport 接入 `SafeHttpClient`，统一执行 SSRF、重定向和响应大小限制
- 为 QA 列出的三个阻塞项补充回归测试

## 根因

管理员 run API 未应用 connection ownership 边界；annotation API 只更新了 `user_modified_at`，没有同步保护对应的 plugin source record；BRS connector 使用的直接 HTTP transport 只校验 URL 语法。

## 验证

- `make test`：943 passed，20 skipped，25 warnings
- Docker 定向回归：46 passed
- Docker `ruff check ./webserver --no-cache`：通过
- Docker `ruff format --diff ./webserver --output-format concise --no-cache`：119 files already formatted

目标分支：`feat/plugins`，等待 QA 复验。
