### PR TITLE
fix(booksource): 搜索后打开书籍不再因连接租约误报 concurrent_run

### DIFF
--- a/tests/test_network_library.py
+++ b/tests/test_network_library.py
@@ -2,6 +2,7 @@
 # -*- coding: UTF-8 -*-
 """网络书库用户接口测试。"""
 
+import datetime
 import json
 import time
 import urllib.parse
@@ -298,6 +299,42 @@ class TestNetworkLibrary(TestWithUserLogin):
         session.expire_all()
         src = session.query(models.BookSourceModel).filter(models.BookSourceModel.id == self.sid).first()
         self.assertEqual(src.weight, 1)
+
+    @mock.patch("webserver.services.booksource.engine.build_session")
+    def test_browse_succeeds_while_connection_lease_is_held(self, m_session):
+        """TB-198 回归：搜索批量/超时宽限占用连接租约时，点击结果进入浏览页不得报 concurrent_run。"""
+        m_session.return_value = self._fake()
+        session = get_db()
+        connection = (
+            session.query(models.PluginConnection)
+            .join(models.PluginInstallation, models.PluginInstallation.id == models.PluginConnection.installation_id)
+            .filter(models.PluginInstallation.plugin_key == "talebook.source.legado")
+            .one()
+        )
+        original = (connection.lease_token, connection.lease_until)
+
+        def restore():
+            cleanup = get_db()
+            item = cleanup.get(models.PluginConnection, connection.id)
+            item.lease_token, item.lease_until = original
+            cleanup.commit()
+
+        self.addCleanup(restore)
+        connection.lease_token = "simulated-search-batch"
+        connection.lease_until = datetime.datetime.now() + datetime.timedelta(minutes=1)
+        session.commit()
+
+        book = self.json("/api/book-sources/book?source_id=%d&book_url=%s" % (self.sid, Q("/book/1001")))
+        self.assertEqual(book["err"], "ok", book)
+        self.assertEqual(book["book"]["name"], "剑来")
+        toc = self.json("/api/book-sources/toc?source_id=%d&book_url=%s" % (self.sid, Q("/book/1001")))
+        self.assertEqual(toc["err"], "ok", toc)
+        self.assertEqual(len(toc["chapters"]), 3, toc)
+
+        session = get_db()
+        item = session.get(models.PluginConnection, connection.id)
+        # 宽容读不带租约，收口后不得干扰租约持有者
+        self.assertEqual(item.lease_token, "simulated-search-batch")
 
     @mock.patch("webserver.services.booksource.engine.build_session")
     def test_book(self, m_session):

