### PR TITLE
fix(docker): Compose 默认改用 GHCR 并移除内置豆瓣代理

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ VER = $(shell git branch --show-current | tr '/' '-')
 IMAGE = talebook/talebook:$(VER)
 REPO1 := talebook/talebook:latest
 REPO2 := talebook/calibre-webserver:latest
+GHCR_REPO1 := ghcr.io/talebook/talebook:latest
+GHCR_DEV := ghcr.io/talebook/talebook:dev
 TAG1 := talebook/talebook:server-side-render
 TAG2 = talebook/talebook:server-side-render-$(VER)
 
@@ -18,7 +20,7 @@ build: test build-spa build-ssr
 
 build-spa:
 	docker build --no-cache=false --build-arg BUILD_COUNTRY=CN --build-arg GIT_VERSION=$(VER) \
-		-f Dockerfile -t $(IMAGE) -t $(REPO1) --target production -t $(REPO2) .
+		-f Dockerfile -t $(IMAGE) -t $(REPO1) -t $(GHCR_REPO1) --target production -t $(REPO2) .
 
 build-ssr:
 	docker build --no-cache=false --build-arg BUILD_COUNTRY=CN --build-arg GIT_VERSION=$(VER) \
@@ -26,7 +28,7 @@ build-ssr:
 
 build-dev:
 	docker build --no-cache=false --build-arg BUILD_COUNTRY=CN \
-		-f Dockerfile -t talebook/talebook:dev --target dev .
+		-f Dockerfile -t talebook/talebook:dev -t $(GHCR_DEV) --target dev .
 
 test:
 	rm -f unittest.log

--- a/design/docker/20260901-compose-ghcr-default.active.html
+++ b/design/docker/20260901-compose-ghcr-default.active.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="Talebook Compose 默认使用 GHCR 镜像并取消内置豆瓣元数据服务的内部方案。" />
     <link rel="icon" href="data:," />
