### PR TITLE
HOU-20: add standalone Talebook audio CLI

### DIFF
--- a/design/packages/20260828-talebook-audio-cli.active.html
+++ b/design/packages/20260828-talebook-audio-cli.active.html
@@ -1,0 +1,104 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Talebook Audio CLI 独立客户端方案 · ACTIVE</title>
+    <style>
+      :root { color-scheme: light; --ink: #172033; --muted: #5d6778; --line: #d9e0ea; --accent: #9a4d0c; --panel: #fff; }
+      * { box-sizing: border-box; }
+      body { margin: 0; color: var(--ink); background: #f5f7fb; font: 15px/1.65 system-ui, sans-serif; }
+      main { width: min(960px, calc(100vw - 32px)); margin: 32px auto; }
+      header, section { margin-bottom: 18px; padding: 24px; border: 1px solid var(--line); border-radius: 16px; background: var(--panel); }
+      h1, h2 { margin-top: 0; line-height: 1.25; }
+      .meta { display: flex; flex-wrap: wrap; gap: 8px; color: var(--muted); }
+      .meta span { padding: 4px 10px; border-radius: 999px; background: #eef2f7; }
+      .flow { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; }
+      .flow div { padding: 12px; border: 1px solid var(--line); border-radius: 12px; }
+      code { padding: 2px 5px; border-radius: 4px; background: #eef2f7; }
+      table { width: 100%; border-collapse: collapse; }
+      th, td { padding: 9px; border: 1px solid var(--line); text-align: left; vertical-align: top; }
+      th { background: #f6f8fb; }
+      .pending { color: var(--accent); font-weight: 700; }
+      @media (max-width: 720px) { main { width: calc(100vw - 20px); margin: 10px auto; } .flow { grid-template-columns: 1fr; } header, section { padding: 18px; } }
+      @media (prefers-reduced-motion: reduce) { * { scroll-behavior: auto !important; } }
+      @media print { body { background: #fff; } main { width: 100%; } header, section { break-inside: avoid; } }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>Talebook Audio CLI 独立客户端</h1>
+        <p>在 Talebook 仓库内新增可独立安装的 Python 命令行包，通过现有账号密码接口登录、浏览已发布有声书并以 mpv 播放。</p>
+        <div class="meta"><span>状态：ACTIVE</span><span>创建日期：2026-08-28</span><span>所属模块：packages</span><span>需求来源：HOU-20</span></div>
+      </header>
+
+      <section>
+        <h2>1. 原始诉求</h2>
+        <p>实现独立可安装、可运行的 Talebook 有声书命令行客户端；用户配置服务地址和账号后，以密码登录，浏览账号可访问的已生成有声书，选择章节播放，并支持暂停、继续、上一段、下一段、进度和可靠退出。</p>
+      </section>
+
+      <section>
+        <h2>2. 目标与边界</h2>
+        <table>
+          <thead><tr><th>目标</th><th>非目标</th></tr></thead>
+          <tbody><tr><td>独立 Python 包；兼容现有 Talebook API；密码不落盘；会话文件权限为 0600；mpv 前台受控播放；错误信息可行动。</td><td>不修改服务端接口；不生成有声书；不提供 GUI；首版不实现跨设备播放进度回写和 Windows 命名管道。</td></tr></tbody>
+        </table>
+      </section>
+
+      <section>
+        <h2>3. 现状证据与接口</h2>
+        <ul>
+          <li><code>POST /api/user/sign_in</code> 接受表单 username/password 并设置安全 Cookie。</li>
+          <li><code>GET /api/audios</code> 返回当前访问者可见的 published edition。</li>
+          <li><code>GET /api/audio/{edition_id}</code> 返回有序章节、时长和相对音频 URL。</li>
+          <li><code>GET /media/audio/{edition_id}/chapter/{number}.mp3</code> 支持 Range，且私有书依赖同一登录 Cookie。</li>
+          <li><code>neteasecli</code> 使用 mpv IPC 实现播放、暂停、切换、进度与退出控制，本实现沿用这一边界但保持前台进程归属。</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>4. 方案</h2>
+        <div class="flow">
+          <div><strong>配置</strong><br />仅保存规范化服务地址和用户名。</div>
+          <div><strong>登录</strong><br />getpass 或 stdin 读取密码，持久化 0600 CookieJar。</div>
+          <div><strong>浏览</strong><br />解析 books/edition/chapters，提供列表和交互选择。</div>
+          <div><strong>播放</strong><br />临时 mpv IPC socket；Cookie 文件供媒体请求；退出总是终止子进程。</div>
+        </div>
+        <p>包路径为 <code>packages/talebook-audio-cli</code>，命令名为 <code>talebook-audio</code>。CLI 子命令包括 <code>configure</code>、<code>login</code>、<code>logout</code>、<code>books</code>、<code>chapters</code> 和 <code>play</code>。未显式给出 book/chapter 时进入编号选择；播放循环支持暂停/继续、上一章、下一章、状态和退出。</p>
+      </section>
+
+      <section>
+        <h2>5. 安全、兼容性与风险</h2>
+        <ul>
+          <li>密码不进入命令行参数、日志、配置、Cookie 文件或异常文本；登录错误只展示服务端安全消息。</li>
+          <li>配置目录遵循 XDG，写入时使用原子替换和 0600 权限；服务 URL 拒绝凭据、查询和片段。</li>
+          <li>Cookie 通过 mpv 的 cookies-file 读取，进程参数不含 Cookie 值；临时 IPC 目录退出即清理。</li>
+          <li>风险：启用登录验证码的部署无法仅靠账号密码完成登录，CLI 会明确报告服务端 captcha 错误。</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>6. 测试计划与结果</h2>
+        <ul>
+          <li><strong>通过：</strong><code>PYTHONPATH=packages/talebook-audio-cli/src python3 -m pytest -q packages/talebook-audio-cli/tests</code>，21 个配置、登录响应、列表/manifest 解析、URL、mpv 缺失、播放器清理和 CLI 测试通过。</li>
+          <li><strong>通过：</strong><code>ruff check packages/talebook-audio-cli</code> 与 <code>ruff format --check packages/talebook-audio-cli</code>。</li>
+          <li><strong>通过：</strong><code>make lint-py-fix</code> 和 <code>make lint-py</code>；既有 102 个服务端 Python 文件无需修改。</li>
+          <li><strong>通过：</strong>使用本机 setuptools 以 <code>pip wheel --no-build-isolation --no-deps</code> 构建 <code>talebook_audio_cli-0.1.0-py3-none-any.whl</code>，随后安装到隔离临时目录并执行 <code>python3 -m talebook_audio_cli.cli --help</code>。</li>
+          <li><strong>环境受限：</strong><code>make pytest</code> 在收集既有服务端测试时因本机缺少 Calibre 出现 6 个 import error；错误发生在与本包无关的测试模块，未伪报为通过。</li>
+          <li><strong>界面审查：</strong>按 <code>interface-review full</code> 审查相对 <code>origin/master</code> 的全部 13 个未跟踪文件。首轮发现中英文混用、空状态无下一步、非 TTY 选择无法退出和窄终端 CJK 进度截断；全部修复后复审结论为 Approve，无 HIGH 或 MEDIUM 问题。无颜色、动画或 Web 页面变更。</li>
+          <li><strong>未验证：</strong>运行环境没有 mpv，也没有可登录的目标 Talebook 实例，因此未做真实音频渲染；风险由缺失依赖测试、IPC/清理单测、API 形状测试和使用文档覆盖，仍建议合并前在真实部署上做一次播放冒烟测试。</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>7. 决策记录</h2>
+        <ul>
+          <li>选择 Python 3.11 标准库，避免给 Talebook 服务端增加运行时依赖，包仍可独立发布安装。</li>
+          <li>不保存密码；“配置密码”由安全的交互式登录步骤承担，会话复用满足非浏览器 Cookie 导入要求。</li>
+          <li>不让 mpv detached/unref；客户端拥有播放器生命周期，SIGINT、正常退出和异常退出都回收进程。</li>
+        </ul>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design/packages/20260828-talebook-audio-mcp.active.html
+++ b/design/packages/20260828-talebook-audio-mcp.active.html
@@ -1,0 +1,145 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Talebook Audio CLI 通过 stdio MCP 接入 OpenXiaoAI Bridge 的实现方案。" />
+    <link rel="icon" href="data:," />
+    <title>Talebook Audio CLI MCP 接入 · ACTIVE</title>
+    <style>
+      :root { color-scheme: light; --ink: #172033; --muted: #5d6778; --line: #d9e0ea; --accent: #8b4f16; --panel: #fff; --good: #e8f5ee; }
+      * { box-sizing: border-box; }
+      html { scroll-behavior: smooth; }
+      body { margin: 0; color: var(--ink); background: #f5f7fb; font: 15px/1.65 system-ui, sans-serif; }
+      a { color: #315f91; text-underline-offset: 3px; }
+      a:focus-visible, [tabindex="0"]:focus-visible { outline: 3px solid var(--accent); outline-offset: 3px; }
+      .skip { position: fixed; top: 8px; left: 8px; z-index: 2; padding: 8px 12px; color: #fff; background: var(--ink); transform: translateY(-160%); }
+      .skip:focus { transform: translateY(0); }
+      main { width: min(1020px, calc(100vw - 32px)); margin: 32px auto; }
+      header, section { margin-bottom: 18px; padding: 24px; border: 1px solid var(--line); border-radius: 16px; background: var(--panel); }
+      h1, h2, h3 { margin-top: 0; line-height: 1.25; }
+      .meta { display: flex; flex-wrap: wrap; gap: 8px; color: var(--muted); }
+      .meta span { padding: 4px 10px; border-radius: 999px; background: #eef2f7; }
+      .meta .wip { color: var(--accent); background: #fff2e4; font-weight: 700; }
+      .flow { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; }
+      .flow div { padding: 14px; border: 1px solid var(--line); border-radius: 12px; }
+      .decision { padding: 14px 16px; border: 1px solid #b9dbc7; border-radius: 12px; background: var(--good); }
+      code { padding: 2px 5px; border-radius: 4px; background: #eef2f7; overflow-wrap: anywhere; }
+      pre { padding: 15px; overflow-x: auto; color: #eef3f8; background: #263244; border-radius: 12px; }
+      pre code { padding: 0; color: inherit; background: transparent; }
+      .table-wrap { overflow-x: auto; }
+      table { width: 100%; min-width: 700px; border-collapse: collapse; }
+      th, td { padding: 9px; border: 1px solid var(--line); text-align: left; vertical-align: top; }
+      th { background: #f6f8fb; }
+      .pending { color: var(--accent); font-weight: 700; }
+      @media (max-width: 720px) { main { width: calc(100vw - 20px); margin: 10px auto; } .flow { grid-template-columns: 1fr; } header, section { padding: 18px; } }
+      @media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } }
+      @media print { body { background: #fff; } main { width: 100%; margin: 0; } header, section, .flow div, .table-wrap { break-inside: avoid; } .skip { display: none; } }
+    </style>
+  </head>
+  <body>
+    <a class="skip" href="#content">跳到正文</a>
+    <main id="content">
+      <header>
+        <h1>Talebook Audio CLI MCP 接入</h1>
+        <p>让 OpenXiaoAI Bridge 像调用 neteasecli 一样，通过常驻 stdio MCP 子进程浏览和播放 Talebook 有声书，同时复用已验证的 Bridge StreamPlayer 后端。</p>
+        <div class="meta"><span>状态：ACTIVE</span><span>创建日期：2026-08-28</span><span>所属模块：packages</span><span>影响范围：CLI 协议、Bridge 配置与部署</span><span>需求来源：HOU-20</span></div>
+      </header>
+
+      <section>
+        <h2>1. 原始诉求</h2>
+        <p>“能不能与bridge接入个mcp，就是与网易cli与bridge接入mcp的方式一样”</p>
+        <p>现有 CLI 已能通过 <code>--player xiaoai</code> 调用 Bridge StreamPlayer，但 AI 对话还不能发现书目、选择章节或控制播放。本次把这些能力暴露成 MCP 工具，并接入用户指定的 <code>/opt/open-xiaoai-bridge</code> 实例。</p>
+      </section>
+
+      <section>
+        <h2>2. 目标与边界</h2>
+        <div class="table-wrap" role="region" aria-label="目标与边界" tabindex="0">
+          <table>
+            <thead><tr><th>目标</th><th>非目标</th></tr></thead>
+            <tbody><tr><td>提供 <code>talebook-audio mcp</code> stdio server；列书、列章节、按书或版本播放；暂停、恢复、停止、上一章、下一章和状态；播放结果返回 Bridge 静默结束信号；真实部署和工具调用可复现。</td><td>不通过 MCP 接收或保存密码；不修改 Talebook 服务端；不新增 HTTP MCP 监听；不把 Cookie、Bridge token 或请求头暴露给模型；不改变 neteasecli 工具。</td></tr></tbody>
+          </table>
+        </div>
+      </section>
+
+      <section>
+        <h2>3. 现状与证据</h2>
+        <ul>
+          <li><code>/opt/open-xiaoai-bridge/config.py</code> 已用 stdio 方式常驻启动 <code>neteasecli mcp</code>，并由 <code>MCPClientManager</code> 聚合工具。</li>
+          <li>Bridge 识别 <code>structuredContent["x-open-xiaoai-bridge"]</code> 的 <code>end_turn_silently / playback_started</code> 信号；播放工具必须复用该契约。</li>
+          <li>Talebook CLI 已具备安全登录会话、书目与章节解析，以及 OpenXiaoAI StreamPlayer 的播放和控制能力。</li>
+          <li>MCP 官方 Python SDK 在 Bridge 的 <code>/app/.venv</code> 中可用；宿主机未安装，因此 SDK 作为可选依赖并保持普通 CLI 无额外依赖。</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>4. 方案</h2>
+        <div class="decision"><strong>方案结论：</strong>在 CLI 包内新增异步 MCP 控制器与官方 SDK stdio 入口。控制器持有当前 Talebook 章节队列和 Bridge 播放器；所有阻塞 HTTP 调用通过工作线程执行，后台监控在章节结束时自动续播。部署只挂载 CLI 源码和受权限保护的会话目录，Bridge token 使用既有只读路径。</div>
+        <div class="flow" aria-label="MCP 调用流程">
+          <div><strong>语音意图</strong><br />Bridge 的 OpenAI 后端选择 Talebook MCP 工具。</div>
+          <div><strong>stdio MCP</strong><br />官方 SDK 校验参数并调用异步控制器。</div>
+          <div><strong>Talebook + Bridge</strong><br />读取已保存会话，解析书目和章节，将公开音频 URL 交给 StreamPlayer。</div>
+          <div><strong>结果</strong><br />查询返回文本与结构化数据；播放返回静默结束信号。</div>
+        </div>
+        <h3>工具与状态</h3>
+        <div class="table-wrap" role="region" aria-label="MCP 工具" tabindex="0">
+          <table>
+            <thead><tr><th>工具</th><th>输入</th><th>语义</th></tr></thead>
+            <tbody>
+              <tr><td><code>list_audiobooks</code></td><td>可选 <code>query</code></td><td>列出当前账号可访问的已发布有声书，并返回 book/edition ID。</td></tr>
+              <tr><td><code>list_chapters</code></td><td><code>edition_id</code></td><td>列章节编号、标题和时长。</td></tr>
+              <tr><td><code>play_audiobook</code></td><td>edition/book/query 三选一；可选 chapter</td><td>建立章节队列并开始播放，返回静默结束信号。</td></tr>
+              <tr><td><code>next_chapter</code> / <code>previous_chapter</code></td><td>无</td><td>在当前队列切章并返回静默结束信号。</td></tr>
+              <tr><td><code>pause</code> / <code>resume</code> / <code>stop</code> / <code>status</code></td><td>无</td><td>确定性控制并报告当前书、章节、进度和队列位置。</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <pre aria-label="Bridge 配置示例"><code>"talebook_audio": {
+  "type": "stdio",
+  "command": "/app/.venv/bin/python",
+  "args": ["-m", "talebook_audio_cli.cli", "mcp"],
+  "env": {"PYTHONPATH": "/opt/talebook-audio-cli/src", "TALEBOOK_AUDIO_PLAYER": "xiaoai"},
+  "cwd": "/opt/talebook-audio-cli",
+  "timeout": 180
+}</code></pre>
+      </section>
+
+      <section>
+        <h2>5. 影响范围、风险与回滚</h2>
+        <ul>
+          <li><strong>代码：</strong>新增 MCP server/controller、CLI 子命令、可选 SDK 依赖、测试和文档；普通命令保持兼容。</li>
+          <li><strong>部署：</strong>新增只读 CLI 源码挂载、读写会话目录挂载和一个 MCP server 配置；Bridge 容器需重建一次。</li>
+          <li><strong>凭据：</strong>管理员先在宿主机登录一次；MCP 不接收密码。会话目录和 Cookie 保持 0600，Bridge token 不进入工具参数或结果。</li>
+          <li><strong>风险：</strong>完整章节下载会让播放工具调用持续约 14 秒；timeout 设为 180 秒。后台自动续播和显式切章可能竞态，使用单一异步锁与监控任务串行化。</li>
+          <li><strong>回滚：</strong>从 <code>mcp_servers</code> 删除 <code>talebook_audio</code> 并移除两项挂载后重建单个容器；CLI 代码回滚为独立提交，不涉及数据迁移。</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>6. 测试计划与结果</h2>
+        <div class="table-wrap" role="region" aria-label="测试计划" tabindex="0">
+          <table>
+            <thead><tr><th>验证层</th><th>命令或场景</th><th>预期</th><th>结果</th></tr></thead>
+            <tbody>
+              <tr><td>单元</td><td><code>PYTHONPATH=packages/talebook-audio-cli/src python3 -m pytest packages/talebook-audio-cli/tests</code></td><td>工具选择、队列、控制、静默信号、错误和既有 CLI 全通过。</td><td>通过，30 passed。</td></tr>
+              <tr><td>协议</td><td>容器内官方 MCP ClientSession 初始化、列工具并依次调用 9 个工具</td><td>stdio 无协议污染，schema 与 structuredContent 正确。</td><td>通过，退出码 0；发现 9 个工具，静默播放信号与 Bridge 契约完全一致。</td></tr>
+              <tr><td>真实部署</td><td><code>/opt/open-xiaoai-bridge</code> 容器</td><td>连接两个 MCP server；Talebook 工具可列书、播放、暂停、恢复、切章和停止。</td><td>通过；Bridge 同时连接 neteasecli 13 个工具与 talebook_audio 9 个工具。真实列出《西游记》3 章，完成首章播放、暂停、恢复、下一章、上一章和停止，最终 idle，容器 healthy。</td></tr>
+              <tr><td>质量门禁</td><td><code>ruff check</code>、<code>ruff format --check</code>、<code>make lint-py-fix</code>、<code>make lint-py</code>、<code>make check-design</code></td><td>相关门禁通过。</td><td>ruff 与 lint 通过；check-design 共 111 份方案通过。<code>make pytest</code> 因宿主机缺少 Calibre，在 6 个既有服务端模块收集阶段失败，与本包无关；独立包 30 项测试全通过。</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p>纯 CLI 协议与部署改动，无 Web 页面、布局、视觉资源或前端消费者，因此界面审查豁免。</p>
+      </section>
+
+      <section>
+        <h2>7. 决策记录</h2>
+        <ol>
+          <li><strong>2026-08-28：</strong>用户明确要求复用 neteasecli → Bridge 的 MCP 方式；选择 stdio 而非新增网络监听。</li>
+          <li><strong>2026-08-28：</strong>不提供登录 MCP 工具，避免模型上下文和工具参数承载密码；采用管理员预登录的 0600 会话目录。</li>
+          <li><strong>2026-08-28：</strong>使用官方 SDK 作为可选依赖；Bridge 部署复用其现有 SDK，普通 CLI 仍保持零运行时依赖。</li>
+        </ol>
+      </section>
+      <footer>Talebook internal design · packages · ACTIVE · 2026-08-28</footer>
+    </main>
+  </body>
+</html>

--- a/packages/talebook-audio-cli/README.md
+++ b/packages/talebook-audio-cli/README.md
@@ -1,11 +1,11 @@
 # Talebook Audio CLI
 
-`talebook-audio` 是一个独立安装的 Talebook 有声书终端客户端。它使用 Talebook 自带的账号密码登录接口，列出当前账号可访问的已发布有声书，并通过 `mpv` 播放章节。
+`talebook-audio` 是一个独立安装的 Talebook 有声书终端客户端。它使用 Talebook 自带的账号密码登录接口，列出当前账号可访问的已发布有声书，并可通过本机 `mpv` 或 OpenXiaoAI Bridge 在小爱音箱上播放章节。
 
 ## 依赖与安装
 
 - Python 3.11 或更高版本
-- `mpv`（需要在 `PATH` 中可执行）
+- 本机播放需要 `mpv`（需要在 `PATH` 中可执行）；小爱音箱播放不依赖 `mpv`
 - 支持有声书 API 的 Talebook 服务端
 
 从 Talebook 仓库安装：
@@ -62,6 +62,24 @@ talebook-audio play --book-id 42 --chapter 3
 talebook-audio play --edition-id 12 --chapter 3
 ```
 
+### 通过 OpenXiaoAI Bridge 播放
+
+Bridge 播放使用它的带鉴权 StreamPlayer API，支持进度、暂停/继续和切章。Bridge 默认地址是
+`http://127.0.0.1:9092`，token 默认从
+`$XDG_CONFIG_HOME/open-xiaoai-bridge/api-token`（未设置时为
+`~/.config/open-xiaoai-bridge/api-token`）读取；token 文件权限必须是 `0600`。
+
+```bash
+OPENXIAOAI_API_TOKEN_FILE=/path/to/open-xiaoai-bridge/api-token \
+  talebook-audio play --player xiaoai --edition-id 12 --chapter 3
+```
+
+也可以设置 `TALEBOOK_AUDIO_PLAYER=xiaoai` 作为默认播放后端。Bridge 位于其他主机时，通过
+`OPENXIAOAI_BASE_URL=https://speaker.example.com:9092` 指定地址；非本机明文 HTTP 默认拒绝。
+自签 CA 和 mTLS 可分别使用 `OPENXIAOAI_TLS_CA`、`OPENXIAOAI_TLS_CLIENT_CERT`、
+`OPENXIAOAI_TLS_CLIENT_KEY`。如确实处于可信内网且正在迁移，可显式设置
+`OPENXIAOAI_ALLOW_INSECURE_HTTP=1` 临时允许非本机 HTTP。
+
 播放时可使用单键控制：
 
 - `Space` 或 `p`：暂停/继续
@@ -70,7 +88,7 @@ talebook-audio play --edition-id 12 --chapter 3
 - `s`：立即刷新进度
 - `q`：退出
 
-客户端持续显示当前章节、播放状态和 `已播放/总时长`。到达章节结尾会自动播放下一章；最后一章结束后退出。正常退出、`Ctrl-C` 或异常都会要求 mpv 退出，超时后依次 terminate/kill，不遗留失控的播放器进程。
+客户端持续显示当前章节、播放状态和 `已播放/总时长`。到达章节结尾会自动播放下一章；最后一章结束后退出。正常退出、`Ctrl-C` 或异常都会停止当前后端；mpv 超时退出时会依次 terminate/kill，Bridge 后端会调用 `/api/stream/stop`，不遗留失控的播放。
 
 ## 常见错误
 
@@ -79,6 +97,7 @@ talebook-audio play --edition-id 12 --chapter 3
 - `无法连接 Talebook`：检查服务地址、TLS 证书和网络。
 - `没有可播放的有声书/章节`：需要先在 Talebook 中生成并发布有声版本。
 - `找不到 mpv`：安装 mpv 并确认 `mpv --version` 可运行。
+- `找不到 Bridge API token`：检查 Bridge 是否至少成功启动过一次，或设置 `OPENXIAOAI_API_TOKEN_FILE`。
 - `音频不可用`：登录态可能已过期，重新登录；也可能是书籍权限或服务端音频文件已变化。
 
 客户端不会在普通输出或异常信息中打印密码、Cookie 值或完整请求头。

--- a/packages/talebook-audio-cli/README.md
+++ b/packages/talebook-audio-cli/README.md
@@ -80,6 +80,58 @@ OPENXIAOAI_API_TOKEN_FILE=/path/to/open-xiaoai-bridge/api-token \
 `OPENXIAOAI_TLS_CLIENT_KEY`。如确实处于可信内网且正在迁移，可显式设置
 `OPENXIAOAI_ALLOW_INSECURE_HTTP=1` 临时允许非本机 HTTP。
 
+### MCP server 模式
+
+安装可选 MCP 依赖后，CLI 可以像 neteasecli 一样作为 stdio MCP server 被
+OpenXiaoAI Bridge 常驻启动：
+
+```bash
+python3 -m pip install 'talebook-audio-cli[mcp]'
+talebook-audio mcp
+```
+
+MCP 工具包括：
+
+- `list_audiobooks`、`list_chapters`：浏览当前登录账号可访问的有声书和章节。
+- `play_audiobook`：按 edition ID、book ID 或书名/作者查询开始播放，可指定起始章节。
+- `next_chapter`、`previous_chapter`：切换当前章节队列。
+- `pause`、`resume`、`stop`、`status`：控制和查询播放。
+
+MCP 不提供登录工具，也不接收密码。管理员应先运行 `configure` 和 `login`，再把对应的
+XDG 配置目录挂载给 Bridge MCP 子进程。`play_audiobook` 和切章工具会返回
+OpenXiaoAI Bridge 的 `end_turn_silently / playback_started` 控制信号，避免音频开始后 AI
+继续播放一段 TTS。与 neteasecli 同时启用时，Bridge 会给重名的 `pause`、`resume`、
+`stop`、`status` 自动加 `talebook_audio_` 命名空间前缀。
+
+Bridge 容器需要两个挂载：CLI 源码只读，会话目录读写。例如：
+
+```yaml
+volumes:
+  - /opt/talebook-audio-cli:/opt/talebook-audio-cli:ro
+  - /opt/talebook-audio-cli-data:/root/.config/talebook-audio-cli
+```
+
+对应的 stdio 配置示例：
+
+```python
+"talebook_audio": {
+    "type": "stdio",
+    "command": "/app/.venv/bin/python",
+    "args": ["-m", "talebook_audio_cli.cli", "mcp"],
+    "env": {
+        "HOME": "/root",
+        "PATH": "/app/.venv/bin:/usr/local/bin:/usr/bin:/bin",
+        "PYTHONPATH": "/opt/talebook-audio-cli/src",
+        "XDG_CONFIG_HOME": "/root/.config/talebook-audio-cli",
+        "OPENXIAOAI_BASE_URL": "http://127.0.0.1:9092",
+        "OPENXIAOAI_API_TOKEN_FILE": "/root/.config/open-xiaoai-bridge/api-token",
+    },
+    "cwd": "/opt/talebook-audio-cli",
+    "enabled": True,
+    "timeout": 180,
+},
+```
+
 播放时可使用单键控制：
 
 - `Space` 或 `p`：暂停/继续

--- a/packages/talebook-audio-cli/README.md
+++ b/packages/talebook-audio-cli/README.md
@@ -1,0 +1,84 @@
+# Talebook Audio CLI
+
+`talebook-audio` 是一个独立安装的 Talebook 有声书终端客户端。它使用 Talebook 自带的账号密码登录接口，列出当前账号可访问的已发布有声书，并通过 `mpv` 播放章节。
+
+## 依赖与安装
+
+- Python 3.11 或更高版本
+- `mpv`（需要在 `PATH` 中可执行）
+- 支持有声书 API 的 Talebook 服务端
+
+从 Talebook 仓库安装：
+
+```bash
+python3 -m pip install ./packages/talebook-audio-cli
+talebook-audio --help
+```
+
+开发安装与测试：
+
+```bash
+python3 -m pip install -e './packages/talebook-audio-cli[test]'
+python3 -m pytest packages/talebook-audio-cli/tests
+```
+
+## 配置与登录
+
+先保存服务地址和账号。地址必须是 `http` 或 `https`，不能包含 URL 用户名、密码、查询参数或片段。
+
+```bash
+talebook-audio configure --server https://books.example.com --username alice
+talebook-audio login
+```
+
+`login` 使用隐藏输入读取密码。自动化场景可从标准输入读取，避免密码出现在命令历史和进程参数中：
+
+```bash
+printf '%s\n' "$TALEBOOK_PASSWORD" | talebook-audio login --password-stdin
+```
+
+客户端只保存服务地址、用户名和 Talebook 登录 Cookie，不保存密码。配置和 Cookie 默认位于 `$XDG_CONFIG_HOME/talebook-audio/`（未设置时为 `~/.config/talebook-audio/`），文件权限为 `0600`。Cookie 过期后再次执行 `talebook-audio login` 即可。
+
+退出并删除本地会话：
+
+```bash
+talebook-audio logout
+```
+
+## 浏览与播放
+
+```bash
+# 列出当前账号可访问且已有已发布音频的书籍
+talebook-audio books
+
+# 查看一个有声版本的章节；edition id 可从 books 输出获得
+talebook-audio chapters 12
+
+# 交互选择书籍和起始章节
+talebook-audio play
+
+# 按书籍或有声版本直接播放，并从指定章节编号开始
+talebook-audio play --book-id 42 --chapter 3
+talebook-audio play --edition-id 12 --chapter 3
+```
+
+播放时可使用单键控制：
+
+- `Space` 或 `p`：暂停/继续
+- `n`：下一章
+- `b`：上一章
+- `s`：立即刷新进度
+- `q`：退出
+
+客户端持续显示当前章节、播放状态和 `已播放/总时长`。到达章节结尾会自动播放下一章；最后一章结束后退出。正常退出、`Ctrl-C` 或异常都会要求 mpv 退出，超时后依次 terminate/kill，不遗留失控的播放器进程。
+
+## 常见错误
+
+- `未配置 Talebook`：先运行 `configure`。
+- `登录失败`：检查账号、密码和账号权限；开启登录验证码的部署会返回验证码错误，首版 CLI 不绕过验证码。
+- `无法连接 Talebook`：检查服务地址、TLS 证书和网络。
+- `没有可播放的有声书/章节`：需要先在 Talebook 中生成并发布有声版本。
+- `找不到 mpv`：安装 mpv 并确认 `mpv --version` 可运行。
+- `音频不可用`：登录态可能已过期，重新登录；也可能是书籍权限或服务端音频文件已变化。
+
+客户端不会在普通输出或异常信息中打印密码、Cookie 值或完整请求头。

--- a/packages/talebook-audio-cli/pyproject.toml
+++ b/packages/talebook-audio-cli/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=66"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "talebook-audio-cli"
+version = "0.1.0"
+description = "A secure terminal client for Talebook audiobooks"
+readme = "README.md"
+requires-python = ">=3.11"
+license = {text = "GPL-3.0-or-later"}
+authors = [{name = "Talebook contributors"}]
+dependencies = []
+
+[project.optional-dependencies]
+test = ["pytest>=7.4"]
+
+[project.scripts]
+talebook-audio = "talebook_audio_cli.cli:entrypoint"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/packages/talebook-audio-cli/pyproject.toml
+++ b/packages/talebook-audio-cli/pyproject.toml
@@ -13,6 +13,7 @@ authors = [{name = "Talebook contributors"}]
 dependencies = []
 
 [project.optional-dependencies]
+mcp = ["mcp>=1.12,<2"]
 test = ["pytest>=7.4"]
 
 [project.scripts]

--- a/packages/talebook-audio-cli/src/talebook_audio_cli/__init__.py
+++ b/packages/talebook-audio-cli/src/talebook_audio_cli/__init__.py
@@ -1,0 +1,3 @@
+"""Talebook audiobook terminal client."""
+
+__version__ = "0.1.0"

--- a/packages/talebook-audio-cli/src/talebook_audio_cli/bridge.py
+++ b/packages/talebook-audio-cli/src/talebook_audio_cli/bridge.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import ipaddress
+import json
+import os
+import re
+import ssl
+import stat
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+from urllib.parse import urlsplit, urlunsplit
+
+
+class BridgeError(RuntimeError):
+    """A user-safe OpenXiaoAI Bridge error."""
+
+
+@dataclass(frozen=True, slots=True)
+class BridgeStatus:
+    state: str
+    position_ms: int
+    duration_ms: int
+
+    @property
+    def paused(self) -> bool:
+        return self.state == "paused"
+
+    @property
+    def playing(self) -> bool:
+        return self.state in {"playing", "paused"}
+
+
+def _enabled(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _is_loopback(hostname: str) -> bool:
+    if hostname.lower() == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(hostname).is_loopback
+    except ValueError:
+        return False
+
+
+def bridge_base_url(value: str | None = None) -> str:
+    raw = (value or os.environ.get("OPENXIAOAI_BASE_URL") or "http://127.0.0.1:9092").strip()
+    try:
+        parsed = urlsplit(raw)
+        port = parsed.port
+    except ValueError as exc:
+        raise BridgeError("OPENXIAOAI_BASE_URL 不是有效的 URL") from exc
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise BridgeError("OPENXIAOAI_BASE_URL 必须是有效的 http 或 https URL")
+    if parsed.username or parsed.password or parsed.query or parsed.fragment:
+        raise BridgeError("OPENXIAOAI_BASE_URL 不能包含凭据、查询参数或片段")
+    if parsed.path.rstrip("/"):
+        raise BridgeError("OPENXIAOAI_BASE_URL 不能包含路径")
+    if parsed.scheme == "http" and not _is_loopback(parsed.hostname) and not _enabled("OPENXIAOAI_ALLOW_INSECURE_HTTP"):
+        raise BridgeError("拒绝通过明文 HTTP 连接非本机 Bridge；请配置 HTTPS")
+    hostname = parsed.hostname.lower()
+    if ":" in hostname and not hostname.startswith("["):
+        hostname = f"[{hostname}]"
+    netloc = hostname + (f":{port}" if port is not None else "")
+    return urlunsplit((parsed.scheme.lower(), netloc, "", "", ""))
+
+
+def bridge_token_file() -> Path:
+    configured = os.environ.get("OPENXIAOAI_API_TOKEN_FILE")
+    if configured:
+        return Path(configured).expanduser()
+    config_home = os.environ.get("XDG_CONFIG_HOME")
+    root = Path(config_home).expanduser() if config_home else Path.home() / ".config"
+    return root / "open-xiaoai-bridge" / "api-token"
+
+
+def load_bridge_token() -> str:
+    explicit = os.environ.get("OPENXIAOAI_API_TOKEN", "").strip()
+    if explicit:
+        if len(explicit) < 32:
+            raise BridgeError("OPENXIAOAI_API_TOKEN 至少需要 32 个字符")
+        return explicit
+    path = bridge_token_file()
+    try:
+        metadata = path.stat()
+        if os.name != "nt" and stat.S_IMODE(metadata.st_mode) & 0o077:
+            raise BridgeError(f"Bridge token 文件权限过宽；请执行 chmod 600 {path}")
+        token = path.read_text(encoding="utf-8").strip()
+    except BridgeError:
+        raise
+    except OSError as exc:
+        raise BridgeError("找不到 Bridge API token；请启动 OpenXiaoAI Bridge，或设置 OPENXIAOAI_API_TOKEN_FILE") from exc
+    if len(token) < 32:
+        raise BridgeError("Bridge API token 文件为空或长度不足")
+    return token
+
+
+def _ssl_context() -> ssl.SSLContext:
+    ca_file = os.environ.get("OPENXIAOAI_TLS_CA") or None
+    cert_file = os.environ.get("OPENXIAOAI_TLS_CLIENT_CERT") or None
+    key_file = os.environ.get("OPENXIAOAI_TLS_CLIENT_KEY") or None
+    if bool(cert_file) != bool(key_file):
+        raise BridgeError("OPENXIAOAI_TLS_CLIENT_CERT 和 OPENXIAOAI_TLS_CLIENT_KEY 必须同时设置")
+    try:
+        context = ssl.create_default_context(cafile=ca_file)
+        context.minimum_version = ssl.TLSVersion.TLSv1_2
+        if cert_file and key_file:
+            context.load_cert_chain(cert_file, key_file)
+    except (OSError, ssl.SSLError) as exc:
+        raise BridgeError("无法加载 Bridge TLS 配置") from exc
+    return context
+
+
+def _sanitize(value: object) -> str:
+    text = str(value or "未知错误")
+    text = re.sub(r"(?i)bearer\s+[a-z0-9._~+/-]+", "Bearer <redacted>", text)
+    text = re.sub(
+        r"(?i)(api[_ -]?key|authorization|token)(\s*[:=]\s*)\S+",
+        r"\1\2<redacted>",
+        text,
+    )
+    return " ".join(text.split())[:300]
+
+
+class BridgeClient:
+    def __init__(
+        self,
+        *,
+        base_url: str | None = None,
+        token: str | None = None,
+        timeout: float = 150.0,
+    ):
+        self.base_url = bridge_base_url(base_url)
+        self.token = token or load_bridge_token()
+        if len(self.token) < 32:
+            raise BridgeError("Bridge API token 至少需要 32 个字符")
+        self.timeout = timeout
+        self.opener = urllib.request.build_opener(urllib.request.HTTPSHandler(context=_ssl_context()))
+
+    def _request(
+        self,
+        path: str,
+        *,
+        method: str = "GET",
+        payload: Mapping[str, Any] | None = None,
+    ) -> Mapping[str, Any]:
+        body = json.dumps(payload).encode("utf-8") if payload is not None else None
+        request = urllib.request.Request(
+            self.base_url + path,
+            data=body,
+            method=method,
+            headers={
+                "Accept": "application/json",
+                "Authorization": f"Bearer {self.token}",
+                "Content-Type": "application/json",
+                "User-Agent": "talebook-audio-cli/0.1",
+            },
+        )
+        try:
+            with self.opener.open(request, timeout=self.timeout) as response:
+                raw = response.read(2 * 1024 * 1024 + 1)
+                if len(raw) > 2 * 1024 * 1024:
+                    raise BridgeError("Bridge 响应过大")
+        except urllib.error.HTTPError as exc:
+            try:
+                response_data = json.loads(exc.read(64 * 1024).decode("utf-8"))
+                reason = response_data.get("error") if isinstance(response_data, dict) else None
+            except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+                reason = None
+            raise BridgeError(f"Bridge {method} {path} 失败（HTTP {exc.code}）：{_sanitize(reason or exc.reason)}") from exc
+        except BridgeError:
+            raise
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            reason = getattr(exc, "reason", None) or exc.__class__.__name__
+            raise BridgeError(f"无法连接 OpenXiaoAI Bridge（{_sanitize(reason)}）") from exc
+        try:
+            result = json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise BridgeError("Bridge 返回了无法解析的响应") from exc
+        if not isinstance(result, dict):
+            raise BridgeError("Bridge 返回的数据格式无效")
+        if result.get("success") is not True:
+            raise BridgeError(f"Bridge 操作失败：{_sanitize(result.get('error'))}")
+        return result
+
+    @staticmethod
+    def _status(result: Mapping[str, Any]) -> BridgeStatus:
+        data = result.get("data")
+        if not isinstance(data, dict):
+            raise BridgeError("Bridge 播放状态格式无效")
+        state = str(data.get("state") or "idle")
+        if state not in {"idle", "playing", "paused"}:
+            raise BridgeError("Bridge 返回了未知播放状态")
+        try:
+            position_ms = max(0, int(data.get("position_ms") or 0))
+            duration_ms = max(0, int(data.get("duration_ms") or 0))
+        except (TypeError, ValueError) as exc:
+            raise BridgeError("Bridge 播放进度格式无效") from exc
+        return BridgeStatus(state, position_ms, duration_ms)
+
+    def play(self, url: str) -> BridgeStatus:
+        return self._status(self._request("/api/stream/play", method="POST", payload={"url": url}))
+
+    def status(self) -> BridgeStatus:
+        return self._status(self._request("/api/stream/status"))
+
+    def pause(self) -> BridgeStatus:
+        return self._status(self._request("/api/stream/pause", method="POST", payload={}))
+
+    def resume(self) -> BridgeStatus:
+        return self._status(self._request("/api/stream/resume", method="POST", payload={}))
+
+    def stop(self) -> BridgeStatus:
+        return self._status(self._request("/api/stream/stop", method="POST", payload={}))

--- a/packages/talebook-audio-cli/src/talebook_audio_cli/cli.py
+++ b/packages/talebook-audio-cli/src/talebook_audio_cli/cli.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import argparse
+import getpass
+import sys
+from collections.abc import Sequence
+
+from .client import TalebookClient, TalebookError
+from .config import AppPaths, Config, ConfigError, load_config, save_config
+from .models import Audiobook, Chapter
+from .player import MpvPlayer, PlayerError, format_time
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="talebook-audio", description="浏览和播放 Talebook 已发布的有声书")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    configure = subparsers.add_parser("configure", help="保存 Talebook 服务地址和用户名")
+    configure.add_argument("--server", required=True, help="Talebook 根地址，例如 https://books.example.com")
+    configure.add_argument("--username", required=True, help="Talebook 用户名")
+
+    login = subparsers.add_parser("login", help="使用账号密码登录并保存会话")
+    login.add_argument("--password-stdin", action="store_true", help="从标准输入读取一行密码")
+
+    subparsers.add_parser("logout", help="删除本地登录会话")
+    subparsers.add_parser("books", help="列出可访问的已发布有声书")
+
+    chapters = subparsers.add_parser("chapters", help="列出有声版本章节")
+    chapters.add_argument("edition_id", type=int, help="有声版本 ID（见 books 输出）")
+
+    play = subparsers.add_parser("play", help="选择并播放有声书")
+    choice = play.add_mutually_exclusive_group()
+    choice.add_argument("--book-id", type=int, help="直接选择书籍 ID")
+    choice.add_argument("--edition-id", type=int, help="直接选择有声版本 ID")
+    play.add_argument("--chapter", type=int, help="从章节编号开始")
+    return parser
+
+
+def _client(paths: AppPaths) -> TalebookClient:
+    return TalebookClient(load_config(paths), paths)
+
+
+def _print_books(books: Sequence[Audiobook]) -> None:
+    if not books:
+        print("当前账号没有可播放的已发布有声书；请先在 Talebook 中生成并发布有声版本")
+        return
+    for book in books:
+        print(f"{book.title} — {book.author}")
+        print(
+            f"  书籍 ID：{book.book_id}  有声版本 ID：{book.edition_id}  "
+            f"章节：{book.chapter_count}  时长：{format_time(book.duration_ms / 1000)}"
+        )
+
+
+def _print_chapters(chapters: Sequence[Chapter]) -> None:
+    if not chapters:
+        print("这个有声版本没有可播放章节；请在 Talebook 中检查生成和发布状态")
+        return
+    for chapter in chapters:
+        print(f"{chapter.number:>3}. {chapter.title}（{format_time(chapter.duration_ms / 1000)}）")
+
+
+def _select(prompt: str, length: int) -> int:
+    if not sys.stdin.isatty():
+        raise TalebookError("交互选择需要终端；请使用 --book-id 或 --edition-id，并用 --chapter 指定起始章节")
+    while True:
+        try:
+            value = int(input(prompt).strip())
+        except EOFError as exc:
+            raise TalebookError("没有读到选择；请重新运行命令并输入编号") from exc
+        except ValueError:
+            print(f"请输入 1 到 {length} 的编号", file=sys.stderr)
+            continue
+        if 1 <= value <= length:
+            return value - 1
+        print(f"请输入 1 到 {length} 的编号", file=sys.stderr)
+
+
+def _find_book(books: Sequence[Audiobook], book_id: int | None, edition_id: int | None) -> Audiobook:
+    if book_id is None and edition_id is None:
+        for index, book in enumerate(books, 1):
+            print(f"{index:>3}. {book.title} — {book.author}（{book.chapter_count} 章）")
+        return books[_select("选择书籍：", len(books))]
+    for book in books:
+        if book_id is not None and book.book_id == book_id:
+            return book
+        if edition_id is not None and book.edition_id == edition_id:
+            return book
+    target = f"书籍 ID {book_id}" if book_id is not None else f"有声版本 ID {edition_id}"
+    raise TalebookError(f"当前账号的有声书列表中找不到 {target}")
+
+
+def _chapter_index(chapters: Sequence[Chapter], requested: int | None) -> int:
+    if requested is not None:
+        for index, chapter in enumerate(chapters):
+            if chapter.number == requested:
+                return index
+        raise TalebookError(f"找不到章节编号 {requested}")
+    for index, chapter in enumerate(chapters, 1):
+        print(f"{index:>3}. {chapter.title}（{format_time(chapter.duration_ms / 1000)}）")
+    return _select("选择起始章节：", len(chapters))
+
+
+def main(argv: Sequence[str] | None = None, *, paths: AppPaths | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    app_paths = paths or AppPaths.default()
+    try:
+        if args.command == "configure":
+            save_config(Config(server=args.server, username=args.username), app_paths)
+            print(f"配置已保存：{load_config(app_paths).server}（用户 {load_config(app_paths).username}）")
+            return 0
+
+        client = _client(app_paths)
+        if args.command == "login":
+            password = sys.stdin.readline().rstrip("\r\n") if args.password_stdin else getpass.getpass("Talebook 密码：")
+            client.login(password)
+            print(f"登录成功：{client.config.username}")
+            return 0
+        if args.command == "logout":
+            client.logout()
+            print("本地登录会话已删除")
+            return 0
+        if args.command == "books":
+            _print_books(client.list_audiobooks())
+            return 0
+        if args.command == "chapters":
+            client.require_login()
+            _print_chapters(client.list_chapters(args.edition_id))
+            return 0
+        if args.command == "play":
+            books = client.list_audiobooks()
+            if not books:
+                raise TalebookError("当前账号没有可播放的已发布有声书；请先在 Talebook 中生成并发布有声版本")
+            book = _find_book(books, args.book_id, args.edition_id)
+            chapters = client.list_chapters(book.edition_id)
+            if not chapters:
+                raise TalebookError("这个有声版本没有可播放章节；请在 Talebook 中检查生成和发布状态")
+            start_index = _chapter_index(chapters, args.chapter)
+            MpvPlayer(chapters, app_paths.cookie_file).run(start_index)
+            return 0
+    except (ConfigError, TalebookError, PlayerError) as exc:
+        print(f"错误：{exc}", file=sys.stderr)
+        return 2
+    except KeyboardInterrupt:
+        print("\n已停止", file=sys.stderr)
+        return 130
+    return 0
+
+
+def entrypoint() -> None:
+    raise SystemExit(main())
+
+
+if __name__ == "__main__":
+    entrypoint()

--- a/packages/talebook-audio-cli/src/talebook_audio_cli/cli.py
+++ b/packages/talebook-audio-cli/src/talebook_audio_cli/cli.py
@@ -25,6 +25,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     subparsers.add_parser("logout", help="删除本地登录会话")
     subparsers.add_parser("books", help="列出可访问的已发布有声书")
+    subparsers.add_parser("mcp", help="以 stdio MCP server 模式运行，供 OpenXiaoAI Bridge 等客户端调用")
 
     chapters = subparsers.add_parser("chapters", help="列出有声版本章节")
     chapters.add_argument("edition_id", type=int, help="有声版本 ID（见 books 输出）")
@@ -114,6 +115,15 @@ def main(argv: Sequence[str] | None = None, *, paths: AppPaths | None = None) ->
         if args.command == "configure":
             save_config(Config(server=args.server, username=args.username), app_paths)
             print(f"配置已保存：{load_config(app_paths).server}（用户 {load_config(app_paths).username}）")
+            return 0
+        if args.command == "mcp":
+            from .mcp_server import McpServerError, run_mcp_server
+
+            try:
+                run_mcp_server()
+            except McpServerError as exc:
+                print(f"错误：{exc}", file=sys.stderr)
+                return 2
             return 0
 
         client = _client(app_paths)

--- a/packages/talebook-audio-cli/src/talebook_audio_cli/cli.py
+++ b/packages/talebook-audio-cli/src/talebook_audio_cli/cli.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 import argparse
 import getpass
+import os
 import sys
 from collections.abc import Sequence
 
 from .client import TalebookClient, TalebookError
 from .config import AppPaths, Config, ConfigError, load_config, save_config
 from .models import Audiobook, Chapter
-from .player import MpvPlayer, PlayerError, format_time
+from .player import MpvPlayer, PlayerError, XiaoAiPlayer, format_time
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -33,6 +34,11 @@ def build_parser() -> argparse.ArgumentParser:
     choice.add_argument("--book-id", type=int, help="直接选择书籍 ID")
     choice.add_argument("--edition-id", type=int, help="直接选择有声版本 ID")
     play.add_argument("--chapter", type=int, help="从章节编号开始")
+    play.add_argument(
+        "--player",
+        choices=("mpv", "xiaoai"),
+        help="播放后端；默认读取 TALEBOOK_AUDIO_PLAYER，未设置时使用 mpv",
+    )
     return parser
 
 
@@ -136,7 +142,13 @@ def main(argv: Sequence[str] | None = None, *, paths: AppPaths | None = None) ->
             if not chapters:
                 raise TalebookError("这个有声版本没有可播放章节；请在 Talebook 中检查生成和发布状态")
             start_index = _chapter_index(chapters, args.chapter)
-            MpvPlayer(chapters, app_paths.cookie_file).run(start_index)
+            player_backend = (args.player or os.environ.get("TALEBOOK_AUDIO_PLAYER") or "mpv").lower()
+            if player_backend == "mpv":
+                MpvPlayer(chapters, app_paths.cookie_file).run(start_index)
+            elif player_backend == "xiaoai":
+                XiaoAiPlayer(chapters).run(start_index)
+            else:
+                raise ConfigError("TALEBOOK_AUDIO_PLAYER 只支持 mpv 或 xiaoai")
             return 0
     except (ConfigError, TalebookError, PlayerError) as exc:
         print(f"错误：{exc}", file=sys.stderr)

--- a/packages/talebook-audio-cli/src/talebook_audio_cli/client.py
+++ b/packages/talebook-audio-cli/src/talebook_audio_cli/client.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import http.cookiejar
+import json
+import socket
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Mapping
+from typing import Any
+
+from .config import AppPaths, Config, secure_cookie_file
+from .models import Audiobook, Chapter
+
+
+class TalebookError(RuntimeError):
+    """Base error with a user-safe message."""
+
+
+class AuthenticationError(TalebookError):
+    pass
+
+
+class TransportError(TalebookError):
+    pass
+
+
+class ResponseError(TalebookError):
+    pass
+
+
+class TalebookClient:
+    def __init__(self, config: Config, paths: AppPaths | None = None, timeout: float = 15.0):
+        self.config = config
+        self.paths = paths or AppPaths.default()
+        self.timeout = timeout
+        self.cookie_jar = http.cookiejar.MozillaCookieJar(str(secure_cookie_file(self.paths)))
+        if self.paths.cookie_file.exists():
+            try:
+                self.cookie_jar.load(ignore_discard=True, ignore_expires=False)
+            except (OSError, http.cookiejar.LoadError):
+                self.paths.cookie_file.unlink(missing_ok=True)
+        self.opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(self.cookie_jar))
+
+    def login(self, password: str) -> None:
+        if not password:
+            raise AuthenticationError("密码不能为空")
+        response = self._request_json(
+            "/api/user/sign_in",
+            method="POST",
+            form={"username": self.config.username, "password": password},
+        )
+        if response.get("err") != "ok":
+            raise AuthenticationError(str(response.get("msg") or "登录失败，请检查账号和密码"))
+        self.cookie_jar.save(ignore_discard=True, ignore_expires=True)
+        self.paths.cookie_file.chmod(0o600)
+
+    def logout(self) -> None:
+        self.cookie_jar.clear()
+        self.paths.cookie_file.unlink(missing_ok=True)
+
+    def require_login(self) -> Mapping[str, Any]:
+        response = self._request_json("/api/user/info")
+        user = response.get("user")
+        if response.get("err") != "ok" or not isinstance(user, dict) or not user.get("is_login"):
+            raise AuthenticationError("登录态无效或已过期；请运行 talebook-audio login")
+        return user
+
+    def list_audiobooks(self) -> list[Audiobook]:
+        self.require_login()
+        response = self._request_json("/api/audios")
+        if response.get("err") != "ok":
+            raise ResponseError(str(response.get("msg") or "无法获取有声书列表"))
+        return parse_audiobook_list(response)
+
+    def list_chapters(self, edition_id: int) -> list[Chapter]:
+        response = self._request_json(f"/api/audio/{int(edition_id)}")
+        if response.get("err") != "ok":
+            raise ResponseError(str(response.get("msg") or "无法获取有声书章节"))
+        return parse_manifest(response, self.config.server)
+
+    def _request_json(
+        self,
+        path: str,
+        *,
+        method: str = "GET",
+        form: Mapping[str, str] | None = None,
+    ) -> dict[str, Any]:
+        url = self.config.server.rstrip("/") + "/" + path.lstrip("/")
+        data = urllib.parse.urlencode(form).encode("utf-8") if form is not None else None
+        request = urllib.request.Request(
+            url,
+            data=data,
+            method=method,
+            headers={"Accept": "application/json", "User-Agent": "talebook-audio-cli/0.1"},
+        )
+        try:
+            with self.opener.open(request, timeout=self.timeout) as response:
+                payload = response.read()
+        except urllib.error.HTTPError as exc:
+            raise TransportError(f"Talebook 返回 HTTP {exc.code}") from exc
+        except (urllib.error.URLError, socket.timeout, TimeoutError, OSError) as exc:
+            reason = getattr(exc, "reason", None)
+            detail = str(reason) if reason else exc.__class__.__name__
+            raise TransportError(f"无法连接 Talebook（{detail}）") from exc
+        try:
+            value = json.loads(payload.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise ResponseError("Talebook 返回了无法解析的响应") from exc
+        if not isinstance(value, dict):
+            raise ResponseError("Talebook 返回的数据格式无效")
+        return value
+
+
+def _integer(value: Any, field: str) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise ResponseError(f"Talebook 响应缺少有效的 {field}") from exc
+
+
+def parse_audiobook_list(response: Mapping[str, Any]) -> list[Audiobook]:
+    raw_books = response.get("books", [])
+    if not isinstance(raw_books, list):
+        raise ResponseError("Talebook 有声书列表格式无效")
+    books: list[Audiobook] = []
+    for raw in raw_books:
+        if not isinstance(raw, dict) or not isinstance(raw.get("edition"), dict):
+            raise ResponseError("Talebook 有声书条目格式无效")
+        edition = raw["edition"]
+        books.append(
+            Audiobook(
+                book_id=_integer(raw.get("id"), "book id"),
+                edition_id=_integer(edition.get("id"), "edition id"),
+                title=str(raw.get("title") or "未命名书籍"),
+                author=str(raw.get("author") or "未知作者"),
+                chapter_count=max(0, _integer(edition.get("chapter_count", 0), "chapter count")),
+                duration_ms=max(0, _integer(edition.get("duration_ms", 0), "duration")),
+            )
+        )
+    return books
+
+
+def parse_manifest(response: Mapping[str, Any], server: str) -> list[Chapter]:
+    manifest = response.get("manifest")
+    if not isinstance(manifest, dict) or not isinstance(manifest.get("chapters"), list):
+        raise ResponseError("Talebook 有声书章节格式无效")
+    chapters: list[Chapter] = []
+    for raw in manifest["chapters"]:
+        if not isinstance(raw, dict):
+            raise ResponseError("Talebook 章节条目格式无效")
+        audio_path = str(raw.get("audio_url") or "")
+        if not audio_path:
+            raise ResponseError("Talebook 章节缺少音频地址")
+        audio_url = urllib.parse.urljoin(server.rstrip("/") + "/", audio_path.lstrip("/"))
+        chapters.append(
+            Chapter(
+                id=_integer(raw.get("id"), "chapter id"),
+                number=_integer(raw.get("number"), "chapter number"),
+                title=str(raw.get("title") or f"第 {raw.get('number', '?')} 章"),
+                duration_ms=max(0, _integer(raw.get("duration_ms", 0), "chapter duration")),
+                audio_url=audio_url,
+            )
+        )
+    return sorted(chapters, key=lambda chapter: chapter.number)

--- a/packages/talebook-audio-cli/src/talebook_audio_cli/config.py
+++ b/packages/talebook-audio-cli/src/talebook_audio_cli/config.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
+
+
+class ConfigError(ValueError):
+    """Raised when local configuration is absent or invalid."""
+
+
+@dataclass(frozen=True, slots=True)
+class AppPaths:
+    directory: Path
+
+    @classmethod
+    def default(cls) -> "AppPaths":
+        root = os.environ.get("XDG_CONFIG_HOME")
+        base = Path(root).expanduser() if root else Path.home() / ".config"
+        return cls(base / "talebook-audio")
+
+    @property
+    def config_file(self) -> Path:
+        return self.directory / "config.json"
+
+    @property
+    def cookie_file(self) -> Path:
+        return self.directory / "cookies.txt"
+
+
+@dataclass(frozen=True, slots=True)
+class Config:
+    server: str
+    username: str
+
+
+def normalize_server_url(value: str) -> str:
+    raw = value.strip()
+    try:
+        parsed = urlsplit(raw)
+        port = parsed.port
+    except ValueError as exc:
+        raise ConfigError("Talebook 服务地址无效") from exc
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise ConfigError("Talebook 服务地址必须是有效的 http 或 https URL")
+    if parsed.username or parsed.password or parsed.query or parsed.fragment:
+        raise ConfigError("Talebook 服务地址不能包含凭据、查询参数或片段")
+    hostname = parsed.hostname.lower()
+    if ":" in hostname and not hostname.startswith("["):
+        hostname = f"[{hostname}]"
+    netloc = hostname + (f":{port}" if port is not None else "")
+    path = parsed.path.rstrip("/")
+    return urlunsplit((parsed.scheme.lower(), netloc, path, "", ""))
+
+
+def _write_private(path: Path, content: str) -> None:
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    try:
+        path.parent.chmod(0o700)
+    except OSError:
+        pass
+    descriptor, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent, text=True)
+    temporary_path = Path(temporary)
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(content)
+        os.replace(temporary_path, path)
+        path.chmod(0o600)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
+
+def save_config(config: Config, paths: AppPaths | None = None) -> None:
+    target = paths or AppPaths.default()
+    payload = {"server": normalize_server_url(config.server), "username": config.username.strip()}
+    if not payload["username"]:
+        raise ConfigError("Talebook 用户名不能为空")
+    _write_private(target.config_file, json.dumps(payload, ensure_ascii=False, indent=2) + "\n")
+
+
+def load_config(paths: AppPaths | None = None) -> Config:
+    target = paths or AppPaths.default()
+    try:
+        payload = json.loads(target.config_file.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ConfigError("未配置 Talebook；请先运行 talebook-audio configure") from exc
+    except (OSError, ValueError, TypeError) as exc:
+        raise ConfigError("Talebook 本地配置损坏；请重新运行 configure") from exc
+    if not isinstance(payload, dict):
+        raise ConfigError("Talebook 本地配置损坏；请重新运行 configure")
+    username = str(payload.get("username", "")).strip()
+    if not username:
+        raise ConfigError("Talebook 本地配置缺少用户名；请重新运行 configure")
+    return Config(server=normalize_server_url(str(payload.get("server", ""))), username=username)
+
+
+def secure_cookie_file(paths: AppPaths | None = None) -> Path:
+    target = paths or AppPaths.default()
+    target.directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+    if target.cookie_file.exists():
+        target.cookie_file.chmod(0o600)
+    return target.cookie_file

--- a/packages/talebook-audio-cli/src/talebook_audio_cli/mcp_controller.py
+++ b/packages/talebook-audio-cli/src/talebook_audio_cli/mcp_controller.py
@@ -1,0 +1,299 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from .client import TalebookClient, TalebookError
+from .config import AppPaths, ConfigError, load_config
+from .models import Audiobook, Chapter
+from .player import PlayerError, XiaoAiPlayer, format_time
+
+
+class McpControllerError(RuntimeError):
+    """An actionable error safe to expose through MCP."""
+
+
+@dataclass(frozen=True, slots=True)
+class PlaybackResult:
+    message: str
+    playback_started: bool = False
+
+
+class McpPlaybackController:
+    """Own the Talebook queue and OpenXiaoAI player for one MCP process."""
+
+    def __init__(
+        self,
+        *,
+        paths: AppPaths | None = None,
+        client: TalebookClient | None = None,
+        player_factory: Callable[[list[Chapter]], XiaoAiPlayer] = XiaoAiPlayer,
+        monitor_interval: float = 0.5,
+    ):
+        self.paths = paths or AppPaths.default()
+        self._talebook = client
+        self._player_factory = player_factory
+        self._monitor_interval = monitor_interval
+        self._lock = asyncio.Lock()
+        self._monitor_task: asyncio.Task[None] | None = None
+        self._generation = 0
+        self.player: XiaoAiPlayer | None = None
+        self.book: Audiobook | None = None
+        self.chapters: list[Chapter] = []
+        self.current_index: int | None = None
+        self.finished = False
+
+    def _client(self) -> TalebookClient:
+        if self._talebook is None:
+            self._talebook = TalebookClient(load_config(self.paths), self.paths)
+        return self._talebook
+
+    @staticmethod
+    def _safe_error(exc: Exception) -> McpControllerError:
+        if isinstance(exc, (ConfigError, TalebookError, PlayerError, McpControllerError)):
+            return McpControllerError(str(exc))
+        return McpControllerError(f"Talebook MCP 操作失败（{exc.__class__.__name__}）")
+
+    async def list_audiobooks(self, query: str | None = None) -> dict[str, Any]:
+        try:
+            async with self._lock:
+                books = await asyncio.to_thread(self._client().list_audiobooks)
+        except Exception as exc:
+            raise self._safe_error(exc) from exc
+        normalized = (query or "").strip().casefold()
+        if normalized:
+            books = [book for book in books if normalized in book.title.casefold() or normalized in book.author.casefold()]
+        return {
+            "query": query or "",
+            "total": len(books),
+            "books": [asdict(book) for book in books],
+        }
+
+    async def list_chapters(self, edition_id: int) -> dict[str, Any]:
+        try:
+            async with self._lock:
+                chapters = await asyncio.to_thread(self._client().list_chapters, edition_id)
+        except Exception as exc:
+            raise self._safe_error(exc) from exc
+        return {
+            "edition_id": edition_id,
+            "total": len(chapters),
+            "chapters": [
+                {
+                    "id": chapter.id,
+                    "number": chapter.number,
+                    "title": chapter.title,
+                    "duration_ms": chapter.duration_ms,
+                }
+                for chapter in chapters
+            ],
+        }
+
+    async def _select_book(
+        self,
+        *,
+        edition_id: int | None,
+        book_id: int | None,
+        query: str | None,
+    ) -> Audiobook:
+        selectors = sum(value is not None and value != "" for value in (edition_id, book_id, query))
+        if selectors > 1:
+            raise McpControllerError("edition_id、book_id 和 query 只能提供一个")
+        books = await asyncio.to_thread(self._client().list_audiobooks)
+        if edition_id is not None:
+            matches = [book for book in books if book.edition_id == edition_id]
+        elif book_id is not None:
+            matches = [book for book in books if book.book_id == book_id]
+        elif query:
+            normalized = query.strip().casefold()
+            matches = [book for book in books if normalized in book.title.casefold() or normalized in book.author.casefold()]
+        elif len(books) == 1:
+            matches = books
+        else:
+            raise McpControllerError("请提供 edition_id、book_id 或 query；可先调用 list_audiobooks")
+        if not matches:
+            raise McpControllerError("没有找到匹配且已发布的有声书")
+        if len(matches) > 1:
+            options = "、".join(f"{book.title}(edition {book.edition_id})" for book in matches[:5])
+            raise McpControllerError(f"匹配到多本有声书：{options}；请改用 edition_id")
+        return matches[0]
+
+    async def _cancel_monitor(self) -> None:
+        task = self._monitor_task
+        self._monitor_task = None
+        if task is None or task is asyncio.current_task() or task.done():
+            return
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    async def play_audiobook(
+        self,
+        *,
+        edition_id: int | None = None,
+        book_id: int | None = None,
+        query: str | None = None,
+        chapter: int = 1,
+    ) -> PlaybackResult:
+        await self._cancel_monitor()
+        try:
+            async with self._lock:
+                book = await self._select_book(edition_id=edition_id, book_id=book_id, query=query)
+                chapters = await asyncio.to_thread(self._client().list_chapters, book.edition_id)
+                try:
+                    index = next(index for index, item in enumerate(chapters) if item.number == chapter)
+                except StopIteration as exc:
+                    raise McpControllerError(f"有声书《{book.title}》没有第 {chapter} 章") from exc
+                if self.player is not None:
+                    await asyncio.to_thread(self.player.close)
+                self.player = None
+                self.book = None
+                self.chapters = []
+                self.current_index = None
+                player = self._player_factory(chapters)
+                await asyncio.to_thread(player.load, index)
+                self.player = player
+                self.book = book
+                self.chapters = chapters
+                self.current_index = index
+                self.finished = False
+                self._generation += 1
+                generation = self._generation
+        except Exception as exc:
+            raise self._safe_error(exc) from exc
+        self._monitor_task = asyncio.create_task(self._monitor(generation))
+        return PlaybackResult(
+            f"正在播放《{book.title}》第 {chapter} 章：{chapters[index].title}",
+            playback_started=True,
+        )
+
+    async def _monitor(self, generation: int) -> None:
+        try:
+            while True:
+                await asyncio.sleep(self._monitor_interval)
+                async with self._lock:
+                    if generation != self._generation or self.player is None or self.current_index is None:
+                        return
+                    _position, _duration, _paused, idle = await asyncio.to_thread(self.player.status)
+                    if not idle:
+                        continue
+                    next_index = self.current_index + 1
+                    if next_index >= len(self.chapters):
+                        self.finished = True
+                        return
+                    await asyncio.to_thread(self.player.load, next_index)
+                    self.current_index = next_index
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            self.finished = True
+
+    async def pause(self) -> PlaybackResult:
+        try:
+            async with self._lock:
+                if self.player is None:
+                    return PlaybackResult("当前没有 Talebook 有声书在播放")
+                _position, _duration, paused, idle = await asyncio.to_thread(self.player.status)
+                if idle:
+                    return PlaybackResult("当前没有 Talebook 有声书在播放")
+                if paused:
+                    return PlaybackResult("当前已经暂停")
+                await asyncio.to_thread(self.player.toggle_pause)
+                return PlaybackResult("已暂停 Talebook 有声书")
+        except Exception as exc:
+            raise self._safe_error(exc) from exc
+
+    async def resume(self) -> PlaybackResult:
+        try:
+            async with self._lock:
+                if self.player is None:
+                    return PlaybackResult("当前没有可恢复的 Talebook 有声书")
+                _position, _duration, paused, idle = await asyncio.to_thread(self.player.status)
+                if idle:
+                    return PlaybackResult("当前没有可恢复的 Talebook 有声书")
+                if not paused:
+                    return PlaybackResult("Talebook 有声书正在播放中")
+                await asyncio.to_thread(self.player.toggle_pause)
+                return PlaybackResult("已恢复 Talebook 有声书播放")
+        except Exception as exc:
+            raise self._safe_error(exc) from exc
+
+    async def _move(self, delta: int) -> PlaybackResult:
+        try:
+            async with self._lock:
+                if self.player is None or self.current_index is None:
+                    return PlaybackResult("当前没有 Talebook 章节队列")
+                target = self.current_index + delta
+                if target < 0:
+                    return PlaybackResult("已经是第一章")
+                if target >= len(self.chapters):
+                    return PlaybackResult("已经是最后一章")
+                await asyncio.to_thread(self.player.load, target)
+                self.current_index = target
+                self.finished = False
+                chapter = self.chapters[target]
+                return PlaybackResult(
+                    f"正在播放第 {chapter.number} 章：{chapter.title}",
+                    playback_started=True,
+                )
+        except Exception as exc:
+            raise self._safe_error(exc) from exc
+
+    async def next_chapter(self) -> PlaybackResult:
+        return await self._move(1)
+
+    async def previous_chapter(self) -> PlaybackResult:
+        return await self._move(-1)
+
+    async def stop(self) -> PlaybackResult:
+        await self._cancel_monitor()
+        try:
+            async with self._lock:
+                if self.player is not None:
+                    await asyncio.to_thread(self.player.close)
+                self.player = None
+                self.book = None
+                self.chapters = []
+                self.current_index = None
+                self.finished = False
+                self._generation += 1
+                return PlaybackResult("已停止 Talebook 有声书")
+        except Exception as exc:
+            raise self._safe_error(exc) from exc
+
+    async def status(self) -> dict[str, Any]:
+        try:
+            async with self._lock:
+                if self.player is None or self.current_index is None or self.book is None:
+                    return {"state": "idle", "message": "当前没有 Talebook 有声书在播放"}
+                position, duration, paused, idle = await asyncio.to_thread(self.player.status)
+                chapter = self.chapters[self.current_index]
+                state = "finished" if self.finished else "idle" if idle else "paused" if paused else "playing"
+                return {
+                    "state": state,
+                    "book_id": self.book.book_id,
+                    "edition_id": self.book.edition_id,
+                    "book_title": self.book.title,
+                    "chapter": chapter.number,
+                    "chapter_title": chapter.title,
+                    "queue_position": self.current_index + 1,
+                    "queue_total": len(self.chapters),
+                    "position_seconds": int(position),
+                    "duration_seconds": int(duration),
+                    "message": (
+                        f"{state}：《{self.book.title}》第 {chapter.number} 章 {chapter.title}，"
+                        f"{format_time(position)}/{format_time(duration)}，队列 {self.current_index + 1}/{len(self.chapters)}"
+                    ),
+                }
+        except Exception as exc:
+            raise self._safe_error(exc) from exc
+
+    async def shutdown(self) -> None:
+        try:
+            await self.stop()
+        except McpControllerError:
+            pass

--- a/packages/talebook-audio-cli/src/talebook_audio_cli/mcp_server.py
+++ b/packages/talebook-audio-cli/src/talebook_audio_cli/mcp_server.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from .mcp_controller import McpPlaybackController, PlaybackResult
+
+
+BRIDGE_CONTROL_KEY = "x-open-xiaoai-bridge"
+PLAYBACK_STARTED_SIGNAL = {
+    "version": 1,
+    "action": "end_turn_silently",
+    "reason": "playback_started",
+}
+
+
+class McpServerError(RuntimeError):
+    pass
+
+
+def _sdk():
+    try:
+        from mcp.server.fastmcp import FastMCP
+        from mcp.types import CallToolResult, TextContent
+    except ModuleNotFoundError as exc:
+        raise McpServerError("MCP 模式需要可选依赖；请安装 talebook-audio-cli[mcp]") from exc
+    return FastMCP, CallToolResult, TextContent
+
+
+def create_mcp_server(controller: McpPlaybackController | None = None):
+    FastMCP, CallToolResult, TextContent = _sdk()
+    playback = controller or McpPlaybackController()
+    server = FastMCP(
+        "talebook-audio",
+        instructions=(
+            "浏览和播放当前账号可访问的 Talebook 有声书。播放前优先调用 list_audiobooks；"
+            "不要索要或传递用户密码，登录会话由管理员预先配置。"
+        ),
+    )
+
+    def result(value: PlaybackResult):
+        structured = {BRIDGE_CONTROL_KEY: PLAYBACK_STARTED_SIGNAL} if value.playback_started else None
+        return CallToolResult(
+            content=[TextContent(type="text", text=value.message)],
+            structuredContent=structured,
+        )
+
+    @server.tool(
+        title="列出 Talebook 有声书",
+        description="列出当前账号可访问且已发布的 Talebook 有声书；可按书名或作者过滤。",
+        structured_output=True,
+    )
+    async def list_audiobooks(query: str | None = None) -> dict[str, Any]:
+        return await playback.list_audiobooks(query)
+
+    @server.tool(
+        title="列出有声书章节",
+        description="按 list_audiobooks 返回的 edition_id 列出章节编号、标题和时长。",
+        structured_output=True,
+    )
+    async def list_chapters(edition_id: int) -> dict[str, Any]:
+        return await playback.list_chapters(edition_id)
+
+    @server.tool(
+        title="播放 Talebook 有声书",
+        description=(
+            "播放 Talebook 有声书并建立自动续播章节队列。edition_id、book_id、query 三选一；"
+            "若当前只有一本书也可省略。chapter 是起始章节编号，默认 1。"
+        ),
+        structured_output=False,
+    )
+    async def play_audiobook(
+        edition_id: int | None = None,
+        book_id: int | None = None,
+        query: str | None = None,
+        chapter: int = 1,
+    ):
+        value = await playback.play_audiobook(
+            edition_id=edition_id,
+            book_id=book_id,
+            query=query,
+            chapter=chapter,
+        )
+        return result(value)
+
+    @server.tool(title="暂停有声书", description="暂停当前 Talebook 有声书播放。", structured_output=False)
+    async def pause():
+        return result(await playback.pause())
+
+    @server.tool(title="恢复有声书", description="恢复已暂停的 Talebook 有声书。", structured_output=False)
+    async def resume():
+        return result(await playback.resume())
+
+    @server.tool(title="下一章", description="播放当前 Talebook 章节队列中的下一章。", structured_output=False)
+    async def next_chapter():
+        return result(await playback.next_chapter())
+
+    @server.tool(title="上一章", description="播放当前 Talebook 章节队列中的上一章。", structured_output=False)
+    async def previous_chapter():
+        return result(await playback.previous_chapter())
+
+    @server.tool(title="停止有声书", description="停止播放并清空 Talebook 章节队列。", structured_output=False)
+    async def stop():
+        return result(await playback.stop())
+
+    @server.tool(
+        title="有声书播放状态",
+        description="查询当前 Talebook 书籍、章节、队列位置和播放进度。",
+        structured_output=True,
+    )
+    async def status() -> dict[str, Any]:
+        return await playback.status()
+
+    return server, playback
+
+
+async def run_mcp_server_async() -> None:
+    server, controller = create_mcp_server()
+    try:
+        await server.run_stdio_async()
+    finally:
+        await controller.shutdown()
+
+
+def run_mcp_server() -> None:
+    asyncio.run(run_mcp_server_async())

--- a/packages/talebook-audio-cli/src/talebook_audio_cli/models.py
+++ b/packages/talebook-audio-cli/src/talebook_audio_cli/models.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class Audiobook:
+    book_id: int
+    edition_id: int
+    title: str
+    author: str
+    chapter_count: int
+    duration_ms: int
+
+
+@dataclass(frozen=True, slots=True)
+class Chapter:
+    id: int
+    number: int
+    title: str
+    duration_ms: int
+    audio_url: str

--- a/packages/talebook-audio-cli/src/talebook_audio_cli/player.py
+++ b/packages/talebook-audio-cli/src/talebook_audio_cli/player.py
@@ -15,6 +15,7 @@ import unicodedata
 from pathlib import Path
 from typing import Any
 
+from .bridge import BridgeClient, BridgeError
 from .models import Chapter
 
 
@@ -253,3 +254,101 @@ class MpvPlayer:
             self._temporary.cleanup()
             self._temporary = None
         self.socket_path = None
+
+
+class XiaoAiPlayer:
+    """Play Talebook chapters through OpenXiaoAI Bridge's StreamPlayer API."""
+
+    def __init__(self, chapters: list[Chapter], client: BridgeClient | None = None):
+        if not chapters:
+            raise PlayerError("这本有声书没有可播放章节")
+        try:
+            self.client = client or BridgeClient()
+        except BridgeError as exc:
+            raise PlayerError(str(exc)) from exc
+        self.chapters = chapters
+        self.current_index = 0
+        self.started = False
+
+    def load(self, index: int) -> None:
+        if index < 0 or index >= len(self.chapters):
+            raise PlayerError("已经到达播放列表边界")
+        try:
+            self.client.play(self.chapters[index].audio_url)
+        except BridgeError as exc:
+            raise PlayerError(str(exc)) from exc
+        self.current_index = index
+        self.started = True
+
+    def toggle_pause(self) -> bool:
+        try:
+            status = self.client.status()
+            result = self.client.resume() if status.paused else self.client.pause()
+        except BridgeError as exc:
+            raise PlayerError(str(exc)) from exc
+        return result.paused
+
+    def status(self) -> tuple[float, float, bool, bool]:
+        try:
+            status = self.client.status()
+        except BridgeError as exc:
+            raise PlayerError(str(exc)) from exc
+        return status.position_ms / 1000, status.duration_ms / 1000, status.paused, not status.playing
+
+    def run(self, start_index: int = 0) -> None:
+        if not sys.stdin.isatty() or not sys.stdout.isatty():
+            raise PlayerError("交互播放需要终端；请在 TTY 中运行 talebook-audio play")
+        if start_index < 0 or start_index >= len(self.chapters):
+            raise PlayerError("起始章节超出范围")
+        self.load(start_index)
+        descriptor = sys.stdin.fileno()
+        original = termios.tcgetattr(descriptor)
+        last_render = 0.0
+        try:
+            tty.setcbreak(descriptor)
+            print("控制：空格或 p 暂停/继续，n 下一章，b 上一章，s 刷新状态，q 退出")
+            while True:
+                position, duration, paused, idle = self.status()
+                if idle:
+                    if self.current_index + 1 >= len(self.chapters):
+                        print("\n播放完成")
+                        return
+                    self.load(self.current_index + 1)
+                    continue
+                now = time.monotonic()
+                if now - last_render >= 0.5:
+                    chapter = self.chapters[self.current_index]
+                    icon = "⏸" if paused else "▶"
+                    line = (
+                        f"\r{icon} [{self.current_index + 1}/{len(self.chapters)}] "
+                        f"{chapter.title}  {format_time(position)}/{format_time(duration)}"
+                    )
+                    print(fit_terminal(line, shutil.get_terminal_size().columns - 1), end="", flush=True)
+                    last_render = now
+                ready, _, _ = select.select([sys.stdin], [], [], 0.2)
+                if not ready:
+                    continue
+                key = os.read(descriptor, 1).decode("utf-8", errors="ignore")
+                if key in {"q", "Q"}:
+                    print()
+                    return
+                if key in {" ", "p", "P"}:
+                    self.toggle_pause()
+                elif key in {"n", "N"} and self.current_index + 1 < len(self.chapters):
+                    self.load(self.current_index + 1)
+                elif key in {"b", "B"} and self.current_index > 0:
+                    self.load(self.current_index - 1)
+                elif key in {"s", "S"}:
+                    last_render = 0
+        finally:
+            termios.tcsetattr(descriptor, termios.TCSADRAIN, original)
+            self.close()
+
+    def close(self) -> None:
+        if not self.started:
+            return
+        try:
+            self.client.stop()
+        except BridgeError:
+            pass
+        self.started = False

--- a/packages/talebook-audio-cli/src/talebook_audio_cli/player.py
+++ b/packages/talebook-audio-cli/src/talebook_audio_cli/player.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import json
+import os
+import select
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import termios
+import time
+import tty
+import unicodedata
+from pathlib import Path
+from typing import Any
+
+from .models import Chapter
+
+
+class PlayerError(RuntimeError):
+    pass
+
+
+def format_time(seconds: float) -> str:
+    seconds = max(0, int(seconds or 0))
+    return f"{seconds // 60}:{seconds % 60:02d}"
+
+
+def display_width(value: str) -> int:
+    width = 0
+    for character in value:
+        if character in {"\r", "\n"} or unicodedata.combining(character):
+            continue
+        width += 2 if unicodedata.east_asian_width(character) in {"W", "F"} else 1
+    return width
+
+
+def fit_terminal(value: str, width: int) -> str:
+    width = max(1, width)
+    prefix = "\r" if value.startswith("\r") else ""
+    content = value[len(prefix) :]
+    if display_width(content) <= width:
+        return prefix + content + " " * (width - display_width(content))
+    target = max(0, width - 1)
+    result: list[str] = []
+    used = 0
+    for character in content:
+        character_width = display_width(character)
+        if used + character_width > target:
+            break
+        result.append(character)
+        used += character_width
+    return prefix + "".join(result) + "…" + " " * max(0, target - used)
+
+
+class MpvPlayer:
+    def __init__(self, chapters: list[Chapter], cookie_file: Path):
+        if not chapters:
+            raise PlayerError("这本有声书没有可播放章节")
+        executable = shutil.which("mpv")
+        if not executable:
+            raise PlayerError("找不到 mpv；请安装 mpv 并确认它位于 PATH 中")
+        self.executable = executable
+        self.chapters = chapters
+        self.cookie_file = cookie_file
+        self.current_index = 0
+        self.process: subprocess.Popen[bytes] | None = None
+        self._temporary: tempfile.TemporaryDirectory[str] | None = None
+        self.socket_path: Path | None = None
+        self._request_id = 0
+
+    def start(self, start_index: int = 0) -> None:
+        if start_index < 0 or start_index >= len(self.chapters):
+            raise PlayerError("起始章节超出范围")
+        self.current_index = start_index
+        self._temporary = tempfile.TemporaryDirectory(prefix="talebook-audio-")
+        self.socket_path = Path(self._temporary.name) / "mpv.sock"
+        chapter = self.chapters[self.current_index]
+        args = [
+            self.executable,
+            "--no-video",
+            "--idle=yes",
+            "--keep-open=yes",
+            f"--input-ipc-server={self.socket_path}",
+            "--cookies=yes",
+            f"--cookies-file={self.cookie_file}",
+            f"--force-media-title={chapter.title}",
+            chapter.audio_url,
+        ]
+        try:
+            self.process = subprocess.Popen(
+                args, stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+            )
+        except OSError as exc:
+            self.close()
+            raise PlayerError(f"无法启动 mpv（{exc.strerror or exc.__class__.__name__}）") from exc
+        deadline = time.monotonic() + 4.0
+        while time.monotonic() < deadline:
+            if self.process.poll() is not None:
+                self.close()
+                raise PlayerError("mpv 启动后立即退出；请检查音频地址和 mpv 安装")
+            if self.socket_path.exists():
+                try:
+                    self.command(["get_property", "pid"])
+                    self._wait_until_active()
+                    return
+                except PlayerError:
+                    pass
+            time.sleep(0.05)
+        self.close()
+        raise PlayerError("mpv 已启动，但 IPC 控制接口不可用")
+
+    def command(self, command: list[Any]) -> Any:
+        if self.socket_path is None:
+            raise PlayerError("播放器尚未启动")
+        self._request_id += 1
+        request_id = self._request_id
+        payload = (json.dumps({"command": command, "request_id": request_id}) + "\n").encode("utf-8")
+        try:
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as connection:
+                connection.settimeout(2.0)
+                connection.connect(str(self.socket_path))
+                connection.sendall(payload)
+                buffer = b""
+                while b"\n" not in buffer:
+                    chunk = connection.recv(65536)
+                    if not chunk:
+                        break
+                    buffer += chunk
+        except (OSError, TimeoutError) as exc:
+            raise PlayerError("无法连接 mpv 控制接口") from exc
+        for line in buffer.splitlines():
+            try:
+                response = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if response.get("request_id") != request_id:
+                continue
+            if response.get("error") != "success":
+                raise PlayerError(f"mpv 控制失败：{response.get('error', 'unknown error')}")
+            return response.get("data")
+        raise PlayerError("mpv 未返回有效控制响应")
+
+    def load(self, index: int) -> None:
+        if index < 0 or index >= len(self.chapters):
+            raise PlayerError("已经到达播放列表边界")
+        self.current_index = index
+        chapter = self.chapters[index]
+        self.command(["set_property", "force-media-title", chapter.title])
+        self.command(["loadfile", chapter.audio_url, "replace"])
+        self._wait_until_active()
+
+    def _wait_until_active(self) -> None:
+        deadline = time.monotonic() + 4.0
+        while time.monotonic() < deadline:
+            if self.process is None or self.process.poll() is not None:
+                raise PlayerError("mpv 意外退出；音频可能失效")
+            try:
+                if not bool(self.command(["get_property", "idle-active"])):
+                    return
+            except PlayerError:
+                pass
+            time.sleep(0.05)
+        raise PlayerError("音频无法开始播放；登录态或音频地址可能已失效")
+
+    def toggle_pause(self) -> bool:
+        self.command(["cycle", "pause"])
+        return bool(self.command(["get_property", "pause"]))
+
+    def status(self) -> tuple[float, float, bool, bool]:
+        idle = bool(self.command(["get_property", "idle-active"]))
+        if idle:
+            return 0, 0, False, True
+        try:
+            position = float(self.command(["get_property", "time-pos"]) or 0)
+        except PlayerError:
+            position = 0
+        try:
+            duration = float(self.command(["get_property", "duration"]) or 0)
+        except PlayerError:
+            duration = 0
+        try:
+            paused = bool(self.command(["get_property", "pause"]))
+        except PlayerError:
+            paused = False
+        return position, duration, paused, idle
+
+    def run(self, start_index: int = 0) -> None:
+        if not sys.stdin.isatty() or not sys.stdout.isatty():
+            raise PlayerError("交互播放需要终端；请在 TTY 中运行 talebook-audio play")
+        self.start(start_index)
+        descriptor = sys.stdin.fileno()
+        original = termios.tcgetattr(descriptor)
+        last_render = 0.0
+        try:
+            tty.setcbreak(descriptor)
+            print("控制：空格或 p 暂停/继续，n 下一章，b 上一章，s 刷新状态，q 退出")
+            while True:
+                if self.process is None or self.process.poll() is not None:
+                    raise PlayerError("mpv 意外退出；音频可能失效")
+                position, duration, paused, idle = self.status()
+                if idle:
+                    if self.current_index + 1 >= len(self.chapters):
+                        print("\n播放完成")
+                        return
+                    self.load(self.current_index + 1)
+                    continue
+                now = time.monotonic()
+                if now - last_render >= 0.5:
+                    chapter = self.chapters[self.current_index]
+                    icon = "⏸" if paused else "▶"
+                    line = f"\r{icon} [{self.current_index + 1}/{len(self.chapters)}] {chapter.title}  {format_time(position)}/{format_time(duration)}"
+                    print(fit_terminal(line, shutil.get_terminal_size().columns - 1), end="", flush=True)
+                    last_render = now
+                ready, _, _ = select.select([sys.stdin], [], [], 0.2)
+                if not ready:
+                    continue
+                key = os.read(descriptor, 1).decode("utf-8", errors="ignore")
+                if key in {"q", "Q"}:
+                    print()
+                    return
+                if key in {" ", "p", "P"}:
+                    self.toggle_pause()
+                elif key in {"n", "N"} and self.current_index + 1 < len(self.chapters):
+                    self.load(self.current_index + 1)
+                elif key in {"b", "B"} and self.current_index > 0:
+                    self.load(self.current_index - 1)
+                elif key in {"s", "S"}:
+                    last_render = 0
+        finally:
+            termios.tcsetattr(descriptor, termios.TCSADRAIN, original)
+            self.close()
+
+    def close(self) -> None:
+        process = self.process
+        if process is not None and process.poll() is None:
+            try:
+                self.command(["quit"])
+            except PlayerError:
+                pass
+            try:
+                process.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                process.terminate()
+                try:
+                    process.wait(timeout=2)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait(timeout=2)
+        self.process = None
+        if self._temporary is not None:
+            self._temporary.cleanup()
+            self._temporary = None
+        self.socket_path = None

--- a/packages/talebook-audio-cli/tests/test_bridge.py
+++ b/packages/talebook-audio-cli/tests/test_bridge.py
@@ -1,0 +1,79 @@
+import io
+import json
+import urllib.error
+
+import pytest
+from talebook_audio_cli.bridge import BridgeClient, BridgeError, bridge_base_url, load_bridge_token
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self.payload = json.dumps(payload).encode()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return None
+
+    def read(self, _limit=None):
+        return self.payload
+
+
+def test_bridge_base_url_rejects_insecure_remote_http(monkeypatch):
+    monkeypatch.delenv("OPENXIAOAI_ALLOW_INSECURE_HTTP", raising=False)
+
+    with pytest.raises(BridgeError, match="明文 HTTP"):
+        bridge_base_url("http://speaker.example.com:9092")
+
+
+def test_bridge_token_file_must_be_private(tmp_path, monkeypatch):
+    token_file = tmp_path / "api-token"
+    token_file.write_text("x" * 43)
+    token_file.chmod(0o644)
+    monkeypatch.delenv("OPENXIAOAI_API_TOKEN", raising=False)
+    monkeypatch.setenv("OPENXIAOAI_API_TOKEN_FILE", str(token_file))
+
+    with pytest.raises(BridgeError, match="权限过宽"):
+        load_bridge_token()
+
+    token_file.chmod(0o600)
+    assert load_bridge_token() == "x" * 43
+
+
+def test_bridge_client_sends_bearer_and_parses_status(monkeypatch):
+    client = BridgeClient(token="x" * 43)
+    requests = []
+
+    def fake_open(request, timeout):
+        requests.append((request, timeout))
+        return FakeResponse({"success": True, "data": {"state": "playing", "position_ms": 1200, "duration_ms": 5000}})
+
+    monkeypatch.setattr(client.opener, "open", fake_open)
+
+    status = client.play("https://books.example.com/chapter.mp3")
+
+    request, timeout = requests[0]
+    assert request.full_url == "http://127.0.0.1:9092/api/stream/play"
+    assert request.get_header("Authorization") == "Bearer " + "x" * 43
+    assert json.loads(request.data) == {"url": "https://books.example.com/chapter.mp3"}
+    assert timeout == 150.0
+    assert status.playing is True
+    assert status.position_ms == 1200
+
+
+def test_bridge_http_error_redacts_secrets(monkeypatch):
+    client = BridgeClient(token="x" * 43)
+    secret = "abcdefghijklmnopabcdefghijklmnop"
+
+    def fake_open(request, timeout):
+        body = io.BytesIO(json.dumps({"error": f"Authorization: Bearer {secret}"}).encode())
+        raise urllib.error.HTTPError(request.full_url, 400, "Bad Request", {}, body)
+
+    monkeypatch.setattr(client.opener, "open", fake_open)
+
+    with pytest.raises(BridgeError) as raised:
+        client.status()
+
+    assert secret not in str(raised.value)
+    assert "<redacted>" in str(raised.value)

--- a/packages/talebook-audio-cli/tests/test_cli.py
+++ b/packages/talebook-audio-cli/tests/test_cli.py
@@ -1,0 +1,49 @@
+import io
+
+import pytest
+from talebook_audio_cli.cli import _print_books, _select, main
+from talebook_audio_cli.client import TalebookError
+from talebook_audio_cli.config import AppPaths
+from talebook_audio_cli.models import Audiobook
+
+
+def test_configure_command_does_not_accept_or_store_password(tmp_path, capsys):
+    paths = AppPaths(tmp_path / "settings")
+
+    result = main(["configure", "--server", "https://books.example.com/", "--username", "alice"], paths=paths)
+
+    assert result == 0
+    assert "alice" in capsys.readouterr().out
+    content = paths.config_file.read_text()
+    assert "password" not in content
+    assert "secret" not in content
+
+
+def test_books_requires_configuration(tmp_path, capsys):
+    result = main(["books"], paths=AppPaths(tmp_path / "settings"))
+
+    assert result == 2
+    assert "configure" in capsys.readouterr().err
+
+
+def test_book_list_uses_consistent_chinese_labels(capsys):
+    _print_books([Audiobook(42, 12, "测试书", "作者", 3, 125000)])
+
+    output = capsys.readouterr().out
+    assert "书籍 ID：42" in output
+    assert "有声版本 ID：12" in output
+    assert "BOOK" not in output
+
+
+def test_empty_book_list_points_to_next_action(capsys):
+    _print_books([])
+
+    assert "生成并发布" in capsys.readouterr().out
+
+
+def test_non_tty_selection_exits_with_actionable_error(monkeypatch):
+    stream = io.StringIO("")
+    monkeypatch.setattr("sys.stdin", stream)
+
+    with pytest.raises(TalebookError, match="--book-id"):
+        _select("选择：", 2)

--- a/packages/talebook-audio-cli/tests/test_client.py
+++ b/packages/talebook-audio-cli/tests/test_client.py
@@ -1,0 +1,73 @@
+import stat
+
+import pytest
+from talebook_audio_cli.client import AuthenticationError, ResponseError, TalebookClient, parse_audiobook_list, parse_manifest
+from talebook_audio_cli.config import AppPaths, Config
+
+
+def test_parse_audiobook_list_reads_published_edition_shape():
+    books = parse_audiobook_list(
+        {
+            "books": [
+                {
+                    "id": 42,
+                    "title": "测试书",
+                    "author": "作者",
+                    "edition": {"id": 12, "chapter_count": 3, "duration_ms": 125000},
+                }
+            ]
+        }
+    )
+
+    assert books[0].book_id == 42
+    assert books[0].edition_id == 12
+    assert books[0].chapter_count == 3
+
+
+def test_parse_manifest_sorts_chapters_and_builds_absolute_urls():
+    chapters = parse_manifest(
+        {
+            "manifest": {
+                "chapters": [
+                    {"id": 2, "number": 2, "title": "二", "duration_ms": 2000, "audio_url": "/media/two.mp3"},
+                    {"id": 1, "number": 1, "title": "一", "duration_ms": 1000, "audio_url": "/media/one.mp3"},
+                ]
+            }
+        },
+        "https://books.example.com/base",
+    )
+
+    assert [chapter.number for chapter in chapters] == [1, 2]
+    assert chapters[0].audio_url == "https://books.example.com/base/media/one.mp3"
+
+
+def test_parse_manifest_rejects_missing_audio_url():
+    with pytest.raises(ResponseError, match="音频地址"):
+        parse_manifest({"manifest": {"chapters": [{"id": 1, "number": 1}]}}, "https://books.example.com")
+
+
+def test_login_saves_session_but_never_password(tmp_path, monkeypatch):
+    paths = AppPaths(tmp_path / "settings")
+    client = TalebookClient(Config("https://books.example.com", "alice"), paths)
+    captured = {}
+
+    def response(path, **kwargs):
+        captured.update(kwargs["form"])
+        return {"err": "ok", "msg": "ok"}
+
+    monkeypatch.setattr(client, "_request_json", response)
+    client.login("super-secret")
+
+    assert captured == {"username": "alice", "password": "super-secret"}
+    assert paths.cookie_file.exists()
+    assert "super-secret" not in paths.cookie_file.read_text()
+    assert stat.S_IMODE(paths.cookie_file.stat().st_mode) == 0o600
+
+
+def test_login_surfaces_server_error_without_echoing_password(tmp_path, monkeypatch):
+    client = TalebookClient(Config("https://books.example.com", "alice"), AppPaths(tmp_path / "settings"))
+    monkeypatch.setattr(client, "_request_json", lambda *args, **kwargs: {"err": "params.invalid", "msg": "用户名或密码错误"})
+
+    with pytest.raises(AuthenticationError, match="用户名或密码错误") as error:
+        client.login("do-not-echo")
+    assert "do-not-echo" not in str(error.value)

--- a/packages/talebook-audio-cli/tests/test_config.py
+++ b/packages/talebook-audio-cli/tests/test_config.py
@@ -1,0 +1,28 @@
+import json
+import stat
+
+import pytest
+from talebook_audio_cli.config import AppPaths, Config, ConfigError, load_config, normalize_server_url, save_config
+
+
+def test_save_config_normalizes_url_and_uses_private_permissions(tmp_path):
+    paths = AppPaths(tmp_path / "settings")
+    save_config(Config("HTTPS://Books.Example.COM/base/", "alice"), paths)
+
+    assert load_config(paths) == Config("https://books.example.com/base", "alice")
+    assert stat.S_IMODE(paths.config_file.stat().st_mode) == 0o600
+    assert "password" not in json.loads(paths.config_file.read_text())
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["books.example.com", "ftp://books.example.com", "https://user:secret@books.example.com", "https://books.example.com?q=1"],
+)
+def test_normalize_server_url_rejects_unsafe_or_ambiguous_values(value):
+    with pytest.raises(ConfigError):
+        normalize_server_url(value)
+
+
+def test_missing_config_has_actionable_message(tmp_path):
+    with pytest.raises(ConfigError, match="configure"):
+        load_config(AppPaths(tmp_path / "missing"))

--- a/packages/talebook-audio-cli/tests/test_mcp_controller.py
+++ b/packages/talebook-audio-cli/tests/test_mcp_controller.py
@@ -1,0 +1,145 @@
+import asyncio
+
+import pytest
+from talebook_audio_cli.mcp_controller import McpControllerError, McpPlaybackController
+from talebook_audio_cli.mcp_server import BRIDGE_CONTROL_KEY, PLAYBACK_STARTED_SIGNAL
+from talebook_audio_cli.models import Audiobook, Chapter
+
+
+class FakeTalebookClient:
+    def __init__(self):
+        self.books = [
+            Audiobook(10, 1, "西游记", "吴承恩", 2, 120000),
+            Audiobook(11, 2, "西游记续", "测试作者", 1, 30000),
+        ]
+        self.chapters = {
+            1: [
+                Chapter(101, 1, "第一回", 60000, "https://books.example.com/one.mp3"),
+                Chapter(102, 2, "第二回", 60000, "https://books.example.com/two.mp3"),
+            ],
+            2: [Chapter(201, 1, "续篇", 30000, "https://books.example.com/next.mp3")],
+        }
+
+    def list_audiobooks(self):
+        return self.books
+
+    def list_chapters(self, edition_id):
+        return self.chapters[edition_id]
+
+
+class FakePlayer:
+    def __init__(self, chapters):
+        self.chapters = chapters
+        self.current_index = 0
+        self.position = 0.25
+        self.duration = 60.0
+        self.paused = False
+        self.idle = True
+        self.loads = []
+        self.closed = False
+
+    def load(self, index):
+        self.current_index = index
+        self.loads.append(index)
+        self.position = 0.25
+        self.paused = False
+        self.idle = False
+
+    def status(self):
+        return self.position, self.duration, self.paused, self.idle
+
+    def toggle_pause(self):
+        self.paused = not self.paused
+        return self.paused
+
+    def close(self):
+        self.closed = True
+        self.idle = True
+
+
+def test_mcp_controller_lists_plays_and_controls_queue():
+    async def scenario():
+        players = []
+
+        def factory(chapters):
+            player = FakePlayer(chapters)
+            players.append(player)
+            return player
+
+        controller = McpPlaybackController(client=FakeTalebookClient(), player_factory=factory, monitor_interval=10)
+        listing = await controller.list_audiobooks("吴承恩")
+        assert listing["total"] == 1
+        assert listing["books"][0]["edition_id"] == 1
+
+        chapters = await controller.list_chapters(1)
+        assert [chapter["number"] for chapter in chapters["chapters"]] == [1, 2]
+
+        started = await controller.play_audiobook(edition_id=1, chapter=1)
+        assert started.playback_started is True
+        assert "第一回" in started.message
+        assert players[0].loads == [0]
+
+        status = await controller.status()
+        assert status["state"] == "playing"
+        assert status["book_title"] == "西游记"
+        assert status["chapter"] == 1
+
+        assert (await controller.pause()).message.startswith("已暂停")
+        assert (await controller.pause()).message == "当前已经暂停"
+        assert (await controller.resume()).message.startswith("已恢复")
+
+        next_result = await controller.next_chapter()
+        assert next_result.playback_started is True
+        assert players[0].loads[-1] == 1
+        previous_result = await controller.previous_chapter()
+        assert previous_result.playback_started is True
+        assert players[0].loads[-1] == 0
+
+        assert (await controller.stop()).message.startswith("已停止")
+        assert players[0].closed is True
+        assert (await controller.status())["state"] == "idle"
+
+    asyncio.run(scenario())
+
+
+def test_mcp_controller_auto_advances_when_chapter_finishes():
+    async def scenario():
+        player = None
+
+        def factory(chapters):
+            nonlocal player
+            player = FakePlayer(chapters)
+            return player
+
+        controller = McpPlaybackController(client=FakeTalebookClient(), player_factory=factory, monitor_interval=0.01)
+        await controller.play_audiobook(edition_id=1)
+        assert player is not None
+        player.idle = True
+        for _ in range(20):
+            if controller.current_index == 1:
+                break
+            await asyncio.sleep(0.01)
+        assert controller.current_index == 1
+        assert player.loads == [0, 1]
+        await controller.shutdown()
+
+    asyncio.run(scenario())
+
+
+def test_mcp_controller_requires_unambiguous_book_selector():
+    async def scenario():
+        controller = McpPlaybackController(client=FakeTalebookClient(), player_factory=FakePlayer)
+        with pytest.raises(McpControllerError, match="匹配到多本"):
+            await controller.play_audiobook(query="西游记")
+        await controller.shutdown()
+
+    asyncio.run(scenario())
+
+
+def test_playback_signal_matches_open_xiaoai_contract():
+    assert BRIDGE_CONTROL_KEY == "x-open-xiaoai-bridge"
+    assert PLAYBACK_STARTED_SIGNAL == {
+        "version": 1,
+        "action": "end_turn_silently",
+        "reason": "playback_started",
+    }

--- a/packages/talebook-audio-cli/tests/test_player.py
+++ b/packages/talebook-audio-cli/tests/test_player.py
@@ -2,8 +2,9 @@ import shutil
 import subprocess
 
 import pytest
+from talebook_audio_cli.bridge import BridgeStatus
 from talebook_audio_cli.models import Chapter
-from talebook_audio_cli.player import MpvPlayer, PlayerError, display_width, fit_terminal, format_time
+from talebook_audio_cli.player import MpvPlayer, PlayerError, XiaoAiPlayer, display_width, fit_terminal, format_time
 
 
 def test_format_time():
@@ -73,3 +74,51 @@ def test_close_escalates_and_cleans_temporary_directory(tmp_path, monkeypatch):
     assert process.terminated is True
     assert process.killed is True
     assert not temporary.exists()
+
+
+def test_xiaoai_player_uses_stream_api_for_playback_controls():
+    chapters = [
+        Chapter(1, 1, "第一章", 5000, "https://books.example.com/one.mp3"),
+        Chapter(2, 2, "第二章", 6000, "https://books.example.com/two.mp3"),
+    ]
+
+    class FakeBridgeClient:
+        def __init__(self):
+            self.calls = []
+            self.current = BridgeStatus("idle", 0, 0)
+
+        def play(self, url):
+            self.calls.append(("play", url))
+            self.current = BridgeStatus("playing", 250, 5000)
+            return self.current
+
+        def status(self):
+            self.calls.append(("status",))
+            return self.current
+
+        def pause(self):
+            self.calls.append(("pause",))
+            self.current = BridgeStatus("paused", self.current.position_ms, self.current.duration_ms)
+            return self.current
+
+        def resume(self):
+            self.calls.append(("resume",))
+            self.current = BridgeStatus("playing", self.current.position_ms, self.current.duration_ms)
+            return self.current
+
+        def stop(self):
+            self.calls.append(("stop",))
+            self.current = BridgeStatus("idle", 0, 0)
+            return self.current
+
+    bridge = FakeBridgeClient()
+    player = XiaoAiPlayer(chapters, bridge)
+
+    player.load(1)
+    assert bridge.calls[-1] == ("play", chapters[1].audio_url)
+    assert player.toggle_pause() is True
+    assert player.toggle_pause() is False
+    position, duration, paused, idle = player.status()
+    assert (position, duration, paused, idle) == (0.25, 5.0, False, False)
+    player.close()
+    assert bridge.calls[-1] == ("stop",)

--- a/packages/talebook-audio-cli/tests/test_player.py
+++ b/packages/talebook-audio-cli/tests/test_player.py
@@ -1,0 +1,75 @@
+import shutil
+import subprocess
+
+import pytest
+from talebook_audio_cli.models import Chapter
+from talebook_audio_cli.player import MpvPlayer, PlayerError, display_width, fit_terminal, format_time
+
+
+def test_format_time():
+    assert format_time(0) == "0:00"
+    assert format_time(125.9) == "2:05"
+
+
+def test_fit_terminal_accounts_for_wide_chinese_characters():
+    fitted = fit_terminal("\r▶ 第一章很长  2:05/5:00", 16)
+
+    assert fitted.startswith("\r")
+    assert display_width(fitted) == 16
+    assert "…" in fitted
+
+
+def test_player_reports_missing_dependency(tmp_path, monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    chapters = [Chapter(1, 1, "第一章", 1000, "https://books.example.com/one.mp3")]
+
+    with pytest.raises(PlayerError, match="mpv"):
+        MpvPlayer(chapters, tmp_path / "cookies.txt")
+
+
+def test_player_rejects_empty_queue(tmp_path, monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/mpv")
+
+    with pytest.raises(PlayerError, match="没有可播放章节"):
+        MpvPlayer([], tmp_path / "cookies.txt")
+
+
+def test_close_escalates_and_cleans_temporary_directory(tmp_path, monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/mpv")
+    chapter = Chapter(1, 1, "第一章", 1000, "https://books.example.com/one.mp3")
+    player = MpvPlayer([chapter], tmp_path / "cookies.txt")
+
+    class FakeProcess:
+        def __init__(self):
+            self.running = True
+            self.terminated = False
+            self.killed = False
+
+        def poll(self):
+            return None if self.running else 0
+
+        def wait(self, timeout):
+            if not self.killed:
+                raise subprocess.TimeoutExpired("mpv", timeout)
+            self.running = False
+            return 0
+
+        def terminate(self):
+            self.terminated = True
+
+        def kill(self):
+            self.killed = True
+
+    process = FakeProcess()
+    temporary = tmp_path / "ipc"
+    temporary.mkdir()
+    player.process = process
+    player._temporary = type("Temporary", (), {"cleanup": lambda self: shutil.rmtree(temporary)})()
+    player.socket_path = temporary / "mpv.sock"
+    monkeypatch.setattr(player, "command", lambda command: None)
+
+    player.close()
+
+    assert process.terminated is True
+    assert process.killed is True
+    assert not temporary.exists()


### PR DESCRIPTION
## 背景与目标

新增可独立安装的 Talebook 有声书终端客户端，让用户无需浏览器 Cookie 导入即可通过服务地址、账号和密码登录，浏览已发布有声书，并通过本机 mpv 或 OpenXiaoAI Bridge 在小爱音箱上播放；同时提供与 neteasecli 相同形态的 stdio MCP server，供 Bridge 的语音对话调用。

Closes HOU-20

## 关键改动

- 新增基础模式零运行时 Python 依赖的 `packages/talebook-audio-cli` 独立包和 `talebook-audio` 命令；MCP SDK 作为可选依赖。
- 支持安全配置、隐藏密码输入、账号密码登录、0600 Cookie 会话复用及本地退出。
- 支持有声书和章节列表、交互/参数选择、暂停/继续、上一章、下一章、实时进度和自动续播。
- 默认 mpv IPC 播放；`--player xiaoai` / `TALEBOOK_AUDIO_PLAYER=xiaoai` 通过 OpenXiaoAI Bridge StreamPlayer API 在音箱播放。
- Bridge 后端强制 Bearer token，校验 0600 token 文件；非本机明文 HTTP 默认拒绝，并支持自签 CA 与 mTLS。
- 新增 `talebook-audio mcp` stdio server，提供 `list_audiobooks`、`list_chapters`、`play_audiobook`、`next_chapter`、`previous_chapter`、`pause`、`resume`、`stop`、`status` 9 个工具。
- MCP 控制器持有章节队列，阻塞网络调用移到工作线程，后台监控章节结束并自动续播；正常断开时停止远端播放。
- 播放和切章返回 OpenXiaoAI Bridge 的 `end_turn_silently / playback_started` 结构化信号，避免音频开始后重复 TTS。
- MCP 不提供登录工具、不接收密码；管理员预先登录后只挂载受保护的会话目录。
- 补充安装、配置、登录、mpv/Bridge/MCP 三种使用方式、部署与错误排查文档，以及 30 个自动化测试。

## 实际验证

- `PYTHONPATH=packages/talebook-audio-cli/src python3 -m pytest packages/talebook-audio-cli/tests`：30 passed。
- `ruff check packages/talebook-audio-cli/src packages/talebook-audio-cli/tests`：通过。
- `ruff format --check packages/talebook-audio-cli/src packages/talebook-audio-cli/tests`：通过。
- `make lint-py-fix`、`make lint-py`：通过，既有 102 个服务端文件无需修改。
- `make check-design`：111 个方案文档通过。
- `pip wheel --no-build-isolation --no-deps packages/talebook-audio-cli`：成功生成通用 wheel；隔离目录安装后 CLI 帮助可运行。
- `interface-review full`：此前 CLI 交互复审 Approve，无 HIGH/MEDIUM 问题；本次 MCP 是无 Web/视觉消费者的协议与部署扩展，按规范豁免界面审查。
- 真实实例 `https://beta.rexliao.cn`：账号密码登录、Cookie 会话复用和 logout 清理通过；配置/Cookie 均为 `0600`，配置未保存密码。
- 真实数据：正确列出《西游记》，edition `1` 共 3 章、总时长 95:10；音频 Range、ffprobe 和 ffmpeg 解码验证通过。
- OpenXiaoAI Bridge 播放：真实容器完成首章播放、暂停、继续、第二章切换、返回首章和停止；最终状态回到 `idle`。
- MCP 部署：`/opt/open-xiaoai-bridge` 同时连接 neteasecli 13 个工具和 talebook_audio 9 个工具，容器 `running / healthy`。
- MCP 协议与实机：官方 ClientSession 退出码 0；完成 9 工具发现、列出 1 本书/3 章、首章播放静默信号、状态、暂停、恢复、下一章、上一章和停止，最终 `idle`。
- `make pytest`：本机缺少 Calibre，6 个既有服务端测试模块在导入阶段报 `ModuleNotFoundError: calibre`；与新增独立包无关。

## 风险与兼容性

- 本机播放需要 Python 3.11+ 和 mpv；Bridge/MCP 播放不依赖本机 mpv，但要求 Bridge 已启用 API Server 和 StreamPlayer。
- MCP 模式需要可选依赖 `mcp>=1.12,<2`；普通 CLI 安装仍无第三方运行时依赖。
- Bridge 会先下载并解码完整章节，再开始播放；真实环境每次播放或切章约需 14 秒，MCP 部署建议 timeout 180 秒。
- neteasecli 与 Talebook 同时启用时，Bridge 自动给重名控制工具加 `talebook_audio_` 前缀。
- 启用登录验证码的部署会返回服务端验证码错误；首版不绕过验证码。
- mpv 后端使用 POSIX Unix socket/TTY 控制，不承诺 Windows 命名管道支持。
- 不修改 Talebook 服务端接口、数据结构或权限模型。

## 方案

- CLI 基础方案：[GitHub 文件](https://github.com/talebook/talebook/blob/7d0c5b1857d95713f52879acbe777368452ccfae/design/packages/20260828-talebook-audio-cli.active.html) · [RawGitHack 在线预览](https://raw.githack.com/talebook/talebook/7d0c5b1857d95713f52879acbe777368452ccfae/design/packages/20260828-talebook-audio-cli.active.html)
- MCP 后续方案：[GitHub 文件](https://github.com/talebook/talebook/blob/7d0c5b1857d95713f52879acbe777368452ccfae/design/packages/20260828-talebook-audio-mcp.active.html) · [RawGitHack 在线预览](https://raw.githack.com/talebook/talebook/7d0c5b1857d95713f52879acbe777368452ccfae/design/packages/20260828-talebook-audio-mcp.active.html)

## 截图

本次新增的是终端客户端、stdio MCP 协议和 Bridge 部署接入，无 Web 页面、布局或视觉资源变更；CLI 与 MCP 的关键状态均已通过自动化测试和真实协议调用验证，因此不附页面截图。