--- a/tests/test_plugin_capability_lookup.py
+++ b/tests/test_plugin_capability_lookup.py
@@ -476,7 +476,13 @@ def test_typed_retry_uses_connection_timeout_as_one_wall_clock_budget(db_session
     assert connection.lease_until is not None
 
 
-def test_typed_call_rejects_an_active_connection_lease(db_session):
+def test_typed_read_proceeds_while_another_run_holds_the_lease(db_session):
+    """TB-198 回归：连接租约被其他 run 占用时，只读能力调用不得报 concurrent_run。
+
+    网络书库里同一连接会同时承载搜索批量与详情/目录抓取；搜索尚未结束或读超时
+    宽限期内，用户点击搜索结果应能正常打开浏览页，而不是看到
+    “Another run is active for this connection”。
+    """
     registry = PluginRegistry()
     plugin = _plugin("talebook.test.typed-lease", "metadata.lookup")
     registry.register(plugin)
@@ -487,13 +493,87 @@ def test_typed_call_rejects_an_active_connection_lease(db_session):
     connection.lease_until = datetime.datetime.now() + datetime.timedelta(minutes=1)
     db_session.commit()
 
-    with pytest.raises(PluginRuntimeError) as exc:
-        PluginRuntime(db_session, SETTINGS, registry=registry).read(connection, "search_books", "三体")
+    result = PluginRuntime(db_session, SETTINGS, registry=registry).read(connection, "search_books", "三体")
 
-    assert exc.value.code == "plugin.concurrent_run"
+    assert result[0]["title"] == "三体"
     run = db_session.query(PluginRun).filter(PluginRun.connection_id == connection.id).one()
-    assert run.status == "failed"
-    assert run.error_code == "plugin.concurrent_run"
+    assert run.status == "succeeded"
+    db_session.refresh(connection)
+    # 宽容读不带租约执行，收口时不得清掉租约持有者
+    assert connection.lease_token == "other-worker"
+    assert connection.lease_until is not None
+
+
+def test_read_during_timeout_grace_is_not_rejected(db_session):
+    """TB-198 回归：读超时保留宽限租约（防不可取消 future 重叠）期间，用户重试的读仍成功。"""
+    registry = PluginRegistry()
+    plugin = _plugin("talebook.test.grace-read", "metadata.lookup")
+    registry.register(plugin)
+    import time as _time
+
+    calls = {"count": 0}
+
+    def slow_first(title, context):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            _time.sleep(0.3)
+        return [{"title": title}]
+
+    plugin.search_books = slow_first
+    connection = _install(db_session, registry, plugin)
+    connection.config = {"timeout_seconds": 0.05, "max_retries": 0, "backoff_seconds": 0}
+    db_session.commit()
+    runtime = PluginRuntime(db_session, SETTINGS, registry=registry)
+
+    with pytest.raises(PluginRuntimeError) as exc:
+        runtime.read(connection, "search_books", "三体")
+    assert exc.value.code == "plugin.timeout"
+    db_session.refresh(connection)
+    assert connection.lease_token
+    assert connection.lease_until is not None
+
+    # 宽限窗口内的下一次读（如重新点击搜索结果）必须成功且不干扰宽限租约
+    result = runtime.read(connection, "search_books", "三体")
+    assert result[0]["title"] == "三体"
+    db_session.refresh(connection)
+    assert connection.lease_token
+    runs = (
+        db_session.query(PluginRun)
+        .filter(PluginRun.connection_id == connection.id)
+        .order_by(PluginRun.id)
+        .all()
+    )
+    assert [run.status for run in runs] == ["failed", "succeeded"]
+    assert runs[0].error_code == "plugin.timeout"
+
+
+def test_second_read_batch_proceeds_while_first_batch_holds_the_lease(db_session):
+    """搜索批量并发宽容：前一批仍占用连接时，新搜索批量不再整批 concurrent_run。"""
+    registry = PluginRegistry()
+    plugin = _plugin("talebook.test.batch-overlap", "metadata.lookup")
+    registry.register(plugin)
+    connection = _install(db_session, registry, plugin)
+    runtime = PluginRuntime(db_session, SETTINGS, registry=registry)
+
+    first = runtime.begin_read_batch(connection, timeout=1, requested_by=1)
+    assert first["lease_token"]
+    second = runtime.begin_read_batch(connection, timeout=1, requested_by=1)
+    # 第二条宽容批量：不带租约，但审计 run 照常记录
+    assert second["lease_token"] == ""
+    assert second["run_id"] != first["run_id"]
+
+    runtime.finish_read_batch(first, {"source:1": {"count": 1}})
+    runtime.finish_read_batch(second, {"source:2": {"count": 1}})
+
+    db_session.refresh(connection)
+    assert connection.lease_token == ""
+    runs = (
+        db_session.query(PluginRun)
+        .filter(PluginRun.connection_id == connection.id)
+        .order_by(PluginRun.id)
+        .all()
+    )
+    assert [run.status for run in runs] == ["succeeded", "succeeded"]
 
 
 def test_read_pages_continues_from_page_cursor_without_overloading_sync_watermark(db_session):

--- a/webserver/services/plugin_runtime.py
+++ b/webserver/services/plugin_runtime.py
@@ -923,25 +923,36 @@ class PluginRuntime:
                 synchronize_session=False,
             )
         )