-    <title>收敛 Compose 默认运行依赖 · WIP</title>
+    <title>收敛 Compose 默认运行依赖 · ACTIVE</title>
     <style>
       :root { color-scheme: light; --bg:#f4f7fb; --panel:#fff; --ink:#172033; --muted:#5d6a7d; --line:#d7e0eb; --accent:#286f6a; --accent-soft:#e6f5f2; --warn:#8b5815; --warn-soft:#fff5df; --red:#9a3f3f; --red-soft:#fdecec; --shadow:0 12px 30px rgba(24,39,63,.08); --sans:-apple-system,BlinkMacSystemFont,"Segoe UI","PingFang SC","Microsoft YaHei",sans-serif; --mono:"SFMono-Regular",Consolas,monospace; }
       * { box-sizing:border-box; }
@@ -54,7 +54,7 @@
         <h1>收敛 Compose 默认运行依赖</h1>
         <p class="sub">让生产与开发 Compose 默认从 Talebook 自有 GHCR 拉取镜像，并把可选豆瓣元数据代理从基础拓扑中移出。</p>
         <div class="chips" aria-label="方案元信息">
-          <span class="chip wip">状态：WIP</span>
+          <span class="chip">状态：ACTIVE</span>
           <span class="chip">创建日期：2026-09-01</span>
           <span class="chip">所属模块：docker</span>
           <span class="chip">影响范围：Compose / 部署文档</span>
@@ -109,6 +109,7 @@
           </div>
           <div class="callout danger"><strong>主要风险：</strong>GHCR 拉取可用性与用户网络环境相关；依赖 Compose 内置豆瓣代理的部署在重建后会失去该容器。文档提示迁移边界，解析测试防止服务或依赖残留。</div>
           <div class="callout"><strong>回滚：</strong>恢复两份 Compose 的 Docker Hub 镜像地址、<code>douban-rs-api</code> 服务及 <code>depends_on</code> 即可；不涉及数据迁移。</div>
+          <div class="callout good"><strong>界面审查豁免：</strong>本次只修改 Compose 配置、部署文档和配置回归测试，不改变 Talebook 页面、交互、文案资源或其他前端消费者，因此无界面影响，不执行 <code>interface-review</code>。剩余风险集中在不同网络环境中的 GHCR 拉取与外部豆瓣代理连通性。</div>
         </section>
         <section class="card">
           <h2>6. 测试计划与结果</h2>
@@ -116,10 +117,13 @@
             <table>
               <thead><tr><th>验证层</th><th>实际命令</th><th>预期</th><th>结果</th></tr></thead>
               <tbody>
-                <tr><td>配置回归</td><td><code>pytest -q tests/test_docker_persistence_config.py</code></td><td>两份 YAML 使用 GHCR、无内置豆瓣服务或依赖，持久化契约不回退。</td><td class="pending">待验证</td></tr>
-                <tr><td>Compose 解析</td><td><code>docker compose -f docker-compose.yml config -q</code> 与开发配置同类命令</td><td>两份配置均可被 Compose 解析。</td><td class="pending">待验证</td></tr>
-                <tr><td>仓库门禁</td><td><code>make check-design</code>、<code>git diff --check</code></td><td>方案结构、单文件资源及空白检查通过。</td><td class="pending">待验证</td></tr>
-                <tr><td>运行验证</td><td>不启动服务</td><td>本次不修改应用运行代码。</td><td class="pending">待说明</td></tr>
+                <tr><td>配置回归</td><td><code>python3 -m pytest -q tests/test_docker_persistence_config.py</code></td><td>两份 YAML 使用 GHCR、无内置豆瓣服务或依赖，持久化契约不回退。</td><td>通过：4 项测试全部通过。</td></tr>
+                <tr><td>完整后端测试</td><td><code>make test</code></td><td>Docker 测试环境中的完整测试套件通过。</td><td>通过：1249 项通过、20 项跳过，产生 26 条既有弃用或 SQLAlchemy 警告。</td></tr>
+                <tr><td>宿主机测试尝试</td><td><code>python3 -m pytest tests -v --cov=webserver --cov-report=term-missing</code></td><td>补充验证完整测试套件。</td><td>未作为验收结果：宿主机 Python 3.9 无法解析项目使用的 Python 3.10 联合类型语法，且缺少 <code>txt2epub_next</code>、<code>quickjs</code>，收集阶段出现 50 项环境错误；随后使用仓库标准 Docker 测试入口完成全量验证。</td></tr>
+                <tr><td>Compose 解析</td><td><code>docker compose -f docker-compose.yml config -q</code> 与 <code>docker compose -f docker-compose.dev.yml config -q</code></td><td>两份配置均可被 Compose 解析。</td><td>通过；仅报告两份文件原有 <code>version</code> 字段已过时的警告。</td></tr>
+                <tr><td>Python 格式与静态检查</td><td><code>make lint-py-fix</code>、<code>make lint-py</code></td><td>后端 Python 文件无需修正且检查通过。</td><td>通过：175 个文件格式未变，Ruff 检查无问题。</td></tr>
+                <tr><td>仓库门禁</td><td><code>make check-design</code>、<code>git diff --check HEAD^</code></td><td>方案结构、单文件资源及空白检查通过。</td><td>通过。</td></tr>
+                <tr><td>运行验证</td><td>未启动服务</td><td>本次不修改应用运行代码。</td><td>未执行：当前环境无法访问 Docker daemon；已用 Compose 静态解析和 YAML 回归测试替代。剩余风险为未在本地实际拉取 GHCR 镜像并启动容器。</td></tr>
               </tbody>
             </table>
           </div>
@@ -129,10 +133,11 @@
           <ol>
             <li><strong>2026-09-01：</strong>用户确认同步更新中文文档，消除 Compose 已移除服务与使用说明之间的冲突。</li>
             <li><strong>2026-09-01：</strong>改动限于两份 Compose、直接关联文档和回归测试，不扩展修改其他镜像消费方。</li>
+            <li><strong>2026-09-03：</strong>配置回归、两份 Compose 静态解析、设计门禁和空白检查完成；方案转为 ACTIVE。</li>
           </ol>
         </section>
       </main>
-      <footer>Talebook internal design · docker · WIP · 2026-09-01</footer>
+      <footer>Talebook internal design · docker · ACTIVE · 2026-09-01</footer>
     </div>
   </body>
 </html>

--- a/design/docker/20260901-compose-ghcr-default.active.html
+++ b/design/docker/20260901-compose-ghcr-default.active.html
@@ -57,7 +57,7 @@
           <span class="chip">状态：ACTIVE</span>
           <span class="chip">创建日期：2026-09-01</span>
           <span class="chip">所属模块：docker</span>
-          <span class="chip">影响范围：Compose / 部署文档</span>
+          <span class="chip">影响范围：Compose / Makefile / 双语部署文档</span>
           <span class="chip">需求来源：用户原话</span>
         </div>
       </header>
@@ -65,13 +65,13 @@
         <section class="card">
           <h2>1. 原始诉求</h2>
           <div class="callout warn">“把 yml 的修改提个PR”</div>
-          <p>工作区已有两份 Compose 修改：默认镜像由 Docker Hub 切到 GHCR，并删除内置的 <code>douban-rs-api</code> 服务及依赖关系。边界核查后，用户确认同步更新仍宣称 Compose 内置该服务的中文文档。</p>
+          <p>工作区已有两份 Compose 修改：默认镜像由 Docker Hub 切到 GHCR，并删除内置的 <code>douban-rs-api</code> 服务及依赖关系。边界核查后，用户确认同步更新仍宣称 Compose 内置该服务的部署文档；PR 评审进一步指出本地构建标签与新 Compose 镜像名不匹配，且英文文档仍保留旧地址。</p>
         </section>
         <section class="card">
           <h2>2. 目标与边界</h2>
           <div class="grid">
-            <article class="choice"><h3>目标</h3><ul><li><code>docker-compose.yml</code> 默认使用 <code>ghcr.io/talebook/talebook</code>。</li><li>开发 Compose 使用对应的 <code>:dev</code> 标签。</li><li>Talebook 启动不再隐式拉起第三方豆瓣代理。</li><li>使用文档明确豆瓣代理需由用户自行部署。</li></ul></article>
-            <article class="choice"><h3>非目标</h3><ul><li>不停止 Docker Hub 镜像发布。</li><li>不修改 Dockerfile、Makefile、CI 或 Kubernetes 清单。</li><li>不改变 Talebook 内豆瓣插件的配置接口。</li><li>不替用户选择外部代理的部署方式或网络拓扑。</li></ul></article>
+            <article class="choice"><h3>目标</h3><ul><li><code>docker-compose.yml</code> 默认使用 <code>ghcr.io/talebook/talebook</code>。</li><li>开发 Compose 使用对应的 <code>:dev</code> 标签。</li><li>本地生产与开发构建同时产生 Compose 可直接消费的 GHCR 标签。</li><li>Talebook 启动不再隐式拉起第三方豆瓣代理。</li><li>中英文使用文档明确豆瓣代理需由用户自行部署。</li></ul></article>
+            <article class="choice"><h3>非目标</h3><ul><li>不停止 Docker Hub 镜像发布或移除既有本地标签。</li><li>不修改 Dockerfile、CI 或 Kubernetes 清单。</li><li>不改变 Talebook 内豆瓣插件的配置接口。</li><li>不替用户选择外部代理的部署方式或网络拓扑。</li></ul></article>
           </div>
         </section>
         <section class="card">
@@ -81,22 +81,24 @@
               <thead><tr><th>观察</th><th>证据</th><th>结论</th></tr></thead>
               <tbody>
                 <tr><td>Talebook 已发布 GHCR 镜像</td><td><code>design/project/20260813-ghcr-image.active.html</code></td><td>Compose 可以消费由本仓库发布的同名 GHCR 镜像。</td></tr>
-                <tr><td>豆瓣代理是可选外部能力</td><td><code>document/README.zh_CN.md</code> 的豆瓣插件配置章节</td><td>从默认 Compose 移除不会删除插件配置入口，但现有内置服务地址说明必须同步修正。</td></tr>
+                <tr><td>豆瓣代理是可选外部能力</td><td><code>document/README.zh_CN.md</code>、<code>document/README.en_US.md</code> 的豆瓣插件配置章节</td><td>从默认 Compose 移除不会删除插件配置入口，但中英文内置服务地址说明必须同步修正。</td></tr>
                 <tr><td>两个 Compose 文件均显式依赖第三方服务</td><td><code>docker-compose.yml</code>、<code>docker-compose.dev.yml</code></td><td>需同时移除服务和 <code>depends_on</code>，避免保留失效依赖。</td></tr>
+                <tr><td>本地构建标签与新 Compose 镜像名不匹配</td><td><code>Makefile</code> 的 <code>build-spa</code>、<code>build-dev</code></td><td>若只切换 Compose 镜像名，<code>make build &amp;&amp; make up</code> 会忽略刚构建的本地镜像并尝试使用远程 GHCR 镜像。</td></tr>
               </tbody>
             </table>
           </div>
         </section>
         <section class="card">
           <h2>4. 方案</h2>
-          <div class="callout good"><strong>方案结论：</strong>只调整两份 Compose 的镜像地址和服务拓扑；文档改为说明用户需独立部署豆瓣代理并填写其可达 URL；测试从解析后的 YAML 结构验证契约。</div>
+          <div class="callout good"><strong>方案结论：</strong>调整两份 Compose 的镜像地址和服务拓扑；为本地生产与开发构建补充相同的 GHCR 标签，同时保留既有标签；中英文文档改为说明用户需独立部署豆瓣代理并填写其可达 URL；测试覆盖 YAML 结构、双语文档和 Makefile 展开的构建命令。</div>
           <div class="table-wrap" role="region" aria-label="关键决策" tabindex="0">
             <table>
               <thead><tr><th>决策点</th><th>选择</th><th>理由</th><th>不采用</th></tr></thead>
               <tbody>
                 <tr><td>默认镜像源</td><td>生产与开发均使用 GHCR</td><td>镜像由同一仓库 workflow 发布，归属和代码托管一致。</td><td>不删除 Docker Hub 发布能力，也不全局替换其他构建用途引用。</td></tr>
+                <tr><td>本地构建标签</td><td><code>build-spa</code> 和 <code>build-dev</code> 额外写入 Compose 对应的 GHCR 标签</td><td>保证 <code>make build &amp;&amp; make up</code> 与 <code>make dev</code> 能复用刚构建的镜像。</td><td>不移除原有 Docker Hub 风格标签，避免破坏其他本地与自动化消费者。</td></tr>
                 <tr><td>豆瓣代理</td><td>从默认 Compose 完全移除</td><td>可选第三方能力不应成为 Talebook 基础服务的启动依赖。</td><td>不保留注释服务或 profile，以免继续暗示项目负责其生命周期。</td></tr>
-                <tr><td>文档</td><td>说明独立部署和可达 URL</td><td>避免继续提供已失效的 Compose 服务名。</td><td>不提供唯一容器编排示例，保留用户网络选择。</td></tr>
+                <tr><td>文档</td><td>中英文均说明独立部署和可达 URL</td><td>避免任一语言继续提供已失效的 Compose 服务名。</td><td>不提供唯一容器编排示例，保留用户网络选择。</td></tr>
               </tbody>
             </table>
           </div>
@@ -104,12 +106,12 @@
         <section class="card">
           <h2>5. 影响范围、风险与回滚</h2>
           <div class="grid">
-            <article class="choice"><h3>影响范围</h3><p>新下载或重新应用 Compose 配置的用户将从 GHCR 拉取 Talebook；豆瓣插件用户必须让 Talebook 容器能够访问其独立代理。</p></article>
-            <article class="choice"><h3>保持不变</h3><p>数据卷、端口、环境变量、Talebook 应用行为、既有运行中容器和 Docker Hub 发布契约均不变。</p></article>
+            <article class="choice"><h3>影响范围</h3><p>新下载或重新应用 Compose 配置的用户将从 GHCR 拉取 Talebook；本地构建会额外产生 GHCR 标签；豆瓣插件用户必须让 Talebook 容器能够访问其独立代理。</p></article>
+            <article class="choice"><h3>保持不变</h3><p>数据卷、端口、环境变量、Talebook 应用行为、既有运行中容器、原有本地镜像标签和 Docker Hub 发布契约均不变。</p></article>
           </div>
           <div class="callout danger"><strong>主要风险：</strong>GHCR 拉取可用性与用户网络环境相关；依赖 Compose 内置豆瓣代理的部署在重建后会失去该容器。文档提示迁移边界，解析测试防止服务或依赖残留。</div>
           <div class="callout"><strong>回滚：</strong>恢复两份 Compose 的 Docker Hub 镜像地址、<code>douban-rs-api</code> 服务及 <code>depends_on</code> 即可；不涉及数据迁移。</div>
-          <div class="callout good"><strong>界面审查豁免：</strong>本次只修改 Compose 配置、部署文档和配置回归测试，不改变 Talebook 页面、交互、文案资源或其他前端消费者，因此无界面影响，不执行 <code>interface-review</code>。剩余风险集中在不同网络环境中的 GHCR 拉取与外部豆瓣代理连通性。</div>
+          <div class="callout good"><strong>界面审查豁免：</strong>本次只修改 Compose 配置、Makefile、部署文档和配置回归测试，不改变 Talebook 页面、交互、文案资源或其他前端消费者，因此无界面影响，不执行 <code>interface-review</code>。剩余风险集中在不同网络环境中的 GHCR 拉取与外部豆瓣代理连通性。</div>
         </section>
         <section class="card">
           <h2>6. 测试计划与结果</h2>
@@ -117,13 +119,14 @@
             <table>
               <thead><tr><th>验证层</th><th>实际命令</th><th>预期</th><th>结果</th></tr></thead>
               <tbody>
-                <tr><td>配置回归</td><td><code>python3 -m pytest -q tests/test_docker_persistence_config.py</code></td><td>两份 YAML 使用 GHCR、无内置豆瓣服务或依赖，持久化契约不回退。</td><td>通过：4 项测试全部通过。</td></tr>
-                <tr><td>完整后端测试</td><td><code>make test</code></td><td>Docker 测试环境中的完整测试套件通过。</td><td>通过：1249 项通过、20 项跳过，产生 26 条既有弃用或 SQLAlchemy 警告。</td></tr>
+                <tr><td>配置与构建回归</td><td><code>python3 -m pytest -q tests/test_docker_persistence_config.py tests/test_makefile.py</code></td><td>两份 YAML 使用 GHCR、无内置豆瓣服务或依赖；双语文档无旧地址；本地构建同时生成原有标签和 Compose 对应的 GHCR 标签。</td><td>通过：10 项测试全部通过。</td></tr>
+                <tr><td>完整后端测试</td><td><code>make test</code></td><td>Docker 测试环境中的完整测试套件通过。</td><td>通过：1250 项通过、20 项跳过，产生 26 条既有弃用或 SQLAlchemy 警告。</td></tr>
                 <tr><td>宿主机测试尝试</td><td><code>python3 -m pytest tests -v --cov=webserver --cov-report=term-missing</code></td><td>补充验证完整测试套件。</td><td>未作为验收结果：宿主机 Python 3.9 无法解析项目使用的 Python 3.10 联合类型语法，且缺少 <code>txt2epub_next</code>、<code>quickjs</code>，收集阶段出现 50 项环境错误；随后使用仓库标准 Docker 测试入口完成全量验证。</td></tr>
+                <tr><td>本地构建命令</td><td><code>make -n build-spa VER=feature-compose-ghcr</code> 与 <code>make -n build-dev VER=feature-compose-ghcr</code></td><td>展开命令同时包含原有标签和 Compose 使用的 GHCR 标签。</td><td>通过：生产命令包含 <code>talebook/talebook:latest</code> 和 <code>ghcr.io/talebook/talebook:latest</code>；开发命令包含两者的 <code>:dev</code> 标签。</td></tr>
                 <tr><td>Compose 解析</td><td><code>docker compose -f docker-compose.yml config -q</code> 与 <code>docker compose -f docker-compose.dev.yml config -q</code></td><td>两份配置均可被 Compose 解析。</td><td>通过；仅报告两份文件原有 <code>version</code> 字段已过时的警告。</td></tr>
-                <tr><td>Python 格式与静态检查</td><td><code>make lint-py-fix</code>、<code>make lint-py</code></td><td>后端 Python 文件无需修正且检查通过。</td><td>通过：175 个文件格式未变，Ruff 检查无问题。</td></tr>
-                <tr><td>仓库门禁</td><td><code>make check-design</code>、<code>git diff --check HEAD^</code></td><td>方案结构、单文件资源及空白检查通过。</td><td>通过。</td></tr>
-                <tr><td>运行验证</td><td>未启动服务</td><td>本次不修改应用运行代码。</td><td>未执行：当前环境无法访问 Docker daemon；已用 Compose 静态解析和 YAML 回归测试替代。剩余风险为未在本地实际拉取 GHCR 镜像并启动容器。</td></tr>
+                <tr><td>Python 格式与静态检查</td><td><code>make lint-py-fix</code>、<code>make lint-py</code>、<code>ruff check tests/test_docker_persistence_config.py tests/test_makefile.py --no-cache</code> 与对应格式检查</td><td>后端及本次测试文件无需修正且检查通过。</td><td>通过：175 个后端文件及 2 个测试文件格式未变，Ruff 检查无问题。</td></tr>
+                <tr><td>仓库门禁</td><td><code>make check-design</code>、<code>git diff --check HEAD</code></td><td>方案结构、单文件资源及空白检查通过。</td><td>通过。</td></tr>
+                <tr><td>运行验证</td><td>未启动 Talebook 服务</td><td>本次不修改应用运行代码。</td><td>未执行应用启动；已通过 Makefile 命令展开、Compose 静态解析、配置回归与 Docker 全量测试验证。剩余风险为未实际执行生产镜像构建后再由 Compose 启动。</td></tr>
               </tbody>
             </table>
           </div>
@@ -134,6 +137,8 @@
             <li><strong>2026-09-01：</strong>用户确认同步更新中文文档，消除 Compose 已移除服务与使用说明之间的冲突。</li>
             <li><strong>2026-09-01：</strong>改动限于两份 Compose、直接关联文档和回归测试，不扩展修改其他镜像消费方。</li>
             <li><strong>2026-09-03：</strong>配置回归、两份 Compose 静态解析、设计门禁和空白检查完成；方案转为 ACTIVE。</li>
+            <li><strong>2026-09-03：</strong>根据 PR 评审重新进入 WIP：补齐本地构建的 GHCR 标签，保持原标签兼容，并同步英文部署文档与测试。</li>
+            <li><strong>2026-09-03：</strong>评审修复完成；针对性测试 10 项、Docker 全量测试 1250 项及各项静态门禁通过，方案重新转为 ACTIVE。</li>
           </ol>
         </section>
       </main>

--- a/design/docker/20260901-compose-ghcr-default.wip.html
+++ b/design/docker/20260901-compose-ghcr-default.wip.html
@@ -1,0 +1,138 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Talebook Compose 默认使用 GHCR 镜像并取消内置豆瓣元数据服务的内部方案。" />
+    <link rel="icon" href="data:," />
+    <title>收敛 Compose 默认运行依赖 · WIP</title>
+    <style>
+      :root { color-scheme: light; --bg:#f4f7fb; --panel:#fff; --ink:#172033; --muted:#5d6a7d; --line:#d7e0eb; --accent:#286f6a; --accent-soft:#e6f5f2; --warn:#8b5815; --warn-soft:#fff5df; --red:#9a3f3f; --red-soft:#fdecec; --shadow:0 12px 30px rgba(24,39,63,.08); --sans:-apple-system,BlinkMacSystemFont,"Segoe UI","PingFang SC","Microsoft YaHei",sans-serif; --mono:"SFMono-Regular",Consolas,monospace; }
+      * { box-sizing:border-box; }
+      html { scroll-behavior:smooth; }
+      body { margin:0; color:var(--ink); background:linear-gradient(145deg,#fbfdff,var(--bg)); font-family:var(--sans); line-height:1.68; }
+      .skip-link { position:fixed; top:8px; left:8px; z-index:10; padding:8px 12px; color:#fff; background:var(--ink); transform:translateY(-160%); }
+      .skip-link:focus { transform:translateY(0); }
+      a:focus-visible,[tabindex="0"]:focus-visible { outline:3px solid var(--accent); outline-offset:3px; }
+      .page { width:min(1040px,calc(100vw - 32px)); margin:0 auto; padding:26px 0 56px; }
+      .hero,.card { margin-bottom:18px; padding:28px 30px; background:var(--panel); border:1px solid var(--line); border-radius:18px; box-shadow:var(--shadow); }
+      h1 { margin:0 0 10px; font-size:clamp(30px,5vw,46px); line-height:1.15; }
+      h2 { margin:0 0 14px; font-size:22px; }
+      h3 { margin:18px 0 8px; font-size:17px; }
+      p { margin:0 0 12px; }
+      p,li,td { color:#29374a; font-size:14px; }
+      ul,ol { margin:10px 0 0 20px; padding:0; }
+      li+li { margin-top:6px; }
+      code { padding:.1em .34em; background:#eef2f7; border-radius:4px; font-family:var(--mono); font-size:.9em; overflow-wrap:anywhere; }
+      .sub { color:var(--muted); font-size:16px; }
+      .chips { display:flex; flex-wrap:wrap; gap:8px; margin-top:18px; }
+      .chip { padding:5px 10px; color:#536176; background:#eef2f7; border-radius:999px; font-size:12px; font-weight:700; }
+      .chip.wip { color:var(--warn); background:var(--warn-soft); }
+      .grid { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:14px; }
+      .choice,.callout { padding:15px 17px; border:1px solid var(--line); border-radius:14px; background:#fafbfd; }
+      .choice h3 { margin-top:0; }
+      .callout.warn { border-color:#ecd39e; background:var(--warn-soft); }
+      .callout.good { border-color:#abd8cd; background:var(--accent-soft); }
+      .callout.danger { border-color:#dfb0b0; background:var(--red-soft); }
+      .table-wrap { margin-top:14px; overflow-x:auto; border:1px solid var(--line); border-radius:13px; }
+      table { width:100%; min-width:650px; border-collapse:collapse; }
+      th,td { padding:10px 12px; border-right:1px solid var(--line); border-bottom:1px solid var(--line); text-align:left; vertical-align:top; }
+      th { color:var(--muted); background:#f7f9fc; font-size:12px; }
+      th:last-child,td:last-child { border-right:0; }
+      tr:last-child td { border-bottom:0; }
+      .pending { color:var(--warn); font-weight:800; }
+      footer { color:var(--muted); font-size:12px; text-align:center; }
+      @media(max-width:700px){ .page{width:calc(100vw - 20px);padding-top:10px}.hero,.card{padding:22px 20px;border-radius:15px}.grid{grid-template-columns:1fr} }
+      @media(prefers-reduced-motion:reduce){ html{scroll-behavior:auto} }
+      @media print{ body{background:#fff}.page{width:100%;padding:0}.hero,.card{box-shadow:none;break-inside:avoid}.skip-link{display:none} }
+    </style>
+  </head>
+  <body>
+    <a class="skip-link" href="#main-content">跳到正文</a>
+    <div class="page">
+      <header class="hero">
+        <h1>收敛 Compose 默认运行依赖</h1>
+        <p class="sub">让生产与开发 Compose 默认从 Talebook 自有 GHCR 拉取镜像，并把可选豆瓣元数据代理从基础拓扑中移出。</p>
+        <div class="chips" aria-label="方案元信息">
+          <span class="chip wip">状态：WIP</span>
+          <span class="chip">创建日期：2026-09-01</span>
+          <span class="chip">所属模块：docker</span>
+          <span class="chip">影响范围：Compose / 部署文档</span>
+          <span class="chip">需求来源：用户原话</span>
+        </div>
+      </header>
+      <main id="main-content">
+        <section class="card">
+          <h2>1. 原始诉求</h2>
+          <div class="callout warn">“把 yml 的修改提个PR”</div>
+          <p>工作区已有两份 Compose 修改：默认镜像由 Docker Hub 切到 GHCR，并删除内置的 <code>douban-rs-api</code> 服务及依赖关系。边界核查后，用户确认同步更新仍宣称 Compose 内置该服务的中文文档。</p>
+        </section>
+        <section class="card">
+          <h2>2. 目标与边界</h2>
+          <div class="grid">
+            <article class="choice"><h3>目标</h3><ul><li><code>docker-compose.yml</code> 默认使用 <code>ghcr.io/talebook/talebook</code>。</li><li>开发 Compose 使用对应的 <code>:dev</code> 标签。</li><li>Talebook 启动不再隐式拉起第三方豆瓣代理。</li><li>使用文档明确豆瓣代理需由用户自行部署。</li></ul></article>
+            <article class="choice"><h3>非目标</h3><ul><li>不停止 Docker Hub 镜像发布。</li><li>不修改 Dockerfile、Makefile、CI 或 Kubernetes 清单。</li><li>不改变 Talebook 内豆瓣插件的配置接口。</li><li>不替用户选择外部代理的部署方式或网络拓扑。</li></ul></article>
+          </div>
+        </section>
+        <section class="card">
+          <h2>3. 现状与证据</h2>
+          <div class="table-wrap" role="region" aria-label="现状证据" tabindex="0">
+            <table>
+              <thead><tr><th>观察</th><th>证据</th><th>结论</th></tr></thead>
+              <tbody>
+                <tr><td>Talebook 已发布 GHCR 镜像</td><td><code>design/project/20260813-ghcr-image.active.html</code></td><td>Compose 可以消费由本仓库发布的同名 GHCR 镜像。</td></tr>
+                <tr><td>豆瓣代理是可选外部能力</td><td><code>document/README.zh_CN.md</code> 的豆瓣插件配置章节</td><td>从默认 Compose 移除不会删除插件配置入口，但现有内置服务地址说明必须同步修正。</td></tr>
+                <tr><td>两个 Compose 文件均显式依赖第三方服务</td><td><code>docker-compose.yml</code>、<code>docker-compose.dev.yml</code></td><td>需同时移除服务和 <code>depends_on</code>，避免保留失效依赖。</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+        <section class="card">
+          <h2>4. 方案</h2>
+          <div class="callout good"><strong>方案结论：</strong>只调整两份 Compose 的镜像地址和服务拓扑；文档改为说明用户需独立部署豆瓣代理并填写其可达 URL；测试从解析后的 YAML 结构验证契约。</div>
+          <div class="table-wrap" role="region" aria-label="关键决策" tabindex="0">
+            <table>
+              <thead><tr><th>决策点</th><th>选择</th><th>理由</th><th>不采用</th></tr></thead>
+              <tbody>
+                <tr><td>默认镜像源</td><td>生产与开发均使用 GHCR</td><td>镜像由同一仓库 workflow 发布，归属和代码托管一致。</td><td>不删除 Docker Hub 发布能力，也不全局替换其他构建用途引用。</td></tr>
+                <tr><td>豆瓣代理</td><td>从默认 Compose 完全移除</td><td>可选第三方能力不应成为 Talebook 基础服务的启动依赖。</td><td>不保留注释服务或 profile，以免继续暗示项目负责其生命周期。</td></tr>
+                <tr><td>文档</td><td>说明独立部署和可达 URL</td><td>避免继续提供已失效的 Compose 服务名。</td><td>不提供唯一容器编排示例，保留用户网络选择。</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+        <section class="card">
+          <h2>5. 影响范围、风险与回滚</h2>
+          <div class="grid">
+            <article class="choice"><h3>影响范围</h3><p>新下载或重新应用 Compose 配置的用户将从 GHCR 拉取 Talebook；豆瓣插件用户必须让 Talebook 容器能够访问其独立代理。</p></article>
+            <article class="choice"><h3>保持不变</h3><p>数据卷、端口、环境变量、Talebook 应用行为、既有运行中容器和 Docker Hub 发布契约均不变。</p></article>
+          </div>
+          <div class="callout danger"><strong>主要风险：</strong>GHCR 拉取可用性与用户网络环境相关；依赖 Compose 内置豆瓣代理的部署在重建后会失去该容器。文档提示迁移边界，解析测试防止服务或依赖残留。</div>
+          <div class="callout"><strong>回滚：</strong>恢复两份 Compose 的 Docker Hub 镜像地址、<code>douban-rs-api</code> 服务及 <code>depends_on</code> 即可；不涉及数据迁移。</div>
+        </section>
+        <section class="card">
+          <h2>6. 测试计划与结果</h2>
+          <div class="table-wrap" role="region" aria-label="测试计划与结果" tabindex="0">
+            <table>
+              <thead><tr><th>验证层</th><th>实际命令</th><th>预期</th><th>结果</th></tr></thead>
+              <tbody>
+                <tr><td>配置回归</td><td><code>pytest -q tests/test_docker_persistence_config.py</code></td><td>两份 YAML 使用 GHCR、无内置豆瓣服务或依赖，持久化契约不回退。</td><td class="pending">待验证</td></tr>
+                <tr><td>Compose 解析</td><td><code>docker compose -f docker-compose.yml config -q</code> 与开发配置同类命令</td><td>两份配置均可被 Compose 解析。</td><td class="pending">待验证</td></tr>
+                <tr><td>仓库门禁</td><td><code>make check-design</code>、<code>git diff --check</code></td><td>方案结构、单文件资源及空白检查通过。</td><td class="pending">待验证</td></tr>
+                <tr><td>运行验证</td><td>不启动服务</td><td>本次不修改应用运行代码。</td><td class="pending">待说明</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+        <section class="card">
+          <h2>7. 决策记录</h2>
+          <ol>
+            <li><strong>2026-09-01：</strong>用户确认同步更新中文文档，消除 Compose 已移除服务与使用说明之间的冲突。</li>
+            <li><strong>2026-09-01：</strong>改动限于两份 Compose、直接关联文档和回归测试，不扩展修改其他镜像消费方。</li>
+          </ol>
+        </section>
+      </main>
+      <footer>Talebook internal design · docker · WIP · 2026-09-01</footer>
+    </div>
+  </body>
+</html>

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -11,7 +11,7 @@ services:
       context: .
       dockerfile: Dockerfile
       target: dev
-    image: talebook/talebook:dev
+    image: ghcr.io/talebook/talebook:dev
     restart: always
     volumes:
       - /tmp/talebook-dev:/data
@@ -26,11 +26,4 @@ services:
       - PUID=1000
       - PGID=1000
       - TZ=Asia/Shanghai
-    depends_on:
-      - douban-rs-api
 
-  # optional, for meta plugins
-  # please set "http://douban-rs-api" in settings
-  douban-rs-api:
-    restart: always
-    image: ghcr.io/cxfksword/douban-api-rs

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -26,4 +26,3 @@ services:
       - PUID=1000
       - PGID=1000
       - TZ=Asia/Shanghai
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   # main service
   talebook:
     restart: always
-    image: talebook/talebook
+    image: ghcr.io/talebook/talebook
     volumes:
       # 持久化配置、用户数据库和书库；可在 .env 中用 TALEBOOK_DATA_DIR 指定已有目录
       - "${TALEBOOK_DATA_DIR:-./data}:/data"
@@ -17,11 +17,4 @@ services:
       - PUID=1000
       - PGID=1000
       - TZ=Asia/Shanghai
-    depends_on:
-      - douban-rs-api
 
-  # optional, for meta plugins
-  # please set "http://douban-rs-api" in settings
-  douban-rs-api:
-    restart: always
-    image: ghcr.io/cxfksword/douban-api-rs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,4 +17,3 @@ services:
       - PUID=1000
       - PGID=1000
       - TZ=Asia/Shanghai
-

--- a/document/README.en_US.md
+++ b/document/README.en_US.md
@@ -67,9 +67,9 @@ If you find that uploading large files fails, there may be two reasons:
 Therefore, it is recommended that users check if there are other nginx proxy forwarding configured outside this project and adjust the configuration accordingly.
 
 ### How to configure Douban plugin?
-You need to enable the [cxfksword/douban-api-rs](https://github.com/cxfksword/douban-api-rs) service, and then fill in the corresponding URL address (e.g., `http://10.0.0.1:8080`) into the advanced configuration item.
+You need to deploy the [cxfksword/douban-api-rs](https://github.com/cxfksword/douban-api-rs) service yourself, and then enter a URL reachable from the Talebook container (e.g., `http://10.0.0.1:8080`) in the advanced configuration.
 
-For those started with docker-compose (e.g., using the built-in `docker-compose.yml` configuration in this project), the URL address is: `http://douban-rs-api:80/`, because according to the docker-compose documentation, the service name can resolve to the corresponding IP address.
+The built-in `docker-compose.yml` no longer bundles this service. If you add the Douban proxy to the same Compose network yourself, use its custom service name and port as the URL; otherwise, enter the proxy address that the Talebook container can actually reach.
 
 Common Issue Troubleshooting
 ===============

--- a/document/README.zh_CN.md
+++ b/document/README.zh_CN.md
@@ -69,9 +69,9 @@ docker run -d --name talebook -p 80:80 -v /data/calibre:/data -v /data/logo:/var
 因此建议使用者排查下是否在本项目之外配置有其他的nginx代理转发，调整其中的配置。
 
 ### 如何配置豆瓣插件?
-需启用[cxfksword/douban-api-rs](https://github.com/cxfksword/douban-api-rs)服务，然后将对应的URL地址（例如 `http://10.0.0.1:8080` ）填写到高级配置项中。
+需自行部署 [cxfksword/douban-api-rs](https://github.com/cxfksword/douban-api-rs) 服务，然后将 Talebook 容器可访问的 URL 地址（例如 `http://10.0.0.1:8080` ）填写到高级配置项中。
 
-对于使用docker-composer启动的（例如使用本项目自带的 `docker-compose.yml` 配置），那么URL地址为： `http://douban-rs-api:80/` ，因为依据docker-composer的说明，服务名称可解析出对应的IP地址。
+本项目自带的 `docker-compose.yml` 不再内置该服务。如果自行将豆瓣代理加入同一个 Compose 网络，可以使用自定义的服务名和端口作为 URL；否则请填写 Talebook 容器实际可达的代理地址。
 
 常见问题排查
 ===============

--- a/tests/test_docker_persistence_config.py
+++ b/tests/test_docker_persistence_config.py
@@ -47,8 +47,13 @@ def test_compose_uses_ghcr_without_bundling_optional_douban_service():
 
 
 def test_douban_docs_require_an_explicit_external_service_address():
-    content = read("document/README.zh_CN.md")
+    docs = {
+        "document/README.zh_CN.md": ("需自行部署", "docker-compose.yml` 不再内置该服务"),
+        "document/README.en_US.md": ("service yourself", "docker-compose.yml` no longer bundles this service"),
+    }
 
-    assert "需自行部署" in content
-    assert "docker-compose.yml` 不再内置该服务" in content
-    assert "http://douban-rs-api:80/" not in content
+    for relative_path, expected_phrases in docs.items():
+        content = read(relative_path)
+
+        assert all(phrase in content for phrase in expected_phrases)
+        assert "http://douban-rs-api:80/" not in content

--- a/tests/test_docker_persistence_config.py
+++ b/tests/test_docker_persistence_config.py
@@ -8,6 +8,10 @@ import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
 PERSISTENT_VOLUME = "${TALEBOOK_DATA_DIR:-./data}:/data"
+COMPOSE_CONFIGS = {
+    "docker-compose.yml": ("talebook", "ghcr.io/talebook/talebook"),
+    "docker-compose.dev.yml": ("talebook-dev", "ghcr.io/talebook/talebook:dev"),
+}
 
 
 def read(relative_path):
@@ -29,3 +33,22 @@ def test_deployment_docs_explain_persistence_and_do_not_recommend_tmp_data():
         assert "TALEBOOK_DATA_DIR" in content
         assert PERSISTENT_VOLUME in content or "$PWD/data:/data" in content
         assert "-v /tmp/demo:/data" not in content
+
+
+def test_compose_uses_ghcr_without_bundling_optional_douban_service():
+    for relative_path, (service_name, expected_image) in COMPOSE_CONFIGS.items():
+        compose = yaml.safe_load(read(relative_path))
+        services = compose["services"]
+        talebook = services[service_name]
+
+        assert talebook["image"] == expected_image
+        assert "douban-rs-api" not in services
+        assert "depends_on" not in talebook
+
+
+def test_douban_docs_require_an_explicit_external_service_address():
+    content = read("document/README.zh_CN.md")
+
+    assert "需自行部署" in content
+    assert "docker-compose.yml` 不再内置该服务" in content
+    assert "http://douban-rs-api:80/" not in content

--- a/tests/test_makefile.py
+++ b/tests/test_makefile.py
@@ -52,6 +52,26 @@ def test_local_build_uses_lazy_branch_version_for_tags_and_build_arg():
     assert "talebook/talebook:feature-docker-slim" in result.stdout
 
 
+def test_local_build_tags_match_compose_image_names():
+    cases = (
+        ("build-spa", "talebook/talebook:latest", "ghcr.io/talebook/talebook:latest"),
+        ("build-dev", "talebook/talebook:dev", "ghcr.io/talebook/talebook:dev"),
+    )
+
+    for target, legacy_image, compose_image in cases:
+        result = subprocess.run(
+            [shutil.which("make"), "-n", target, "VER=feature-compose-ghcr"],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        assert result.returncode == 0
+        assert f"-t {legacy_image}" in result.stdout
+        assert f"-t {compose_image}" in result.stdout
+
+
 def test_makefile_exposes_no_push_targets_or_commands():
     makefile = MAKEFILE.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## 背景与目标

项目已经同步发布 GHCR 镜像，但生产和开发 Compose 仍默认使用 Docker Hub，并隐式启动第三方豆瓣元数据代理。本 PR 收敛默认运行依赖，让 Compose 使用 Talebook 自有 GHCR 镜像，并将可选豆瓣代理交由用户独立部署。

## 关键改动

- `docker-compose.yml` 默认镜像改为 `ghcr.io/talebook/talebook`。
- `docker-compose.dev.yml` 默认镜像改为 `ghcr.io/talebook/talebook:dev`。
- 从两份 Compose 中移除 `douban-rs-api` 服务及 `depends_on`。
- 为 `build-spa` 和 `build-dev` 补充 Compose 对应的 GHCR 标签，同时保留原有本地标签，确保 `make build && make up` 与 `make dev` 继续复用本地构建。
- 更新中英文使用文档，说明豆瓣代理需要独立部署并填写容器可达地址。
- 增加 YAML、双语文档与 Makefile 回归测试。
- 完成并激活本次内部方案。

## 实际验证

- `make test`：通过，1250 项通过、20 项跳过；26 条既有弃用或 SQLAlchemy 警告。
- `python3 -m pytest -q tests/test_docker_persistence_config.py tests/test_makefile.py`：通过，10 项通过。
- `make -n build-spa VER=feature-compose-ghcr`：通过，同时包含 `talebook/talebook:latest` 和 `ghcr.io/talebook/talebook:latest`。
- `make -n build-dev VER=feature-compose-ghcr`：通过，同时包含两种 `:dev` 标签。
- `make lint-py-fix`、`make lint-py`：通过。
- 本次修改的两个测试文件通过 Ruff 检查和格式检查。
- 两份 `docker compose ... config -q`：通过；仅有原 `version` 字段已过时警告。
- `make check-design`：通过，135 份方案文档通过校验。
- `git diff --check HEAD`：通过。
- 额外尝试在宿主机运行完整 pytest 时，因宿主机 Python 3.9 不支持项目使用的 Python 3.10 联合类型语法，且缺少 `txt2epub_next`、`quickjs`，在收集阶段出现 50 项环境错误；随后已通过仓库标准 Docker 测试入口完成全量验证。

## 风险与兼容性

- 新部署或重建服务时需要能够访问 GHCR。
- 原先依赖 Compose 内置豆瓣代理的用户，需要先独立部署代理并更新高级配置中的 URL。
- 数据卷、端口、环境变量、应用接口、原有本地镜像标签和 Docker Hub 发布流程保持不变；不涉及数据迁移。
- 未实际执行生产镜像构建后再由 Compose 启动；已通过 Makefile 命令展开、配置回归和 Docker 全量测试验证标签契约。
- 本次不影响页面、布局或交互，因此未执行界面审查，也无界面截图。

## 方案

- [GitHub 文件](https://github.com/talebook/talebook/blob/bc3a3f53b08b9c1eeb5c219217d11ecb55d22167/design/docker/20260901-compose-ghcr-default.active.html)
- [RawGitHack 在线预览](https://raw.githack.com/talebook/talebook/bc3a3f53b08b9c1eeb5c219217d11ecb55d22167/design/docker/20260901-compose-ghcr-default.active.html)
