### PR TITLE
TB-198: 插件请求按 plugin+host 排队

### DIFF
--- a/design/webserver/20260904-plugin-host-concurrency-queue.active.html
+++ b/design/webserver/20260904-plugin-host-concurrency-queue.active.html
@@ -1,0 +1,98 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Talebook 插件按 plugin 与 host 公平排队的并发控制方案。" />
+    <link rel="icon" href="data:," />
+    <title>插件请求按 plugin + host 排队 · ACTIVE</title>
+    <style>
+      :root { color-scheme: light; --bg:#f5f7fb; --panel:#fff; --ink:#172033; --muted:#58657a; --line:#d8e0ec; --accent:#176b87; --soft:#e9f5f8; --warn:#fff5dd; --good:#e7f6ed; --shadow:0 12px 30px rgba(23,32,51,.08); --sans:-apple-system,BlinkMacSystemFont,"Segoe UI","PingFang SC","Microsoft YaHei",sans-serif; --mono:"SFMono-Regular",Consolas,monospace; }
+      * { box-sizing:border-box; } body { margin:0; color:var(--ink); background:linear-gradient(145deg,#fafdff,var(--bg)); font-family:var(--sans); line-height:1.65; }
+      .page { width:min(1080px,calc(100vw - 28px)); margin:auto; padding:26px 0 52px; } .hero,.card { background:var(--panel); border:1px solid var(--line); border-radius:18px; box-shadow:var(--shadow); }
+      .hero { padding:30px 32px; margin-bottom:18px; border-top:5px solid var(--accent); } h1 { margin:0 0 10px; font-size:clamp(28px,4vw,44px); line-height:1.15; } .sub { margin:0; color:var(--muted); }
+      .chips { display:flex; flex-wrap:wrap; gap:8px; margin-top:18px; } .chip { padding:5px 11px; border-radius:999px; background:#eef2f7; color:#4c5a70; font-size:12px; font-weight:700; } .chip.active { color:#176238; background:var(--good); }
+      .card { padding:24px 27px; margin-bottom:18px; } h2 { margin:0 0 13px; font-size:22px; } h3 { margin:20px 0 8px; font-size:16px; } p { margin:0 0 12px; } p,li,td,th { font-size:14px; } ul,ol { margin:8px 0 0 21px; padding:0; } li + li { margin-top:5px; }
+      code { padding:.1em .35em; border-radius:4px; background:#edf2f7; font-family:var(--mono); overflow-wrap:anywhere; } .callout { padding:14px 16px; border:1px solid var(--line); border-radius:13px; background:#f8fafc; } .callout.good { background:var(--good); border-color:#b9dcc7; } .callout.warn { background:var(--warn); border-color:#ead4a5; }
+      .grid { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:14px; } .choice { padding:16px; border:1px solid var(--line); border-radius:14px; } .choice h3 { margin-top:0; }
+      .flow { display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); gap:10px; margin-top:14px; } .step { padding:15px; border:1px solid var(--line); border-radius:14px; background:#fbfcfe; } .step b { display:block; margin-bottom:5px; } .step span { color:var(--accent); font:700 11px var(--mono); }
+      .table-wrap { overflow-x:auto; border:1px solid var(--line); border-radius:13px; } table { width:100%; min-width:680px; border-collapse:collapse; } th,td { padding:10px 11px; border-right:1px solid var(--line); border-bottom:1px solid var(--line); text-align:left; vertical-align:top; } th { background:#f6f8fb; color:#4d5b70; } th:last-child,td:last-child { border-right:0; } tr:last-child td { border-bottom:0; }
+      .passed { color:#176238; font-weight:800; } footer { color:var(--muted); text-align:center; font-size:12px; } .skip { position:absolute; left:-9999px; } .skip:focus { left:8px; top:8px; background:#fff; padding:8px; z-index:2; }
+      @media (max-width:720px) { .page { width:calc(100vw - 18px); padding-top:10px; } .hero,.card { padding:21px 18px; border-radius:14px; } .grid,.flow { grid-template-columns:1fr; } }
+      @media (prefers-reduced-motion:reduce) { * { scroll-behavior:auto !important; } } @media print { body { background:#fff; } .page { width:100%; } .hero,.card { box-shadow:none; break-inside:avoid; } }
+    </style>
+  </head>
+  <body>
+    <a class="skip" href="#main">跳到正文</a>
+    <div class="page">
+      <header class="hero">
+        <h1>插件请求按 plugin + host 排队</h1>
+        <p class="sub">把网络书库的并发约束从 connection 互斥改为真实 HTTP 出口上的共享 host 队列；搜索、浏览与保存在达到上限后等待，而不是立即失败。</p>
+        <div class="chips" aria-label="方案元信息">
+          <span class="chip active">状态：ACTIVE</span><span class="chip">创建日期：2026-09-04</span><span class="chip">所属模块：webserver</span><span class="chip">影响范围：插件运行时、网络书库</span><span class="chip">需求来源：TB-198</span>
+        </div>
+      </header>
+      <main id="main">
+        <section class="card">
+          <h2>1. 原始诉求</h2>
+          <div class="callout warn">“之前的 PR 已经合并了。你优化一下，按照 plugin+host 来排队，并且对于搜索、保存场景，应该是【限频后排队等待】而不是立刻失败报错。”</div>
+          <p>PR 1034 已让并发 read 绕过 connection lease，消除了点击搜索结果时的误拒绝；但它没有建立上游站点级限流，而且第一个 read 仍会持有 connection lease。</p>
+        </section>
+        <section class="card">
+          <h2>2. 目标与边界</h2>
+          <div class="grid">
+            <article class="choice"><h3>目标</h3><ul><li>以 <code>(plugin_key, hostname, effective_port)</code> 为唯一排队键。</li><li>同键请求按 FIFO 等待空位，等待计入能力调用总 deadline。</li><li>搜索、详情、目录、章节与封面请求共用同一 host 上限。</li><li>read 不再取得 connection lease；有副作用能力保持互斥。</li></ul></article>
+            <article class="choice"><h3>非目标</h3><ul><li>本次不实现 QPS/token-bucket；限制的是同时在途 HTTP 数。</li><li>不新增数据库表或迁移，队列作用域为当前服务进程。</li><li>不改变 HTTP API、前端交互和书源协议。</li><li>不移除搜索及保存线程池的进程资源上限。</li></ul></article>
+          </div>
+        </section>
+        <section class="card">
+          <h2>3. 现状与证据</h2>
+          <div class="table-wrap" role="region" aria-label="现状证据" tabindex="0"><table><thead><tr><th>现状</th><th>证据</th><th>影响</th></tr></thead><tbody>
+            <tr><td>lease 键是 <code>connection_id</code></td><td><code>webserver/services/plugin_runtime.py</code> 的 <code>_begin_capability_run</code></td><td>Legado 的多个 host 共用一条 connection，粒度过粗。</td></tr>
+            <tr><td>搜索池是进程全局池</td><td><code>webserver/services/booksource_search.py</code></td><td>只有总 worker 上限，没有单 host 共享队列。</td></tr>
+            <tr><td>整书保存每任务建池</td><td><code>webserver/services/booksource/save_service.py</code></td><td>多个保存任务的同 host 请求可以叠加。</td></tr>
+            <tr><td>所有 Legado HTTP 已经过安全客户端</td><td><code>webserver/plugins/source/legado.py</code></td><td>在 <code>SafeHttpClient</code> 出口排队可覆盖实际 URL 和多种业务入口。</td></tr>
+          </tbody></table></div>
+        </section>
+        <section class="card">
+          <h2>4. 方案</h2>
+          <div class="callout good"><strong>结论：</strong>运行时在调用 provider 时注入 plugin 身份与 host 并发配置，<code>SafeHttpClient</code> 按实际请求 URL 归一化 host 并进入进程级 FIFO 队列；请求完成或异常时在 <code>finally</code> 释放 slot。</div>
+          <div class="flow" aria-label="排队流程">
+            <article class="step"><span>IDENTIFY</span><b>绑定 plugin</b><p>运行时以 manifest id 标识当前 provider。</p></article>
+            <article class="step"><span>GROUP</span><b>归一化 host</b><p>URL 转为小写 hostname 与有效端口。</p></article>
+            <article class="step"><span>QUEUE</span><b>FIFO 等待</b><p>同键达到上限后等待，保留跨键独立性。</p></article>
+            <article class="step"><span>RELEASE</span><b>完成后唤醒</b><p>成功、HTTP 错误或异常均释放并唤醒队首。</p></article>
+          </div>
+          <h3>配置与兼容性</h3>
+          <ul>
+            <li>新增运行时连接配置 <code>host_concurrency</code>，默认 10，允许 1–100；Legado schema 显式展示该项。</li>
+            <li><code>search_concurrency</code> 继续控制搜索生产者线程池，<code>save_concurrency</code> 继续控制单个保存任务的章节 worker；二者不再冒充 host 上限。</li>
+            <li>未通过 <code>SafeHttpClient</code> 发出的非插件网络请求不进入此队列，避免无 plugin 身份时错误合并。</li>
+            <li>队列等到总 deadline 耗尽时返回 timeout 类错误，不返回 <code>plugin.concurrent_run</code>。</li>
+          </ul>
+        </section>
+        <section class="card">
+          <h2>5. 影响、风险与回滚</h2>
+          <div class="grid"><article class="choice"><h3>影响范围</h3><p><code>safe_http.py</code> 新增公平队列；<code>plugin_runtime.py</code> 注入策略并移除 read lease；Legado 暴露 host 上限；保存封面显式携带 plugin 身份。</p></article><article class="choice"><h3>保持不变</h3><p>写、同步和 execute 的 connection lease；429 重试；搜索结果协议；保存任务去重；SSRF、重定向和响应大小校验。</p></article></div>
+          <div class="callout warn"><strong>风险：</strong>同步等待会占用调用线程；现有有界 worker 池提供进程容量上限。FIFO、不同 key 不互阻、异常释放、deadline 退出与多入口共享必须用并发测试锁定。</div>
+          <p><strong>回滚：</strong>整项改动无数据迁移，可按提交回滚；旧连接没有新字段时自动使用默认值。</p>
+        </section>
+        <section class="card">
+          <h2>6. 测试计划与结果</h2>
+          <div class="table-wrap" role="region" aria-label="测试计划" tabindex="0"><table><thead><tr><th>验证层</th><th>计划命令</th><th>关键断言</th><th>结果</th></tr></thead><tbody>
+            <tr><td>队列单元</td><td><code>pytest -q tests/test_book_source_plugins.py tests/test_plugin_capability_lookup.py tests/test_plugin_runtime.py tests/test_booksource_engine.py</code></td><td>同 plugin+host FIFO 等待；不同 plugin/host 独立；超时保留 typed error。</td><td class="passed">通过：143 passed</td></tr>
+            <tr><td>运行时</td><td><code>pytest -q tests/test_book_source_plugins.py tests/test_plugin_capability_lookup.py tests/test_plugin_runtime.py tests/test_booksource_engine.py</code></td><td>read 不持 lease；write/sync 仍互斥；deadline 正确。</td><td class="passed">通过：143 passed</td></tr>
+            <tr><td>官方 Docker 全量</td><td><code>make test</code></td><td>网络书库、保存、插件 API 与全仓回归。</td><td class="passed">通过：1271 passed, 20 skipped</td></tr>
+            <tr><td>质量门禁</td><td><code>make lint-py</code>、<code>ruff check</code>、<code>git diff --check</code>、<code>make check-design</code></td><td>格式、静态检查、补丁完整性与方案门禁。</td><td class="passed">通过</td></tr>
+          </tbody></table></div>
+          <p>纯后端调度改动，不修改页面、布局、交互或前端消费者；无需界面渲染审查。配置项由既有插件 schema 表单承载，API 结构保持不变。</p>
+        </section>
+        <section class="card">
+          <h2>7. 决策记录</h2>
+          <ol><li><strong>2026-09-04：</strong>用户确认排队键为 plugin+host，并明确搜索、保存达到上限后等待而非快速失败。</li><li><strong>2026-09-04：</strong>选择实际 HTTP 出口排队，避免仅在搜索/保存入口限流而漏掉详情、目录、分页和封面。</li><li><strong>2026-09-04：</strong>官方 Docker 全量回归与质量门禁通过，方案状态固化为 ACTIVE。</li></ol>
+        </section>
+      </main>
+      <footer>Talebook internal design · webserver · ACTIVE · 2026-09-04</footer>
+    </div>
+  </body>
+</html>

--- a/design/webserver/20260904-plugin-host-concurrency-queue.active.html
+++ b/design/webserver/20260904-plugin-host-concurrency-queue.active.html
@@ -63,6 +63,9 @@
             <article class="step"><span>QUEUE</span><b>FIFO 等待</b><p>同键达到上限后等待，保留跨键独立性。</p></article>
             <article class="step"><span>RELEASE</span><b>完成后唤醒</b><p>成功、HTTP 错误或异常均释放并唤醒队首。</p></article>
           </div>
+          <h3>评审修订（2026-09-12）</h3>
+          <p>PR 1035 尚未合并，本轮在同一方案中修订。有效并发上限取所有等待及在途请求配置的最小值；使用按配置值计数的集合，在请求完成、异常或排队超时时移除对应限制，避免旧低值在持续繁忙时永久生效。等待中的低值也约束新请求，让已有请求排空后再按严格上限执行。</p>
+          <p>队首取得槽位后立即通知其他等待者，确保还有空位时下一位无需等到无关请求完成。保留 FIFO、跨键隔离和总 deadline；不引入新配置。验证计划：低值请求结束及超时后恢复吞吐、在途低值仍受保护、多槽位漏唤醒的确定性调度回归、全量测试及本地 DeepSec L1/L2。队列验证：新增 5 项全部通过；用原实现运行同一组测试为 4 failed、1 passed，证明可复现两条评审缺陷。全量复验：1276 passed、20 skipped。</p>
           <h3>配置与兼容性</h3>
           <ul>
             <li>新增运行时连接配置 <code>host_concurrency</code>，默认 10，允许 1–100；Legado schema 显式展示该项。</li>
@@ -79,6 +82,8 @@
         </section>
         <section class="card">
           <h2>6. 测试计划与结果</h2>
+          <p><strong>2026-09-12 评审复验：</strong><code>python3 -m pytest -q tests/test_plugin_host_queue.py</code>：5 passed；<code>make lint-py-fix</code>、<code>make lint-py</code>、新增测试 <code>ruff check</code> 通过。本轮在现有 <code>talebook/talebook:v26.08.11</code> 容器中补装 <code>pytest==7.4.4</code>、分支要求的 <code>rarfile==4.2</code> 后执行 <code>pytest -q tests</code>：1276 passed、20 skipped（74.76 秒）。<code>make pytest</code> 的覆盖率运行曾出现 <code>test_search_weight_increment</code> 五秒等待超时（1275 passed、20 skipped、1 failed，整体覆盖率 73%）；上述无覆盖率全量复验通过，保留此时序敏感风险。标准 <code>make test</code> 在 Debian 软件源下载阶段长时间无进展后取消，替代镜像不是本分支新构建的 test 镜像。最初替代镜像缺少 rarfile 引起的 8 项失败已通过补装声明依赖消除。<code>make check-design</code> 与 <code>git diff --check</code> 通过。下面原有测试表记录 2026-09-04 的首次验证。</p>
+          <p>DeepSec 0.2.0（fff031fc01fb36b95348214c8ee359f6ede8aa8b），执行 <code>deepsec shield scan . --layer l1,l2 --include-tests --format json --output -</code>，全仓 520 个支持的文件，L1/L2，退出码 2，stderr 为空。122 项发现（32 critical、69 high、21 medium）；队列代码与新增测试无发现。涉及 PR 文件的 2 项为测试固定 lease token 误报，另外 120 项位于与 merge-base 相同的文件，未在本次评审中修复或完整审计，不能视为全仓安全通过。所有改动 Python 均在覆盖范围，HTML 方案使用 check-design 检查；未使用远程 LLM。</p>
           <div class="table-wrap" role="region" aria-label="测试计划" tabindex="0"><table><thead><tr><th>验证层</th><th>计划命令</th><th>关键断言</th><th>结果</th></tr></thead><tbody>
             <tr><td>队列单元</td><td><code>pytest -q tests/test_book_source_plugins.py tests/test_plugin_capability_lookup.py tests/test_plugin_runtime.py tests/test_booksource_engine.py</code></td><td>同 plugin+host FIFO 等待；不同 plugin/host 独立；超时保留 typed error。</td><td class="passed">通过：143 passed</td></tr>
             <tr><td>运行时</td><td><code>pytest -q tests/test_book_source_plugins.py tests/test_plugin_capability_lookup.py tests/test_plugin_runtime.py tests/test_booksource_engine.py</code></td><td>read 不持 lease；write/sync 仍互斥；deadline 正确。</td><td class="passed">通过：143 passed</td></tr>
@@ -89,7 +94,7 @@
         </section>
         <section class="card">
           <h2>7. 决策记录</h2>
-          <ol><li><strong>2026-09-04：</strong>用户确认排队键为 plugin+host，并明确搜索、保存达到上限后等待而非快速失败。</li><li><strong>2026-09-04：</strong>选择实际 HTTP 出口排队，避免仅在搜索/保存入口限流而漏掉详情、目录、分页和封面。</li><li><strong>2026-09-04：</strong>官方 Docker 全量回归与质量门禁通过，方案状态固化为 ACTIVE。</li></ol>
+          <ol><li><strong>2026-09-04：</strong>用户确认排队键为 plugin+host，并明确搜索、保存达到上限后等待而非快速失败。</li><li><strong>2026-09-04：</strong>选择实际 HTTP 出口排队，避免仅在搜索/保存入口限流而漏掉详情、目录、分页和封面。</li><li><strong>2026-09-04：</strong>官方 Docker 全量回归与质量门禁通过，方案首次转为 ACTIVE（尚未合并）。</li><li><strong>2026-09-12：</strong>修复低值并发上限残留和多槽位漏唤醒；完成确定性回归、全量复验和安全扫描记录，同一方案恢复 ACTIVE。无界面影响：仅修订后端队列内部调度和测试，不修改页面、API 或配置表单；本轮豁免界面审查。</li></ol>
         </section>
       </main>
       <footer>Talebook internal design · webserver · ACTIVE · 2026-09-04</footer>

--- a/tests/test_book_source_plugins.py
+++ b/tests/test_book_source_plugins.py
@@ -2,6 +2,7 @@ import hashlib
 import json
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 from unittest import mock
 
@@ -13,9 +14,14 @@ from tests.test_booksource_admin import CSS_SOURCE
 from tests.test_booksource_engine import FakeSession, text
 from webserver.models import Base, PluginRunItem, PluginSourceRecord
 from webserver.plugins.register import SOURCE_PROVIDERS
-from webserver.plugins.runtime.domains import MetadataQuery
+from webserver.plugins.runtime.domains import MetadataQuery, SourceChapter
 from webserver.plugins.runtime.protocol import PROTOCOL_VERSION, ProviderItem, ProviderResult
-from webserver.plugins.runtime.safe_http import EndpointPolicyError, SafeHttpClient, validate_remote_endpoint
+from webserver.plugins.runtime.safe_http import (
+    EndpointPolicyError,
+    HostQueueTimeout,
+    SafeHttpClient,
+    validate_remote_endpoint,
+)
 from webserver.plugins.source.base import OPDSProvider
 from webserver.plugins.source.internet_archive import InternetArchiveProvider
 from webserver.plugins.source.legado import PROVIDER as LEGADO_PROVIDER
@@ -332,12 +338,96 @@ def test_endpoint_policy_rejects_private_credentials_and_redirect_targets():
         ).request("GET", "https://books.example/opds")
 
 
+class BlockingHttpSession:
+    def __init__(self, started=None, release=None):
+        self.started = started or threading.Event()
+        self.release = release
+
+    @staticmethod
+    def resolver(host, port, **kwargs):
+        return [(2, 1, 6, "", ("93.184.216.34", port or 443))]
+
+    def request(self, *args, **kwargs):
+        self.started.set()
+        if self.release is not None:
+            assert self.release.wait(2), "blocked HTTP request was not released"
+        return response({"ok": True})
+
+
+def test_plugin_host_queue_waits_and_keeps_other_keys_independent():
+    release = threading.Event()
+    first_started = threading.Event()
+    second_started = threading.Event()
+    first = SafeHttpClient(
+        session=BlockingHttpSession(first_started, release),
+        plugin_key="talebook.test.queue",
+        max_concurrency=1,
+    )
+    second = SafeHttpClient(
+        session=BlockingHttpSession(second_started),
+        plugin_key="talebook.test.queue",
+        max_concurrency=1,
+    )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first_future = executor.submit(first.request, "GET", "https://books.example/first")
+        assert first_started.wait(1)
+        second_future = executor.submit(second.request, "GET", "https://books.example/second")
+        assert not second_started.wait(0.05), "same plugin+host request must wait for a slot"
+
+        # The same host under another plugin and another host under the same
+        # plugin are distinct queues and must not be held behind the first call.
+        other_plugin = SafeHttpClient(
+            session=BlockingHttpSession(),
+            plugin_key="talebook.test.other",
+            max_concurrency=1,
+        )
+        other_host = SafeHttpClient(
+            session=BlockingHttpSession(),
+            plugin_key="talebook.test.queue",
+            max_concurrency=1,
+        )
+        assert other_plugin.request("GET", "https://books.example/other-plugin").status_code == 200
+        assert other_host.request("GET", "https://catalog.example/other-host").status_code == 200
+
+        release.set()
+        assert first_future.result(timeout=1).status_code == 200
+        assert second_future.result(timeout=1).status_code == 200
+        assert second_started.is_set()
+
+
+def test_plugin_host_queue_waits_until_request_deadline_before_timing_out():
+    release = threading.Event()
+    first_started = threading.Event()
+    first = SafeHttpClient(
+        session=BlockingHttpSession(first_started, release),
+        plugin_key="talebook.test.deadline",
+        max_concurrency=1,
+    )
+    waiting = SafeHttpClient(
+        session=BlockingHttpSession(),
+        plugin_key="talebook.test.deadline",
+        max_concurrency=1,
+    )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first_future = executor.submit(first.request, "GET", "https://books.example/first")
+        assert first_started.wait(1)
+        started = time.monotonic()
+        with pytest.raises(HostQueueTimeout):
+            waiting.request("GET", "https://books.example/waiting", timeout=0.05)
+        assert time.monotonic() - started >= 0.04
+        release.set()
+        assert first_future.result(timeout=1).status_code == 200
+
+
 def test_legado_global_config_declares_safe_bounded_defaults():
     schema = LEGADO_PROVIDER.manifest["config_schema"]["properties"]
 
     assert schema["search_result_limit"] == {"type": "integer", "minimum": 1, "maximum": 100, "default": 5}
     assert schema["search_concurrency"]["default"] == 20
     assert schema["save_concurrency"]["default"] == 10
+    assert schema["host_concurrency"] == {"type": "integer", "minimum": 1, "maximum": 100, "default": 10}
     assert schema["private_network_protection"] == {"type": "boolean", "default": True}
 
 
@@ -352,6 +442,36 @@ def test_legado_search_limits_each_source_result_count():
 
     assert len(result.items) == 1
     assert result.items[0].title == "剑来"
+
+
+def test_legado_search_and_save_reads_share_the_plugin_host_queue():
+    search_started = threading.Event()
+    chapter_started = threading.Event()
+    release_search = threading.Event()
+
+    class QueuedLegadoSession(FakeSession):
+        def request(self, method, url, **kwargs):
+            if "/search" in url:
+                search_started.set()
+                assert release_search.wait(2), "search request was not released"
+            elif "/chapter" in url:
+                chapter_started.set()
+            return super().request(method, url, **kwargs)
+
+    session = QueuedLegadoSession({"/search": text("search.html"), "/chapter": text("content.html")})
+    config = {"source_raw": CSS_SOURCE, "host_concurrency": 1}
+    chapter = SourceChapter(external_id="http://x.com/chapter", title="第一章")
+
+    with mock.patch("webserver.plugins.source.legado.booksource_engine.build_session", return_value=session):
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            search_future = executor.submit(LEGADO_PROVIDER.search, "剑来", {}, context(config=config))
+            assert search_started.wait(1)
+            chapter_future = executor.submit(LEGADO_PROVIDER.get_chapter, chapter, context(config=config))
+            assert not chapter_started.wait(0.05), "save chapter must queue behind search for the same plugin+host"
+            release_search.set()
+            assert search_future.result(timeout=1).items
+            assert chapter_future.result(timeout=1).content
+            assert chapter_started.is_set()
 
 
 def test_legado_admin_config_can_disable_only_the_private_address_check():

--- a/tests/test_network_library.py
+++ b/tests/test_network_library.py
@@ -169,7 +169,7 @@ class TestNetworkLibrary(TestWithUserLogin):
         m_session.return_value = self._fake()
         # 创建任务：立即返回 task_id，不阻塞
         # 默认搜索还会覆盖启用的公共书源插件；这里显式选中 Legado，
-        # 让本用例只验证其任务进度与 runtime lease/run 收口。
+        # 让本用例只验证其任务进度与 runtime audit run 收口。
         d = self.json("/api/network/search?key=%s&sources=%s" % (Q("剑来"), Q("legado:%s" % self.sid)))
         self.assertEqual(d["err"], "ok")
         self.assertTrue(d["task_id"])
@@ -198,7 +198,7 @@ class TestNetworkLibrary(TestWithUserLogin):
 
     @mock.patch("webserver.services.booksource.engine.build_session")
     def test_search_groups_multiple_bindings_into_one_runtime_run(self, m_session):
-        """Legado 多个事实书源共用一条 connection，也只占用一个 lease/run。"""
+        """Legado 多个事实书源共用一条 connection，也只建立一个 audit run。"""
         m_session.side_effect = lambda *_args, **_kwargs: self._fake()
         session = get_db()
         second = models.BookSourceModel(CSS_SOURCE)
@@ -302,7 +302,7 @@ class TestNetworkLibrary(TestWithUserLogin):
 
     @mock.patch("webserver.services.booksource.engine.build_session")
     def test_browse_succeeds_while_connection_lease_is_held(self, m_session):
-        """TB-198 回归：搜索批量/超时宽限占用连接租约时，点击结果进入浏览页不得报 concurrent_run。"""
+        """TB-198 回归：有副作用调用持有连接租约时，只读浏览不得报 concurrent_run。"""
         m_session.return_value = self._fake()
         session = get_db()
         connection = (
@@ -333,7 +333,7 @@ class TestNetworkLibrary(TestWithUserLogin):
 
         session = get_db()
         item = session.get(models.PluginConnection, connection.id)
-        # 宽容读不带租约，收口后不得干扰租约持有者
+        # read 不参与租约，收口后不得干扰有副作用调用的租约。
         self.assertEqual(item.lease_token, "simulated-search-batch")
 
     @mock.patch("webserver.services.booksource.engine.build_session")

--- a/tests/test_plugin_capability_lookup.py
+++ b/tests/test_plugin_capability_lookup.py
@@ -4,6 +4,7 @@ import asyncio
 import inspect
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from unittest import mock
 
 import pytest
@@ -14,6 +15,7 @@ from webserver.models import Base, PluginRun
 from webserver.plugins.push.base import PUSH_CAPABILITY
 from webserver.plugins.runtime.domains import CheckReport, Page, Review
 from webserver.plugins.runtime.protocol import PROTOCOL_VERSION, UpstreamAuthError, UpstreamRateLimitError
+from webserver.plugins.runtime.safe_http import HostQueueTimeout, SafeHttpClient
 from webserver.services.plugin_runtime import (
     PluginRegistry,
     PluginRuntime,
@@ -288,7 +290,7 @@ def test_push_route_creates_personal_connection_and_uses_sync_runtime(db_session
     assert connection.lease_until is None
 
 
-def test_read_batch_timeout_keeps_the_grace_lease(db_session):
+def test_read_batch_timeout_never_creates_a_connection_lease(db_session):
     registry = PluginRegistry()
     plugin = _plugin("talebook.test.batch-timeout", "metadata.lookup")
     registry.register(plugin)
@@ -305,8 +307,9 @@ def test_read_batch_timeout_keeps_the_grace_lease(db_session):
     db_session.refresh(connection)
     assert run.status == "failed"
     assert run.error_code == "plugin.timeout"
-    assert connection.lease_token == batch["lease_token"]
-    assert connection.lease_until is not None
+    assert batch["lease_token"] == ""
+    assert connection.lease_token == ""
+    assert connection.lease_until is None
 
 
 def test_prepare_read_returns_callables_that_never_touch_the_session(db_session):
@@ -327,8 +330,125 @@ def test_prepare_read_returns_callables_that_never_touch_the_session(db_session)
     assert unit["call"]("search_books", "标题")[0]["title"] == "标题"
 
 
-def test_external_pool_bridge_uses_lease_retry_and_durable_audit(db_session):
-    """既有流式线程池桥接也必须继承 typed runtime 的租约、重试与审计。"""
+def test_prepared_reads_inject_plugin_identity_into_the_shared_host_queue(db_session):
+    registry = PluginRegistry()
+    plugin = _plugin("talebook.test.host-queue", "metadata.lookup")
+    registry.register(plugin)
+    instance_connection = _install(db_session, registry, plugin)
+    user_connection = save_connection(
+        db_session,
+        SETTINGS,
+        instance_connection.installation_id,
+        "user",
+        42,
+        {},
+        config={"host_concurrency": 1},
+        name="个人连接",
+    )
+    instance_connection.config = {"host_concurrency": 1}
+    db_session.commit()
+
+    first_started = threading.Event()
+    second_started = threading.Event()
+    release = threading.Event()
+    lock = threading.Lock()
+    calls = {"count": 0}
+
+    class Session:
+        @staticmethod
+        def resolver(host, port, **kwargs):
+            return [(2, 1, 6, "", ("93.184.216.34", port or 443))]
+
+        def request(self, *args, **kwargs):
+            with lock:
+                calls["count"] += 1
+                number = calls["count"]
+            if number == 1:
+                first_started.set()
+                assert release.wait(2), "first plugin HTTP request was not released"
+            else:
+                second_started.set()
+            return mock.Mock(status_code=200, headers={}, content=b"{}")
+
+    client = SafeHttpClient(session=Session())
+
+    def queued_search(title, context):
+        client.request("GET", "https://books.example/search", timeout=1)
+        return [{"title": title}]
+
+    plugin.search_books = queued_search
+    runtime = PluginRuntime(db_session, SETTINGS, registry=registry)
+    prepared, failures = runtime.prepare_read([instance_connection, user_connection], timeout=1)
+    assert failures == {}
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(prepared[0]["call"], "search_books", "第一本")
+        assert first_started.wait(1)
+        second = executor.submit(prepared[1]["call"], "search_books", "第二本")
+        assert not second_started.wait(0.05), "runtime must group connections by plugin+host, not connection id"
+        release.set()
+        assert first.result(timeout=1)[0]["title"] == "第一本"
+        assert second.result(timeout=1)[0]["title"] == "第二本"
+
+
+def test_host_queue_timeout_keeps_its_typed_runtime_error(db_session):
+    plugin_id = "talebook.test.host-queue-timeout"
+    registry = PluginRegistry()
+    plugin = _plugin(plugin_id, "metadata.lookup")
+    registry.register(plugin)
+    connection = _install(db_session, registry, plugin)
+    connection.config = {"host_concurrency": 1}
+    db_session.commit()
+
+    release = threading.Event()
+    first_started = threading.Event()
+
+    class BlockingSession:
+        @staticmethod
+        def resolver(host, port, **kwargs):
+            return [(2, 1, 6, "", ("93.184.216.34", port or 443))]
+
+        def request(self, *args, **kwargs):
+            first_started.set()
+            assert release.wait(2), "blocking request was not released"
+            return mock.Mock(status_code=200, headers={}, content=b"{}")
+
+    class WaitingSession:
+        @staticmethod
+        def resolver(host, port, **kwargs):
+            return [(2, 1, 6, "", ("93.184.216.34", port or 443))]
+
+        @staticmethod
+        def request(*args, **kwargs):
+            return mock.Mock(status_code=200, headers={}, content=b"{}")
+
+    blocker = SafeHttpClient(session=BlockingSession(), plugin_key=plugin_id, max_concurrency=1)
+    client = SafeHttpClient(session=WaitingSession())
+    plugin.search_books = lambda title, context: client.request(
+        "GET",
+        "https://books.example/search",
+        timeout=0.03,
+    )
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        blocked = executor.submit(blocker.request, "GET", "https://books.example/block")
+        assert first_started.wait(1)
+        try:
+            with pytest.raises(HostQueueTimeout) as exc:
+                PluginRuntime(db_session, SETTINGS, registry=registry).read(
+                    connection,
+                    "search_books",
+                    "三体",
+                    timeout=1,
+                )
+            assert exc.value.code == "plugin.host_queue_timeout"
+        finally:
+            release.set()
+        assert blocked.result(timeout=1).status_code == 200
+
+
+def test_external_pool_bridge_uses_retry_and_durable_audit(db_session):
+    """既有流式线程池桥接也必须继承 typed runtime 的重试与审计。"""
     registry = PluginRegistry()
     plugin = _plugin("talebook.test.external-pool", "metadata.lookup", behaviour="retry")
     registry.register(plugin)
@@ -379,7 +499,7 @@ def test_read_rejects_missing_mode_scope_before_dispatch(db_session):
     assert connection.health == "degraded"
 
 
-def test_typed_read_uses_lease_retry_and_durable_audit(db_session):
+def test_typed_read_uses_retry_and_durable_audit(db_session):
     registry = PluginRegistry()
     plugin = _plugin("talebook.test.audited-read", "metadata.lookup", behaviour="retry")
     registry.register(plugin)
@@ -472,8 +592,8 @@ def test_typed_retry_uses_connection_timeout_as_one_wall_clock_budget(db_session
     assert 1 <= run.attempt <= 2
     assert run.status == "failed"
     db_session.refresh(connection)
-    assert connection.lease_token
-    assert connection.lease_until is not None
+    assert connection.lease_token == ""
+    assert connection.lease_until is None
 
 
 def test_typed_read_proceeds_while_another_run_holds_the_lease(db_session):
@@ -499,13 +619,13 @@ def test_typed_read_proceeds_while_another_run_holds_the_lease(db_session):
     run = db_session.query(PluginRun).filter(PluginRun.connection_id == connection.id).one()
     assert run.status == "succeeded"
     db_session.refresh(connection)
-    # 宽容读不带租约执行，收口时不得清掉租约持有者
+    # read 不参与租约，收口时不得清掉有副作用调用的租约。
     assert connection.lease_token == "other-worker"
     assert connection.lease_until is not None
 
 
-def test_read_during_timeout_grace_is_not_rejected(db_session):
-    """TB-198 回归：读超时保留宽限租约（防不可取消 future 重叠）期间，用户重试的读仍成功。"""
+def test_read_timeout_does_not_create_a_grace_lease_or_reject_retry(db_session):
+    """TB-198 回归：只读超时由 host 队列约束，不得创建 connection 宽限租约。"""
     registry = PluginRegistry()
     plugin = _plugin("talebook.test.grace-read", "metadata.lookup")
     registry.register(plugin)
@@ -529,14 +649,15 @@ def test_read_during_timeout_grace_is_not_rejected(db_session):
         runtime.read(connection, "search_books", "三体")
     assert exc.value.code == "plugin.timeout"
     db_session.refresh(connection)
-    assert connection.lease_token
-    assert connection.lease_until is not None
+    assert connection.lease_token == ""
+    assert connection.lease_until is None
 
-    # 宽限窗口内的下一次读（如重新点击搜索结果）必须成功且不干扰宽限租约
+    # 下一次读（如重新点击搜索结果）必须成功，不会被 connection 互斥拒绝。
     result = runtime.read(connection, "search_books", "三体")
     assert result[0]["title"] == "三体"
     db_session.refresh(connection)
-    assert connection.lease_token
+    assert connection.lease_token == ""
+    assert connection.lease_until is None
     runs = (
         db_session.query(PluginRun)
         .filter(PluginRun.connection_id == connection.id)
@@ -547,8 +668,8 @@ def test_read_during_timeout_grace_is_not_rejected(db_session):
     assert runs[0].error_code == "plugin.timeout"
 
 
-def test_second_read_batch_proceeds_while_first_batch_holds_the_lease(db_session):
-    """搜索批量并发宽容：前一批仍占用连接时，新搜索批量不再整批 concurrent_run。"""
+def test_concurrent_read_batches_never_use_the_connection_lease(db_session):
+    """搜索批量由 plugin+host 队列约束，connection lease 不参与只读调度。"""
     registry = PluginRegistry()
     plugin = _plugin("talebook.test.batch-overlap", "metadata.lookup")
     registry.register(plugin)
@@ -556,9 +677,8 @@ def test_second_read_batch_proceeds_while_first_batch_holds_the_lease(db_session
     runtime = PluginRuntime(db_session, SETTINGS, registry=registry)
 
     first = runtime.begin_read_batch(connection, timeout=1, requested_by=1)
-    assert first["lease_token"]
+    assert first["lease_token"] == ""
     second = runtime.begin_read_batch(connection, timeout=1, requested_by=1)
-    # 第二条宽容批量：不带租约，但审计 run 照常记录
     assert second["lease_token"] == ""
     assert second["run_id"] != first["run_id"]
 
@@ -653,7 +773,7 @@ def _blocking_metadata_handler(db_session, plugin_id):
     return handler, connection, plugin_call, started, release
 
 
-def test_metadata_sync_outer_timeout_keeps_lease_for_uncancellable_provider(db_session):
+def test_metadata_sync_outer_timeout_does_not_lease_read_connection(db_session):
     plugin_id = "talebook.test.metadata-sync-timeout"
     handler, connection, plugin_call, started, release = _blocking_metadata_handler(db_session, plugin_id)
     handler._build_search_tasks = lambda _metadata: {plugin_id: plugin_call}
@@ -664,13 +784,13 @@ def test_metadata_sync_outer_timeout_keeps_lease_for_uncancellable_provider(db_s
         run = db_session.query(PluginRun).filter(PluginRun.connection_id == connection.id).one()
         db_session.refresh(connection)
         assert run.error_code == "plugin.timeout"
-        assert connection.lease_token
-        assert connection.lease_until is not None
+        assert connection.lease_token == ""
+        assert connection.lease_until is None
     finally:
         release.set()
 
 
-def test_metadata_stream_close_keeps_lease_for_uncancellable_provider(db_session):
+def test_metadata_stream_close_does_not_lease_read_connection(db_session):
     plugin_id = "talebook.test.metadata-stream-timeout"
     handler, connection, plugin_call, started, release = _blocking_metadata_handler(db_session, plugin_id)
 
@@ -696,8 +816,8 @@ def test_metadata_stream_close_keeps_lease_for_uncancellable_provider(db_session
         run = db_session.query(PluginRun).filter(PluginRun.connection_id == connection.id).one()
         db_session.refresh(connection)
         assert run.error_code == "plugin.timeout"
-        assert connection.lease_token
-        assert connection.lease_until is not None
+        assert connection.lease_token == ""
+        assert connection.lease_until is None
     finally:
         release.set()
 

--- a/tests/test_plugin_host_queue.py
+++ b/tests/test_plugin_host_queue.py
@@ -1,0 +1,133 @@
+"""Deterministic regressions for shared host queue limits and wakeups."""
+
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import ExitStack
+
+import pytest
+
+from webserver.plugins.runtime.safe_http import HostQueueTimeout, _PluginHostQueue
+
+
+class ObservedCondition(threading.Condition):
+    """Expose wait boundaries and optionally pause a notified thread."""
+
+    def __init__(self):
+        super().__init__()
+        self.waiting = {name: threading.Event() for name in ("C", "D")}
+        self.pause_c = False
+        self.c_notified = threading.Event()
+        self.resume_c = threading.Event()
+
+    def wait(self, timeout=None):
+        name = threading.current_thread().name
+        self.waiting[name].set()
+        result = super().wait(timeout)
+        if name == "C" and self.pause_c:
+            self.pause_c = False
+            self.release()
+            try:
+                self.c_notified.set()
+                assert self.resume_c.wait(3)
+            finally:
+                self.acquire()
+        return result
+
+
+def slot(queue, limit):
+    return queue.slot("test.plugin", "https://books.example/book", limit, time.monotonic() + 2)
+
+
+def hold_slot(queue, name, limit, entered, release):
+    threading.current_thread().name = name
+    with slot(queue, limit):
+        entered.set()
+        assert release.wait(3), "request was not released"
+
+
+@pytest.mark.parametrize("raise_error", [False, True])
+def test_low_limit_expires_after_request_finishes_with_high_limit_waiters(raise_error):
+    queue = _PluginHostQueue()
+    condition = queue._condition = ObservedCondition()
+    entered = [threading.Event(), threading.Event()]
+    release = threading.Event()
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        try:
+            try:
+                with slot(queue, 1):
+                    futures = [
+                        pool.submit(hold_slot, queue, name, 3, entered[i], release) for i, name in enumerate(("C", "D"))
+                    ]
+                    assert all(event.wait(1) for event in condition.waiting.values())
+                    assert not any(event.is_set() for event in entered)
+                    if raise_error:
+                        raise ValueError("HTTP failure")
+            except ValueError:
+                assert raise_error
+            # Both must enter before either finishes: the host never goes idle
+            # because the high-limit requests were already queued.
+            assert all(event.wait(1) for event in entered)
+        finally:
+            release.set()
+        for future in futures:
+            future.result(timeout=3)
+    assert not queue._states
+
+
+def test_expired_low_limit_waiter_does_not_pin_a_busy_host():
+    queue = _PluginHostQueue()
+    with slot(queue, 3):
+        with pytest.raises(HostQueueTimeout):
+            with queue.slot("test.plugin", "https://books.example/book", 1, time.monotonic()):
+                pytest.fail("low-limit request entered while host was busy")
+        with slot(queue, 3):
+            pass
+    assert not queue._states
+
+
+def test_same_limit_is_retained_until_its_last_request_finishes():
+    queue = _PluginHostQueue()
+    with slot(queue, 2):
+        with slot(queue, 2):
+            pass
+        with slot(queue, 3):
+            with pytest.raises(HostQueueTimeout):
+                with queue.slot("test.plugin", "https://books.example/book", 3, time.monotonic()):
+                    pytest.fail("remaining low-limit request must still constrain the host")
+    assert not queue._states
+
+
+def test_advancing_head_wakes_new_waiter_when_multiple_slots_are_free():
+    queue = _PluginHostQueue()
+    condition = queue._condition = ObservedCondition()
+    condition.pause_c = True
+    entered_c, entered_d, release = (threading.Event() for _ in range(3))
+    with ExitStack() as active, ThreadPoolExecutor(max_workers=2) as pool:
+        # A, B and E occupy all three slots; E stays active throughout.
+        a, b = ExitStack(), ExitStack()
+        active.enter_context(a)
+        active.enter_context(b)
+        a.enter_context(slot(queue, 3))
+        b.enter_context(slot(queue, 3))
+        active.enter_context(slot(queue, 3))
+        try:
+            c = pool.submit(hold_slot, queue, "C", 3, entered_c, release)
+            assert condition.waiting["C"].wait(1)
+            with condition:
+                a.close()
+                b.close()
+            assert condition.c_notified.wait(1)
+            # D arrives after the release notifications, before C reacquires
+            # the lock. D waits behind C despite there being two free slots.
+            d = pool.submit(hold_slot, queue, "D", 3, entered_d, release)
+            assert condition.waiting["D"].wait(1)
+            condition.resume_c.set()
+            assert entered_c.wait(1)
+            assert entered_d.wait(1), "free slot was stranded until an unrelated request completed"
+        finally:
+            condition.resume_c.set()
+            release.set()
+        c.result(timeout=3)
+        d.result(timeout=3)
+    assert not queue._states

--- a/tests/test_plugins_api.py
+++ b/tests/test_plugins_api.py
@@ -118,12 +118,14 @@ class TestPluginsApi(TestWithAdminUser):
         self.assertEqual(properties["search_result_limit"]["default"], 5)
         self.assertEqual(properties["search_concurrency"]["default"], 20)
         self.assertEqual(properties["save_concurrency"]["default"], 10)
+        self.assertEqual(properties["host_concurrency"]["default"], 10)
         self.assertTrue(properties["private_network_protection"]["default"])
 
         config = {
             "search_result_limit": 7,
             "search_concurrency": 4,
             "save_concurrency": 3,
+            "host_concurrency": 2,
             "private_network_protection": False,
         }
         saved = self.json(
@@ -146,7 +148,7 @@ class TestPluginsApi(TestWithAdminUser):
                     "installation_id": installation["id"],
                     "role": connection["role"],
                     "name": connection["name"],
-                    "config": {**config, "save_concurrency": 0},
+                    "config": {**config, "host_concurrency": 0},
                 }
             ),
         )

--- a/webserver/plugins/runtime/safe_http.py
+++ b/webserver/plugins/runtime/safe_http.py
@@ -1,10 +1,115 @@
+import collections
+import contextlib
 import ipaddress
 import socket
+import threading
+import time
 import urllib.parse
 
 import requests
 
 from .protocol import UpstreamAuthError, UpstreamError, UpstreamRateLimitError
+
+
+HOST_CONCURRENCY_CONFIG_KEY = "host_concurrency"
+DEFAULT_HOST_CONCURRENCY = 10
+
+
+class HostQueueTimeout(UpstreamError):
+    code = "plugin.host_queue_timeout"
+
+    def __init__(self, message="Plugin host queue deadline expired", *, error_type="timeout", status_code=None):
+        # Keep the normal UpstreamError constructor shape so runtime redaction
+        # can rebuild this typed error without losing its public error code.
+        super().__init__(message, error_type=error_type, status_code=status_code)
+
+
+class _PluginHostQueue:
+    """Process-local fair queue keyed only by plugin and normalized host."""
+
+    def __init__(self):
+        self._condition = threading.Condition()
+        self._states = {}
+
+    @staticmethod
+    def _key(plugin_key, url):
+        parsed = urllib.parse.urlsplit(url)
+        hostname = (parsed.hostname or "").rstrip(".").lower()
+        if not plugin_key or not hostname:
+            return None
+        default_port = 443 if parsed.scheme.lower() == "https" else 80
+        return str(plugin_key), hostname, parsed.port or default_port
+
+    @contextlib.contextmanager
+    def slot(self, plugin_key, url, limit, deadline=None):
+        key = self._key(plugin_key, url)
+        if key is None:
+            yield
+            return
+
+        limit = max(1, min(100, int(limit)))
+        waiter = object()
+        acquired = False
+        with self._condition:
+            state = self._states.get(key)
+            if state is None:
+                state = {"active": 0, "limit": limit, "waiters": collections.deque()}
+                self._states[key] = state
+            else:
+                # A plugin configuration change must not temporarily exceed the
+                # stricter value while an older request is still in flight.
+                state["limit"] = min(state["limit"], limit)
+            state["waiters"].append(waiter)
+            while state["waiters"][0] is not waiter or state["active"] >= state["limit"]:
+                remaining = None if deadline is None else deadline - time.monotonic()
+                if remaining is not None and remaining <= 0:
+                    state["waiters"].remove(waiter)
+                    if not state["waiters"] and state["active"] == 0:
+                        self._states.pop(key, None)
+                    self._condition.notify_all()
+                    raise HostQueueTimeout()
+                self._condition.wait(remaining)
+            state["waiters"].popleft()
+            state["active"] += 1
+            acquired = True
+
+        try:
+            yield
+        finally:
+            if acquired:
+                with self._condition:
+                    state = self._states.get(key)
+                    if state is not None:
+                        state["active"] -= 1
+                        if not state["waiters"] and state["active"] == 0:
+                            self._states.pop(key, None)
+                    self._condition.notify_all()
+
+
+_PLUGIN_HOST_QUEUE = _PluginHostQueue()
+_PLUGIN_HTTP_POLICY = threading.local()
+
+
+@contextlib.contextmanager
+def plugin_http_policy(plugin_key, max_concurrency=DEFAULT_HOST_CONCURRENCY, deadline=None):
+    """Bind runtime-owned plugin identity to SafeHttpClient calls in this thread."""
+
+    previous = getattr(_PLUGIN_HTTP_POLICY, "value", None)
+    _PLUGIN_HTTP_POLICY.value = {
+        "plugin_key": str(plugin_key or ""),
+        "max_concurrency": max(1, min(100, int(max_concurrency))),
+        "deadline": deadline,
+    }
+    try:
+        yield
+    finally:
+        if previous is None:
+            try:
+                del _PLUGIN_HTTP_POLICY.value
+            except AttributeError:
+                pass
+        else:
+            _PLUGIN_HTTP_POLICY.value = previous
 
 
 class EndpointPolicyError(UpstreamError):
@@ -61,6 +166,8 @@ class SafeHttpClient:
         max_bytes=8 * 1024 * 1024,
         allowed_hosts=(),
         enforce_public_address=True,
+        plugin_key="",
+        max_concurrency=None,
     ):
         self.session = session or requests.Session()
         self.resolver = resolver or getattr(self.session, "resolver", socket.getaddrinfo)
@@ -70,11 +177,24 @@ class SafeHttpClient:
         # request target itself must never auto-whitelist its host.
         self.allowed_hosts = tuple(allowed_hosts or ())
         self.enforce_public_address = bool(enforce_public_address)
+        self.plugin_key = str(plugin_key or "")
+        self.max_concurrency = max_concurrency
 
     def request(self, method, url, *, allowed_hosts=None, headers=None, timeout=30, data=None, params=None, json=None):
         current = url
         origin = self._origin(url)
         allowed_hosts = self.allowed_hosts if allowed_hosts is None else tuple(allowed_hosts or ())
+        policy = getattr(_PLUGIN_HTTP_POLICY, "value", None) or {}
+        plugin_key = self.plugin_key or policy.get("plugin_key", "")
+        max_concurrency = self.max_concurrency
+        if max_concurrency is None:
+            max_concurrency = policy.get("max_concurrency", DEFAULT_HOST_CONCURRENCY)
+        max_concurrency = max(1, min(100, int(max_concurrency)))
+        deadline = policy.get("deadline")
+        timeout_seconds = self._timeout_seconds(timeout)
+        if plugin_key and timeout_seconds is not None:
+            request_deadline = time.monotonic() + timeout_seconds
+            deadline = request_deadline if deadline is None else min(deadline, request_deadline)
         for redirect_count in range(self.max_redirects + 1):
             validate_remote_endpoint(
                 current,
@@ -84,16 +204,18 @@ class SafeHttpClient:
             )
             if self._origin(current) != origin:
                 raise EndpointPolicyError("Cross-origin redirects are not allowed")
-            response = self.session.request(
-                method,
-                current,
-                headers=dict(headers or {}),
-                data=data,
-                params=params,
-                json=json,
-                timeout=timeout,
-                allow_redirects=False,
-            )
+            with _PLUGIN_HOST_QUEUE.slot(plugin_key, current, max_concurrency, deadline):
+                request_timeout = self._remaining_timeout(timeout, deadline) if plugin_key else timeout
+                response = self.session.request(
+                    method,
+                    current,
+                    headers=dict(headers or {}),
+                    data=data,
+                    params=params,
+                    json=json,
+                    timeout=request_timeout,
+                    allow_redirects=False,
+                )
             if response.status_code in {301, 302, 303, 307, 308}:
                 if redirect_count >= self.max_redirects:
                     raise EndpointPolicyError("Endpoint exceeded the redirect limit")
@@ -142,3 +264,23 @@ class SafeHttpClient:
         parsed = urllib.parse.urlsplit(url)
         default_port = 443 if parsed.scheme == "https" else 80
         return parsed.scheme.lower(), (parsed.hostname or "").lower(), parsed.port or default_port
+
+    @staticmethod
+    def _timeout_seconds(timeout):
+        if isinstance(timeout, (int, float)):
+            return max(0.0, float(timeout))
+        if isinstance(timeout, (tuple, list)) and timeout:
+            values = [float(value) for value in timeout if isinstance(value, (int, float))]
+            return sum(max(0.0, value) for value in values) if values else None
+        return None
+
+    @staticmethod
+    def _remaining_timeout(timeout, deadline):
+        if deadline is None:
+            return timeout
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise HostQueueTimeout()
+        if isinstance(timeout, (int, float)):
+            return max(0.001, min(float(timeout), remaining))
+        return timeout

--- a/webserver/plugins/runtime/safe_http.py
+++ b/webserver/plugins/runtime/safe_http.py
@@ -53,17 +53,17 @@ class _PluginHostQueue:
         with self._condition:
             state = self._states.get(key)
             if state is None:
-                state = {"active": 0, "limit": limit, "waiters": collections.deque()}
+                state = {"active": 0, "limits": collections.Counter(), "waiters": collections.deque()}
                 self._states[key] = state
-            else:
-                # A plugin configuration change must not temporarily exceed the
-                # stricter value while an older request is still in flight.
-                state["limit"] = min(state["limit"], limit)
+            # Keep the strictest limit only while its requests are waiting or
+            # in flight, so a busy host can recover after a low-limit request.
+            state["limits"][limit] += 1
             state["waiters"].append(waiter)
-            while state["waiters"][0] is not waiter or state["active"] >= state["limit"]:
+            while state["waiters"][0] is not waiter or state["active"] >= min(state["limits"]):
                 remaining = None if deadline is None else deadline - time.monotonic()
                 if remaining is not None and remaining <= 0:
                     state["waiters"].remove(waiter)
+                    self._remove_limit(state, limit)
                     if not state["waiters"] and state["active"] == 0:
                         self._states.pop(key, None)
                     self._condition.notify_all()
@@ -72,6 +72,9 @@ class _PluginHostQueue:
             state["waiters"].popleft()
             state["active"] += 1
             acquired = True
+            # Advancing the FIFO head can make another waiter eligible even
+            # before any in-flight request finishes when multiple slots are free.
+            self._condition.notify_all()
 
         try:
             yield
@@ -81,9 +84,16 @@ class _PluginHostQueue:
                     state = self._states.get(key)
                     if state is not None:
                         state["active"] -= 1
+                        self._remove_limit(state, limit)
                         if not state["waiters"] and state["active"] == 0:
                             self._states.pop(key, None)
                     self._condition.notify_all()
+
+    @staticmethod
+    def _remove_limit(state, limit):
+        state["limits"][limit] -= 1
+        if state["limits"][limit] == 0:
+            del state["limits"][limit]
 
 
 _PLUGIN_HOST_QUEUE = _PluginHostQueue()

--- a/webserver/plugins/source/legado.py
+++ b/webserver/plugins/source/legado.py
@@ -16,7 +16,11 @@ from webserver.plugins.runtime.domains import (
     SourceContent,
 )
 from webserver.plugins.runtime.protocol import PROTOCOL_VERSION, ProviderResult, UpstreamError
-from webserver.plugins.runtime.safe_http import SafeHttpClient
+from webserver.plugins.runtime.safe_http import (
+    DEFAULT_HOST_CONCURRENCY,
+    HOST_CONCURRENCY_CONFIG_KEY,
+    SafeHttpClient,
+)
 from webserver.services.booksource.metadata import BookSourceMetadataService, collect_metadata_sources
 
 
@@ -85,6 +89,8 @@ class LegadoSourcePlugin:
             session=booksource_engine.build_session(source),
             max_bytes=int(engine_config.get("BOOKSOURCE_MAX_RESPONSE_BYTES") or 8 * 1024 * 1024),
             enforce_public_address=bool(config.get(PRIVATE_NETWORK_PROTECTION_KEY, True)),
+            plugin_key=PLUGIN_ID,
+            max_concurrency=config.get(HOST_CONCURRENCY_CONFIG_KEY, DEFAULT_HOST_CONCURRENCY),
         )
         return BookSourceEngine(source, session=transport, config=engine_config)
 
@@ -231,6 +237,12 @@ class LegadoProvider(LegadoSourcePlugin):
                             "minimum": 1,
                             "maximum": 100,
                             "default": DEFAULT_SAVE_CONCURRENCY,
+                        },
+                        HOST_CONCURRENCY_CONFIG_KEY: {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 100,
+                            "default": DEFAULT_HOST_CONCURRENCY,
                         },
                         PRIVATE_NETWORK_PROTECTION_KEY: {"type": "boolean", "default": True},
                     },

--- a/webserver/services/booksource/analyze_url.py
+++ b/webserver/services/booksource/analyze_url.py
@@ -16,6 +16,8 @@ import logging
 import re
 from urllib.parse import urljoin
 
+from webserver.plugins.runtime.safe_http import HostQueueTimeout
+
 from .exceptions import JsRuleUnsupported, SourceHttpError
 from .http_client import build_session, decode_response
 from .js_runtime import run_js
@@ -158,6 +160,8 @@ class AnalyzeUrl:
                 resp = self.session.post(self.url, data=data, headers=headers, timeout=self.timeout)
             else:
                 resp = self.session.get(self.url, headers=headers, timeout=self.timeout)
+        except HostQueueTimeout:
+            raise
         except Exception as err:
             logging.info("booksource: http error for %s: %s", self.url, err)
             raise SourceHttpError(str(err))

--- a/webserver/services/booksource/save_service.py
+++ b/webserver/services/booksource/save_service.py
@@ -12,6 +12,7 @@ import traceback
 from webserver import loader
 from webserver.i18n import _
 from webserver.models import Item, OnlineBookMeta
+from webserver.plugins.runtime.safe_http import DEFAULT_HOST_CONCURRENCY, HOST_CONCURRENCY_CONFIG_KEY, SafeHttpClient
 from webserver.plugins.source.legado import DEFAULT_SAVE_CONCURRENCY, SAVE_CONCURRENCY_KEY
 from webserver.plugins.source.legado import PLUGIN_ID as LEGADO_PLUGIN_ID
 from webserver.services import AsyncService
@@ -55,14 +56,12 @@ def _build_metadata(detail):
     return mi
 
 
-def _attach_cover(mi, cover_url):
+def _attach_cover(mi, cover_url, plugin_key="", max_concurrency=DEFAULT_HOST_CONCURRENCY):
     if not cover_url:
         return
     try:
-        from webserver.plugins.runtime.safe_http import SafeHttpClient
-
         img = (
-            SafeHttpClient()
+            SafeHttpClient(plugin_key=plugin_key, max_concurrency=max_concurrency)
             .request(
                 "GET",
                 cover_url,
@@ -122,7 +121,7 @@ class SaveOnlineBookService(AsyncService):
             book_id = self._import_file(detail, book_file)
             if not book_id:
                 raise RuntimeError(_("导入本地书库失败"))
-            self._save_meta(book_id, user_id, detail, [])
+            self._save_meta(book_id, user_id, detail, [], source)
             if task_id:
                 BackgroundService().update_progress(task_id, 100, {"total": 1, "done": 1, "book_id": book_id})
             self.add_msg(user_id, "success", _("《%s》已保存到本地书库") % detail.title)
@@ -158,7 +157,7 @@ class SaveOnlineBookService(AsyncService):
         if not book_id:
             raise RuntimeError(_("导入本地书库失败"))
 
-        self._save_meta(book_id, user_id, detail, chapters)
+        self._save_meta(book_id, user_id, detail, chapters, source)
         if task_id:
             BackgroundService().update_progress(task_id, 100, {"total": total, "done": total, "book_id": book_id})
 
@@ -216,10 +215,14 @@ class SaveOnlineBookService(AsyncService):
             return same_author_book_id
         return self.db.import_book(mi, [txt_path])
 
-    def _save_meta(self, book_id, user_id, detail, chapters):
+    def _save_meta(self, book_id, user_id, detail, chapters, source):
         # cover
         mi = self.db.get_metadata(book_id, index_is_id=True)
-        _attach_cover(mi, detail.cover_url)
+        max_concurrency = (source.connection.config or {}).get(
+            HOST_CONCURRENCY_CONFIG_KEY,
+            DEFAULT_HOST_CONCURRENCY,
+        )
+        _attach_cover(mi, detail.cover_url, source.plugin_key, max_concurrency)
         if getattr(mi, "cover_data", None) and mi.cover_data[1]:
             try:
                 self.db.set_cover(book_id, mi.cover_data[1])

--- a/webserver/services/plugin_runtime.py
+++ b/webserver/services/plugin_runtime.py
@@ -34,6 +34,11 @@ from webserver.plugins.runtime import (
     contract_violations,
 )
 from webserver.plugins.runtime.protocol import ManifestError, validate_against_schema
+from webserver.plugins.runtime.safe_http import (
+    DEFAULT_HOST_CONCURRENCY,
+    HOST_CONCURRENCY_CONFIG_KEY,
+    plugin_http_policy,
+)
 from webserver.services.plugin_secrets import SENSITIVE_KEY_RE, SecretCipher, SecretCipherError, redact, secret_mask_hint
 from webserver.services.plugin_writers import writer_for
 
@@ -46,6 +51,12 @@ PLATFORM_CONFIG_SCHEMA = {
         "timeout_seconds": {"type": "number", "minimum": 0.01, "maximum": 3600},
         "max_retries": {"type": "integer", "minimum": 0, "maximum": 5},
         "backoff_seconds": {"type": "number", "minimum": 0, "maximum": 60},
+        HOST_CONCURRENCY_CONFIG_KEY: {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": DEFAULT_HOST_CONCURRENCY,
+        },
     },
 }
 ENTITY_TYPES = frozenset({"metadata", "annotation", "review", "book_source"})
@@ -59,6 +70,16 @@ DEFAULT_COUNTS = {"fetched": 0, "written": 0, "updated": 0, "skipped": 0, "faile
 # pool; timed-out work may finish later, but the process has a hard concurrency
 # ceiling instead of leaking an unbounded number of workers.
 _PLUGIN_IO_EXECUTOR = ThreadPoolExecutor(max_workers=16, thread_name_prefix="plugin-io")
+
+
+def _host_concurrency(context):
+    value = (context.get("config") or {}).get(HOST_CONCURRENCY_CONFIG_KEY, DEFAULT_HOST_CONCURRENCY)
+    return max(1, min(100, int(value)))
+
+
+def _invoke_provider_method(provider, context, plugin_key, deadline, method, args):
+    with plugin_http_policy(plugin_key, _host_concurrency(context), deadline):
+        return getattr(provider, method)(*args, context)
 
 
 class PluginRuntimeError(RuntimeError):
@@ -740,7 +761,16 @@ class PluginRuntime:
             deadline=(datetime.datetime.now() + datetime.timedelta(seconds=effective_timeout)).isoformat(),
             platform=dict(override.get("platform") or {}),
         ).as_dict()
-        future = _PLUGIN_IO_EXECUTOR.submit(getattr(provider, method), *args, context)
+        deadline = time.monotonic() + effective_timeout
+        future = _PLUGIN_IO_EXECUTOR.submit(
+            _invoke_provider_method,
+            provider,
+            context,
+            plugin_key,
+            deadline,
+            method,
+            args,
+        )
         try:
             return future.result(timeout=effective_timeout)
         except FutureTimeoutError:
@@ -775,7 +805,7 @@ class PluginRuntime:
 
         SQLAlchemy session 不是线程安全的，因此所有涉及 session 的工作都在这里
         完成；返回的 ``call`` 只做网络 I/O，可放进任意线程池。接入既有外部
-        线程池时传 ``audit=True``，由 ``finish_read`` 在调用线程结束租约与 run。
+        线程池时传 ``audit=True``，由 ``finish_read`` 在调用线程结束 audit run。
         """
         prepared, failures = [], {}
         overrides_by_connection = context_overrides or {}
@@ -831,13 +861,22 @@ class PluginRuntime:
             attempt_state = {"value": 0, "deadline": time.monotonic() + effective_timeout}
             if audit or retry:
 
-                def call(method, *args, _p=provider, _c=context, _conn=connection, _state=attempt_state):
-                    return self._invoke_prepared_with_retry(_p, _c, _conn, _state, method, args)
+                def call(
+                    method,
+                    *args,
+                    _p=provider,
+                    _c=context,
+                    _conn=connection,
+                    _state=attempt_state,
+                    _plugin_key=plugin_key,
+                ):
+                    return self._invoke_prepared_with_retry(_p, _c, _conn, _state, _plugin_key, method, args)
 
             else:
 
-                def call(method, *args, _p=provider, _c=context):
-                    return getattr(_p, method)(*args, _c)
+                def call(method, *args, _p=provider, _c=context, _timeout=effective_timeout, _plugin_key=plugin_key):
+                    deadline = time.monotonic() + _timeout
+                    return _invoke_provider_method(_p, _c, _plugin_key, deadline, method, args)
 
             prepared.append(
                 {
@@ -856,7 +895,7 @@ class PluginRuntime:
             )
         return prepared, failures
 
-    def _invoke_prepared_with_retry(self, provider, context, connection, attempt_state, method, args):
+    def _invoke_prepared_with_retry(self, provider, context, connection, attempt_state, plugin_key, method, args):
         """外部线程池内的纯 I/O 重试器；不得访问 SQLAlchemy session。
 
         调用本身交给运行时的有界池，因此书源自己卡住时不会永久占用
@@ -871,7 +910,15 @@ class PluginRuntime:
                 raise PluginRuntimeError("plugin.timeout", "Plugin %s timed out" % method, retryable=True)
             attempt_state["value"] = attempt
             context["attempt"] = attempt
-            future = _PLUGIN_IO_EXECUTOR.submit(getattr(provider, method), *args, context)
+            future = _PLUGIN_IO_EXECUTOR.submit(
+                _invoke_provider_method,
+                provider,
+                context,
+                plugin_key,
+                attempt_state["deadline"],
+                method,
+                args,
+            )
             try:
                 return future.result(timeout=remaining)
             except FutureTimeoutError:
@@ -907,33 +954,30 @@ class PluginRuntime:
 
     def _begin_capability_run(self, connection, mode, timeout, requested_by=None, audit_data=None):
         requested_by = self._audit_subject(connection, requested_by)
-        token = uuid.uuid4().hex
         now = datetime.datetime.now()
-        acquired = (
-            self.session.query(PluginConnection)
-            .filter(
-                PluginConnection.id == connection.id,
-                or_(PluginConnection.lease_until.is_(None), PluginConnection.lease_until < now),
+        token = ""
+        acquired = True
+        # read 只做外部读取，由 SafeHttpClient 按 plugin+host 公平排队；它不再
+        # 参与持久化 connection lease。这样搜索、浏览和保存既不会互相快速
+        # 拒绝，也不会让一次慢读阻塞后续 write。write/sync/execute 等有状态或
+        # 有副作用的模式仍使用数据库租约，保持跨进程互斥与超时宽限保护。
+        if mode != "read":
+            token = uuid.uuid4().hex
+            acquired = (
+                self.session.query(PluginConnection)
+                .filter(
+                    PluginConnection.id == connection.id,
+                    or_(PluginConnection.lease_until.is_(None), PluginConnection.lease_until < now),
+                )
+                .update(
+                    {
+                        PluginConnection.lease_token: token,
+                        PluginConnection.lease_until: now + datetime.timedelta(seconds=timeout + 30),
+                    },
+                    synchronize_session=False,
+                )
             )
-            .update(
-                {
-                    PluginConnection.lease_token: token,
-                    PluginConnection.lease_until: now + datetime.timedelta(seconds=timeout + 30),
-                },
-                synchronize_session=False,
-            )
-        )
-        # read 型能力调用（网络书库搜索批量、详情/目录/正文抓取等）只是远端只读
-        # 请求，运行时内部本就允许同一连接上的并发读（一次搜索批量会并发执行多个
-        # 书源）。若把连接租约当作互斥锁强加给读，搜索批量占用的租约——或读超时
-        # 后保留的宽限租约——会让「点击搜索结果进入详情页」等后续读直接报
-        # concurrent_run。读遇忙时改为不带租约并发执行：不阻塞任何其他调用，也
-        # 不会在收口时误清持有者的租约（token 为空时清理语句匹配不到任何 token）。
-        # write/sync/execute 等有副作用的模式保持互斥，仍然快速失败。
-        tolerate = not acquired and mode == "read"
-        refused = not acquired and not tolerate
-        if tolerate:
-            token = ""
+        refused = not acquired
         run = PluginRun(
             connection_id=connection.id,
             action=mode,
@@ -1266,7 +1310,7 @@ class PluginRuntime:
         return results
 
     def begin_read_batch(self, connection, *, timeout=30, requested_by=None, audit_data=None):
-        """为共用一条 connection 的多个 read binding 只建立一个 lease/run。"""
+        """为共用一条 connection 的多个 read binding 只建立一个 audit run。"""
         effective_timeout = self._effective_timeout(connection, timeout)
         run, token = self._begin_capability_run(
             connection,
@@ -1549,7 +1593,16 @@ class PluginRuntime:
 
     @staticmethod
     def _call_method_with_timeout(provider, method, context, timeout):
-        future = _PLUGIN_IO_EXECUTOR.submit(getattr(provider, method), context)
+        plugin_key = (getattr(provider, "manifest", None) or {}).get("id", "")
+        future = _PLUGIN_IO_EXECUTOR.submit(
+            _invoke_provider_method,
+            provider,
+            context,
+            plugin_key,
+            time.monotonic() + timeout,
+            method,
+            (),
+        )
         try:
             return future.result(timeout=timeout)
         except FutureTimeoutError as exc:

--- a/webserver/services/source_catalog.py
+++ b/webserver/services/source_catalog.py
@@ -208,7 +208,7 @@ class SourceCatalogService:
         """在请求线程完成 session/Secret 工作，worker 只保留网络调用。
 
         多个 Legado/OPDS 事实 binding 可以共用同一条插件连接。这里按
-        connection 分组，一组只建一个 lease/run；每个 binding 仍有自己的
+        connection 分组，一组只建一个 audit run；每个 binding 仍有自己的
         config 与总 deadline。任务完成后由预绑定的独立 session 立即调用
         ``finish_read_batch`` 收口；status 请求与 TTL cleanup 只负责失败重试。
         """


### PR DESCRIPTION
搜索、浏览和保存同时访问同一站点时，需要共享 plugin + host 并发上限并排队等待，避免 connection 租约误拒绝只读请求。

## 实现

- 在 SafeHttpClient 的实际 HTTP 出口按 `(plugin_key, normalized hostname, effective port)` 进入进程内 FIFO 队列。`host_concurrency` 默认 10、范围 1–100，等待计入总 deadline。
- 搜索、详情、目录、章节和封面共用队列。read 不持 connection lease；write/sync/execute 保留互斥。
- 有效上限取仍在等待或执行的请求配置最小值；对应请求完成、异常或等待超时后移除其限制，持续繁忙的主机也能恢复较高上限。
- 队首获得槽位后通知其他等待者，避免有空位时漏唤醒。新增 5 项确定性回归，覆盖两条评审意见及重复低值请求的保护。

## 验证

- `python3 -m pytest -q tests/test_plugin_host_queue.py`：5 passed；相同测试对原实现为 4 failed、1 passed。
- 现有 `talebook/talebook:v26.08.11` 容器补装 `pytest==7.4.4`、`rarfile==4.2` 后执行 `pytest -q tests`：1276 passed、20 skipped。
- `make lint-py-fix`、`make lint-py`、`ruff check tests/test_plugin_host_queue.py`、`git diff --check` 通过；`make check-design`：138 份通过。
- 标准 `make test` 在 Debian 软件源下载停滞后取消。替代环境的 `make pytest` 覆盖率运行曾有 1 项搜索等待超时（1275 passed、20 skipped，整体覆盖率 73%）；之后无覆盖率全量复验通过。保留该时序敏感风险，不将替代镜像称为本分支标准 test 镜像。
- DeepSec Shield 0.2.0（来源 fff031fc01fb36b95348214c8ee359f6ede8aa8b）：`deepsec shield scan . --layer l1,l2 --include-tests --format json --output -`。全仓 520 文件，退出码 2，122 项发现（32 critical / 69 high / 21 medium）。队列实现和新增测试无发现；PR 涉及文件中 2 项是固定测试 lease token 误报，其余 120 项在与 merge-base 相同的文件中，未在本轮修复或完整审计。不是全仓安全通过；报告及逐项处理说明交付 TB-198。仅本地 L1/L2，HTML 方案不在语言覆盖范围。

## 风险与兼容性

队列仅在单进程共享，等待占用调用线程；不新增数据库迁移或 HTTP API。不同连接配置并存时，仍在等待或执行的严格配置约束整个同键队列。无界面影响，本轮仅修正内部调度，豁免界面审查。

## 方案

- [GitHub 文件](https://github.com/talebook/talebook/blob/c3e221bda9319e4376c068ab96a0c634b0e80c09/design/webserver/20260904-plugin-host-concurrency-queue.active.html)
- [HTML 预览](https://raw.githack.com/talebook/talebook/c3e221bda9319e4376c068ab96a0c634b0e80c09/design/webserver/20260904-plugin-host-concurrency-queue.active.html)

