### PR TITLE
fix: 清理已升级版本的过期更新通知

### DIFF
--- a/tests/test_update_checker.py
+++ b/tests/test_update_checker.py
@@ -58,14 +58,39 @@ class TestUpdateChecker(unittest.TestCase):
 
     def test_check_for_updates_does_not_report_same_version_with_v_prefix(self):
         checker = UpdateChecker()
-        checker.current_version = "v26.06.29"
+        checker.current_version = "v26.08.11"
 
-        with self._mock_latest_release("26.06.29"):
+        with self._mock_latest_release("26.08.11"):
             checker.check_for_updates()
 
         self.assertFalse(checker.has_update)
-        self.assertEqual(checker.latest_version, "26.06.29")
+        self.assertEqual(checker.latest_version, "26.08.11")
         self.assertIsNone(checker.check_error)
+
+    def test_notify_admins_hides_same_version_notification_after_upgrade(self):
+        checker = UpdateChecker()
+        checker.current_version = "v26.08.11"
+        checker.latest_version = "26.08.11"
+        checker.has_update = False
+
+        admin = mock.Mock(id=1, username="admin")
+        existing = mock.Mock(
+            data={update_checker.UPDATE_NOTIFY_VERSION_KEY: "26.08.11"},
+            unread=True,
+        )
+        admin_query = mock.Mock()
+        admin_query.filter.return_value.all.return_value = [admin]
+        message_query = mock.Mock()
+        message_query.filter.return_value.first.return_value = existing
+        session = mock.Mock()
+        session.query.side_effect = [admin_query, message_query]
+        checker.set_session_maker(mock.Mock(return_value=session))
+
+        checker._notify_admins()
+
+        self.assertFalse(existing.unread)
+        session.commit.assert_called_once_with()
+        session.close.assert_called_once_with()
 
     def test_check_for_updates_reports_only_newer_latest_release(self):
         checker = UpdateChecker()

--- a/webserver/services/update_checker.py
+++ b/webserver/services/update_checker.py
@@ -157,8 +157,8 @@ class UpdateChecker:
             logging.error("Update check failed: %s", self.check_error)
 
     def _notify_admins(self):
-        """Send update notifications to all admin users (only called in background loop)"""
-        if not self._session_maker or not self.has_update:
+        """Reconcile update notifications for all admin users."""
+        if not self._session_maker:
             return
 
         session = self._session_maker()
@@ -179,6 +179,16 @@ class UpdateChecker:
 
                 if existing:
                     existing_version = existing.data.get(UPDATE_NOTIFY_VERSION_KEY, "")
+                    if not self.has_update:
+                        if existing.unread and not _has_newer_version(self.current_version, existing_version):
+                            existing.unread = False
+                            existing.update_time = datetime.datetime.now()
+                            logging.info(
+                                "Dismissed obsolete update notification for admin %s: version %s",
+                                admin.username,
+                                existing_version,
+                            )
+                        continue
                     if _same_version(existing_version, self.latest_version):
                         continue
                     if _compare_versions(existing_version, self.latest_version):
@@ -190,7 +200,7 @@ class UpdateChecker:
                         existing.unread = True
                         existing.save()
                         logging.info("Updated notification for admin %s: version %s", admin.username, self.latest_version)
-                else:
+                elif self.has_update:
                     msg = Message(
                         user_id=admin.id,
                         status=UPDATE_NOTIFY_STATUS,


### PR DESCRIPTION
## 背景
当前版本为 `v26.08.11`、GitHub 最新版本为 `26.08.11` 时，版本比较本身会忽略 `v` 前缀，但升级前创建的系统更新通知不会在升级后清除，导致管理员仍看到“发现新版本”的误报。

## 关键改动
- 无可用更新时继续核对管理员的更新通知。
- 通知版本不高于当前版本时，将该过期通知标记为已读。
- 增加 `v26.08.11` 与 `26.08.11` 的回归测试及升级后通知清理测试。

## 验证
- `python3 -m pytest -q tests/test_update_checker.py`：6 passed
- `make lint-py`：通过
- `git diff --check`：通过

## 风险与兼容性
仅处理 `system_update` 类型的过期未读通知；版本确实更新时的通知创建和刷新逻辑保持不变。无需数据迁移。

## 方案
本次为局部、低风险的缺陷修复，不涉及 API、数据结构或界面变更，按项目规范豁免方案文档。