+        # read 型能力调用（网络书库搜索批量、详情/目录/正文抓取等）只是远端只读
+        # 请求，运行时内部本就允许同一连接上的并发读（一次搜索批量会并发执行多个
+        # 书源）。若把连接租约当作互斥锁强加给读，搜索批量占用的租约——或读超时
+        # 后保留的宽限租约——会让「点击搜索结果进入详情页」等后续读直接报
+        # concurrent_run。读遇忙时改为不带租约并发执行：不阻塞任何其他调用，也
+        # 不会在收口时误清持有者的租约（token 为空时清理语句匹配不到任何 token）。
+        # write/sync/execute 等有副作用的模式保持互斥，仍然快速失败。
+        tolerate = not acquired and mode == "read"
+        refused = not acquired and not tolerate
+        if tolerate:
+            token = ""
         run = PluginRun(
             connection_id=connection.id,
             action=mode,
             trigger="capability",
-            status="running" if acquired else "failed",
+            status="failed" if refused else "running",
             requested_by=requested_by,
             counts=dict(DEFAULT_COUNTS),
             cursor_before=dict(connection.cursor or {}),
             cursor_after=dict(connection.cursor or {}),
             input_data=dict(audit_data or {}),
-            error_code="" if acquired else "plugin.concurrent_run",
-            error_message="" if acquired else "Another run is active for this connection",
+            error_code="" if not refused else "plugin.concurrent_run",
+            error_message="" if not refused else "Another run is active for this connection",
             create_time=now,
-            started_at=now if acquired else None,
-            finished_at=None if acquired else now,
+            started_at=None if refused else now,
+            finished_at=now if refused else None,
         )
         self.session.add(run)
         self.session.commit()
-        if not acquired:
+        if refused:
             raise PluginRuntimeError("plugin.concurrent_run", "Another run is active for this connection")
         return run, token
 


### PR DESCRIPTION
## 背景

网络书库（插件化书源）中，搜索书籍后点击搜索结果进入书籍浏览页时，页面报错 **"Another run is active for this connection"**（TB-198）。

## 根因

`PluginRuntime._begin_capability_run()` 把同一插件连接的租约当作全量互斥锁：租约被占用时，任何新 run 立即以 `plugin.concurrent_run` 失败。

但 read 型能力调用（搜索批量、`get_book`/`get_toc`/`get_chapter` 等）只是远端只读请求，同一连接本就允许并发——一次搜索批量就会并发执行同一连接上的多个书源（每个 binding 自带独立 engine/session）。被误伤的场景：

1. **搜索批量持有租约期间点击结果**：搜索按 connection 分组只建一个 lease/run，直到该组最后一个书源结束才收口；结果按书源逐个浮现，用户在批量结束前点击任意结果，详情读即被拒。
2. **读超时后的宽限租约**：读超时（`plugin.timeout`）后运行时会保留租约到 `timeout + 30s`（防不可取消的 future 与副作用重叠）。宽限期内用户重试点击（或浏览器重发）仍然被拒，表现为持续报错。

Beta 实例（`cacb4880`）的 `plugin_runs` 中有直接证据：`get_toc` 超时 run（23:18:05→23:18:25）结束后 0.26s 的下一次读即被记成 `plugin.concurrent_run`（run #41、#32 同型）。

## 修复

`webserver/services/plugin_runtime.py`：read 模式能力调用在租约被占用时不再快速失败，改为**不带租约并发执行**：

- 审计 run 照常记录（running → succeeded/failed）；
- 宽容读 token 为空，收口清理语句 `WHERE lease_token == token` 匹配不到任何持有者，不会误清他人租约；
- `write` / `sync` / `execute()` 等有副作用的模式保持互斥、照旧快速失败。

## 测试

- `tests/test_plugin_capability_lookup.py`：
  - typed read 在租约被其他 run 占有时成功，且不干扰租约持有者（改写原 `test_typed_call_rejects_an_active_connection_lease`）；
  - 读超时宽限期内重试的读成功；
  - 前一搜索批量持约时，新搜索批量正常收口（不再整批 concurrent_run）。
- `tests/test_network_library.py`：占用 Legado 连接租约（模拟进行中的搜索批量）后，`/api/book-sources/book` 与 `/api/book-sources/toc` 均正常返回，且租约未被误清。

验证（docker 测试镜像，与 CI 同源）：
- `tests/test_plugin_capability_lookup.py`、`tests/test_plugin_runtime.py`：54 passed
- `tests/test_network_library.py`：24 passed
- `tests/test_main.py`：98 passed, 1 skipped
- 插件/书源/管理相关集（network_save、plugin_connection_role、plugin_contract、plugin_protocol_tightening、booksource_admin、book_source_plugins、plugins_api、admin、self_check 等）：242 passed
- `ruff check` 通过
- 无方案文档：本次为既有运行时语义的定向缺陷修复，不改 API/表结构/权限，行为变化由上述回归测试直接锁定，按小型修复豁免。
